### PR TITLE
Add deploy on Railway button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadshe
 
 # Quick try
 ### 1-Click Deploy
+
+#### Heroku
 <a href="https://heroku.com/deploy?template=https://github.com/npgia/nocodb-seed-heroku">
     <img 
     src="https://www.herokucdn.com/deploy/button.svg" 
@@ -38,6 +40,10 @@ Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadshe
     alt="Deploy NocoDB to Heroku with 1-Click" 
     />
 </a>
+<br>
+
+#### Railway
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https%3A%2F%2Fgithub.com%2Frailwayapp-starters%2Fnocodb&plugins=postgresql&envs=NC_ONE_CLICK%2CNC_DATABASE_URL&NC_ONE_CLICKDefault=true&NC_DATABASE_URLDefault=postgres%3A%2F%2F%24%7B%7B+PGUSER+%7D%7D%3A%24%7B%7B+PGPASSWORD+%7D%7D%40%24%7B%7B+PGHOST+%7D%7D%3A%24%7B%7B+PGPORT+%7D%7D%2F%24%7B%7B+PGDATABASE+%7D%7D)
 <br>
 
 ### Using Docker


### PR DESCRIPTION
This PR adds a `Deploy on Railway` button which allows users to deploy NocoDB to Railway in just one click.