### PR TITLE
NC_DATABASE_URL_FILE patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ docker-compose up
 |-------------------------|-----------|----------------------------------------------------------------------------------|--------------------------------------------|
 | NC_DB                   | Yes       | See our database URLs                                                            | A local SQLite will be created in root folder  |
 | DATABASE_URL            | No        | JDBC URL Format. Can be used instead of NC_DB. Used in 1-Click Heroku deployment|   |
+| DATABASE_URL_FILE       | No        | path to file containing JDBC URL Format. Can be used instead of NC_DB. Used in 1-Click Heroku deployment|   |
 | NC_PUBLIC_URL           | Yes       | Used for sending Email invitations                   | Best guess from http request params        |
 | NC_AUTH_JWT_SECRET      | Yes       | JWT secret used for auth and storing other secrets                               | A Random secret will be generated          |
 | NC_SENTRY_DSN           | No        | For Sentry monitoring                                                     |   |

--- a/packages/nocodb/src/lib/utils/NcConfigFactory.ts
+++ b/packages/nocodb/src/lib/utils/NcConfigFactory.ts
@@ -1,4 +1,5 @@
 import {SqlClientFactory} from 'nc-help';
+import fs from 'fs';
 import parseDbUrl from "parse-database-url";
 
 import {AuthConfig, DbConfig, MailerConfig, NcConfig} from "../../interface/config";
@@ -565,7 +566,10 @@ export default class NcConfigFactory implements NcConfig {
 
 
   public static jdbcToXcUrl() {
-    if (process.env.NC_DATABASE_URL || process.env.DATABASE_URL) {
+    if (process.env.NC_DATABASE_URL_FILE || process.env.DATABASE_URL_FILE) {
+      const database_url = fs.readFileSync(process.env.NC_DATABASE_URL_FILE || process.env.DATABASE_URL_FILE, 'utf-8');
+      process.env.NC_DB = this.extractXcUrlFromJdbc(database_url);
+    } else if (process.env.NC_DATABASE_URL || process.env.DATABASE_URL) {
       process.env.NC_DB = this.extractXcUrlFromJdbc(process.env.NC_DATABASE_URL || process.env.DATABASE_URL);
     }
   }


### PR DESCRIPTION
docker compose ECS integration only passes secrets via runtime available files. This allows for nocodb to be provided with a database configuration via a secret without too much hassle