### PR TITLE
Expanded form fix for text overflow

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/expandedForm.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/expandedForm.vue
@@ -476,6 +476,12 @@ export default {
   color: var(--v-primary-base);
 }
 
+.title.text-center {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 ::v-deep {
 
   .v-breadcrumbs__item:nth-child(odd) {
@@ -597,6 +603,7 @@ h5 {
  *
  * @author Naveen MR <oof1lab@gmail.com>
  * @author Pranav C Balan <pranavxc@gmail.com>
+ * @author Ayush Sahu <aztrexdx@gmail.com>
  *
  * @license GNU AGPL version 3 or any later version
  *


### PR DESCRIPTION
There is text overflow issue that when text length is large then causes bug that button moves up and it doesn't looks good overall. So put a text limit using css.

Signed-off-by: Ayush Sahu <aztrexdx@gmail.com>
![after changes](https://user-images.githubusercontent.com/86340924/129552605-04542deb-d3aa-4fc5-acb2-86401d2f10bb.jpg)
![title header breaks when too much text](https://user-images.githubusercontent.com/86340924/129552610-b423c084-a4b9-4016-963c-e9a3b9d58d01.jpg)
