### PR TITLE
Docker multiarch workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,77 @@
+name: docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker image tag"
+        required: true
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./packages/nocodb
+    strategy:
+      matrix:
+        node-version: [12]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: ${{ env.working-directory }}
+
+      - name: Build nocodb and docker files
+        run: |
+          npm run build
+          npm run docker:build
+        working-directory: ${{ env.working-directory }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.working-directory }}
+          build-args: NC_VERSION=${{ github.event.inputs.tag }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: true
+          tags: |
+            nocodb/nocodb:${{ github.event.inputs.tag }}
+            nocodb/nocodb:latest
+
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/packages/nocodb/Dockerfile
+++ b/packages/nocodb/Dockerfile
@@ -1,52 +1,44 @@
-FROM alpine:3.12
+###########
+# Builder
+###########
+FROM node:12 as builder
+WORKDIR /usr/src/app
 
-# Bug fix for segfault ( Convert PT_GNU_STACK program header into PT_PAX_FLAGS )
-#RUN apk --update --no-cache add paxctl \
-#	&& paxctl -cm $(which node)
-
+ENV NODE_ENV production
+ENV NC_VERSION 0.6
+ENV NC_DOCKER 0.6
 ENV PORT 8080
-ENV NODE_ENV=dev
-#ENV TOOL_DIR=/tool
-ENV NC_VERSION=0.6
-ENV NC_DOCKER=0.6
-
-# Create and change to the app directory.
-WORKDIR /usr/src/appTemp
 
 # Copy application dependency manifests to the container image.
 # A wildcard is used to ensure both package.json AND package-lock.json are copied.
-# Copying this separately prevents re-running npm install on every code change.
-#COPY ./build/ ./build/
+# Copying this separately prevents re-running npm ci on every code change.
+COPY ./package*.json ./
 COPY ./docker/main.js ./docker/main.js
-COPY ./package.json ./
 COPY ./docker/start.sh /usr/src/appEntry/start.sh
 
-# Install production dependencies.
-#RUN npm i ../xc-lib-gui/ && npm install --cache=/usr/src/app/cache --production && npx modclean  --patterns="default:*" --run && rm -rf /usr/src/app/cache && rm -rf /root/.npm
-RUN apk --update --no-cache add \
-    	nodejs \
-    	nodejs-npm \
-    	tar\
-   && npm install --cache=/usr/src/app/cache --production \
+# install production dependencies,
+# reduce node_module size with modclean & removing sqlite deps,
+# package built code into app.tar.gz & add execute permission to start.sh
+RUN npm ci --production --quiet \
     && npx modclean --patterns="default:*" --ignore="nc-lib-gui/**,dayjs/**,express-status-monitor/**" --run  \
     && rm -rf ./node_modules/sqlite3/deps \
-#    && rm -rf ./node_modules/nc-lib-gui/lib/dist/_nuxt \
-    && rm -rf /usr/src/app/cache && rm -rf /root/.npm \
-   && apk del nodejs-npm \
-   && tar -czf ../appEntry/app.tar.gz ./* ; rm -rf ./* && chmod +x /usr/src/appEntry/start.sh
+    && tar -czf ../appEntry/app.tar.gz ./* \
+    && chmod +x /usr/src/appEntry/start.sh
 
-
-#COPY ./node_modules/xc-lib/ ./node_modules/xc-lib/
-#COPY ./node_modules/xc-lib-gui/ ./node_modules/xc-lib-gui/
+##########
+# Runner
+##########
+FROM alpine:3.12
 WORKDIR /usr/src/app
 
-# Run the web service on container startup.
-#CMD [ "node", "docker/index.js" ]
+RUN apk --update --no-cache add \
+    nodejs \
+    tar
+
+# Copy packaged production code & main entry file
+COPY --from=builder /usr/src/appEntry/ /usr/src/appEntry/
+
+EXPOSE 8080
+
+# Start Nocodb
 ENTRYPOINT ["sh", "/usr/src/appEntry/start.sh"]
-
-
-
-
-
-
-


### PR DESCRIPTION
Resolves #183, resolves #249

## Overview

### GitHub Action - Docker
This PR introduces a github action workflow to automate building nocodb into 3 architectures, namely:
-  `linux/amd64`
-  `linux/arm64`
- `linux/arm/v7`

The trigger for the github action is manual (on  workflow_dispatch) as per discussion as of now, where the maintainers can enter the tag/version variable (`Docker image tag`) as seen in the screenshot below:
![chrome_zjpqwJLNUT](https://user-images.githubusercontent.com/42867097/122609753-141a7880-d0b1-11eb-95b5-1e29cffce864.png)

Clicking **Run workflow** will result in the workflow pushing 2 tags to the nocodb dockerhub repo, namely (refer line 68-69 in `.github/workflows/docker.yml`):
- `nocodb:<version>`
- `nocodb:latest`

### Dockerfile modification
The Dockerfile is also modified to use multi-stage builds (so the builder can compile **sqlite3** properly for `arm64` and `arm/v7`) while keeping the final image small. Comments are added to further describe the steps involved.

## Action items needed for maintainers before merging this PR

2 new repository secrets are needed to be created in order for the github action step **Login to Dockerhub** to use `${{ secrets.DOCKERHUB_USERNAME }}` and `${{ secrets.DOCKERHUB_TOKEN }}` to login to nocodb dockerhub account successfully to push the resulting images.

Sample screenshot:
![chrome_VbgpRS51PP](https://user-images.githubusercontent.com/42867097/122610240-e08c1e00-d0b1-11eb-9d4f-3e58e344e10e.png)
Reference from github docs: https://docs.github.com/en/actions/reference/encrypted-secrets