### PR TITLE
Example docker-compose.yml for use with nginx-proxy-manager and 2 seperate networks

### DIFF
--- a/docker-compose/nginx-proxy-manager/docker-compose.yml
+++ b/docker-compose/nginx-proxy-manager/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.3'
+
+services:
+  root_db:
+    image: mysql:5.7
+    volumes:
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: root_db
+      MYSQL_USER: noco
+      MYSQL_PASSWORD: password
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 20s
+      retries: 10
+    networks:
+      default:
+
+  nocodb:
+    depends_on:
+      root_db:
+        condition: service_healthy
+    image: nocodb/nocodb:latest
+    restart: always
+    environment:
+      NC_DB: "mysql2://root_db:3306?u=noco&p=password&d=root_db"
+    networks:
+      default:
+      nginxproxy:
+      
+volumes:
+  db_data: {}
+
+networks:
+  default:
+  nginxproxy:

--- a/docker-compose/nginx-proxy-manager/docker-compose.yml
+++ b/docker-compose/nginx-proxy-manager/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       timeout: 20s
       retries: 10
     networks:
-      default:
+      - default
 
   nocodb:
     depends_on:
@@ -27,10 +27,27 @@ services:
     environment:
       NC_DB: "mysql2://root_db:3306?u=noco&p=password&d=root_db"
     networks:
-      default:
-      nginxproxy:
+      - default
+      - nginxproxy
       
+  nginx-proxy-manager:
+    image: jlesage/nginx-proxy-manager
+    restart: always
+    environment:
+      PUID: 1000
+      PGID: 1000
+      TZ: Europe/Amsterdam
+    ports:
+      - "8181:8181"
+      - "80:8080"
+      - "443:4443"
+    volumes:
+      - nginx-proxy-manager:/config:rw
+    networks:
+      - nginxproxy
+
 volumes:
+  nginx-proxy-manager: {}
   db_data: {}
 
 networks:


### PR DESCRIPTION
Here my example for using nginx-proxy-manager for exposing nocodb to the outside. 
It creates 2 networks:
One for the nocodedb app container and mysql database. Thus mysql is not exposed beyond this network as it is with the traefik example. And one for nginx-proxy-manager and the nocodb app container.