### PR TITLE
Expanded form fix for text overflow

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/expandedForm.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/expandedForm.vue
@@ -476,6 +476,12 @@ export default {
   color: var(--v-primary-base);
 }
 
+.title.text-center {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 ::v-deep {
 
   .v-breadcrumbs__item:nth-child(odd) {
@@ -597,6 +603,7 @@ h5 {
  *
  * @author Naveen MR <oof1lab@gmail.com>
  * @author Pranav C Balan <pranavxc@gmail.com>
+ * @author Ayush Sahu <aztrexdx@gmail.com>
  *
  * @license GNU AGPL version 3 or any later version
  *


### PR DESCRIPTION
Hi,

There is text overflow issue that when text length is large then causes bug that button moves up and it doesn't looks good overall. So put a text limit using css.

Signed-off-by: AztrexDX <aztrexdnx@gmail.com>
![title header breaks when too much text](https://user-images.githubusercontent.com/86340924/129476883-ab12e3a3-0e70-42b4-90ec-1bc5fd474370.jpg)
![after changes](https://user-images.githubusercontent.com/86340924/129476886-9664b626-dafc-403c-a5f4-2ca6051b45c6.jpg)
