### PR TITLE
[Bugfix] Fix linking records when tables have a string primary key field

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/virtualCell/belogsToCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/virtualCell/belogsToCell.vue
@@ -311,7 +311,7 @@ export default {
       }
 
       await this.api.update(id, {
-        [_cn]: +pid
+        [_cn]: pid
       }, {
         [_cn]: this.value && this.value[this.parentPrimaryKey]
       })
@@ -389,6 +389,7 @@ export default {
  *
  * @author Naveen MR <oof1lab@gmail.com>
  * @author Pranav C Balan <pranavxc@gmail.com>
+ * @author Md Ishtiaque Zafar <ishtiaque.zafar92@gmail.com>
  *
  * @license GNU AGPL version 3 or any later version
  *


### PR DESCRIPTION
**Bug fix**

Environment:

* Database: Postgres
* Database version: 13.3
* NocoDB version: [0.11.39 - Bug fix release](https://docs.nocodb.com/releases)

Summary:
The database had a string field as the primary key, instead of the usual Number, but a certain update function was typecasting it to Number in the payload, resulting the id to be sent as `null`.

[Video showing the bug and the bug being resolved after the fix](https://www.loom.com/share/201a0132c754423b9bea9a7405a21ec9)

Changelog:
* removed the Number conversion