### PR TITLE
Add ignoreTLS to email plugin

### DIFF
--- a/packages/nocodb/src/lib/noco/plugins/adapters/email/SMTP.ts
+++ b/packages/nocodb/src/lib/noco/plugins/adapters/email/SMTP.ts
@@ -21,6 +21,7 @@ class SMTP implements IEmailAdapter {
       "host": this.input?.host,
       "port": parseInt(this.input?.port, 10),
       "secure": this.input?.secure === 'true',
+      "ignoreTLS": this.input?.ignoreTLS === 'true',
       "auth": {
         "user": this.input?.username,
         "pass": this.input?.password

--- a/packages/nocodb/src/lib/noco/plugins/smtp.ts
+++ b/packages/nocodb/src/lib/noco/plugins/smtp.ts
@@ -27,6 +27,12 @@ const input: XcForm = {
     type: XcType.SingleLineText,
     required: true
   }, {
+    key: 'ignoreTLS',
+    label: 'IgnoreTLS',
+    placeholder: 'IgnoreTLS',
+    type: XcType.SingleLineText,
+    required: true
+  }, {
     key: 'username',
     label: 'Username',
     placeholder: 'Username',

--- a/packages/nocodb/src/plugins/smtp/SMTP.ts
+++ b/packages/nocodb/src/plugins/smtp/SMTP.ts
@@ -20,6 +20,7 @@ export default class SMTP implements IEmailAdapter {
       "host": this.input?.host,
       "port": parseInt(this.input?.port, 10),
       "secure": this.input?.secure === 'true',
+      "ignoreTLS": this.input?.ignoreTLS === 'true',
       "auth": {
         "user": this.input?.username,
         "pass": this.input?.password

--- a/packages/nocodb/src/plugins/smtp/index.ts
+++ b/packages/nocodb/src/plugins/smtp/index.ts
@@ -41,6 +41,12 @@ const config: XcPluginConfig ={
       type: XcType.SingleLineText,
       required: true
     }, {
+      key: 'ignoreTLS',
+      label: 'IgnoreTLS',
+      placeholder: 'IgnoreTLS',
+      type: XcType.SingleLineText,
+      required: false
+    }, {
       key: 'username',
       label: 'Username',
       placeholder: 'Username',


### PR DESCRIPTION
Happened to work with a server that needs `port:587, secure:false, ignoreTLS:true` to work. 
Just addded the new field, did not test. Please check.