### PR TITLE
Initial Commit to change email field input type

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,13 +52,13 @@ Cypress.Commands.add('signinOrSignup', (_args) => {
           cy.wait(8000);
           cy.get('body').trigger('mousemove');
           cy.contains('Let\'s Begin').click();
-          cy.get('input[type="text"]', { timeout: 12000 }).type(args.username);
+          cy.get('input[type="email"]', { timeout: 12000 }).type(args.username);
           cy.get('input[type="password"]').type(args.password);
           cy.get('button:contains("SIGN UP")').click()
 
           // handle signin
         } else {
-          cy.get('input[type="text"]', { timeout: 12000 }).type(args.username);
+          cy.get('input[type="email"]', { timeout: 12000 }).type(args.username);
           cy.get('input[type="password"]').type(args.password);
           cy.get('button:contains("SIGN IN")').click()
         }

--- a/cypress/support/page_objects/mainPage.js
+++ b/cypress/support/page_objects/mainPage.js
@@ -71,7 +71,7 @@ export class _mainPage {
 
             // Redirected to new URL, feed details
             //
-            cy.get('input[type="text"]').type(userCred.username)
+            cy.get('input[type="email"]').type(userCred.username)
             cy.get('input[type="password"]').type(userCred.password)
             cy.get('button:contains("SIGN UP")').click()
 

--- a/cypress/support/page_objects/navigation.js
+++ b/cypress/support/page_objects/navigation.js
@@ -26,7 +26,7 @@ export class _loginPage {
     signIn(userCredentials) {
         this.go(urlPool.ncUrlSignIn)
 
-        cy.get('input[type="text"]', {timeout: 6000}).type(userCredentials.username)
+        cy.get('input[type="email"]', {timeout: 6000}).type(userCredentials.username)
         cy.get('input[type="password"]').type(userCredentials.password)
         cy.get('button:contains("SIGN IN")').click()
 
@@ -38,7 +38,7 @@ export class _loginPage {
     signUp(userCredentials) {
         this.go(urlPool.ncUrlSignUp)
 
-        cy.get('input[type="text"]', {timeout: 6000}).type(userCredentials.username)
+        cy.get('input[type="email"]', {timeout: 6000}).type(userCredentials.username)
         cy.get('input[type="password"]').type(userCredentials.password)
         cy.get('button:contains("SIGN UP")').click()
 

--- a/packages/nocodb/src/lib/public/index.html
+++ b/packages/nocodb/src/lib/public/index.html
@@ -371,7 +371,7 @@
                                                 <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
                                                 <div style="position: absolute; left: -5000px;" aria-hidden="true">
                                                     <input
-                                                            type="text"
+                                                            type="email"
                                                             name="b_34a5d2680bab8825d485af859_f04c6c8b8d"
                                                             tabindex="-1" value=""></div>
 


### PR DESCRIPTION
This PR looks to fix issue #627. 

I have changed the input type from text to email.
In my attempt to replicate the capitalization issue brought up in #627, I was unable to replicate the problem. I tested using Chrome. Mozilla, and Microsoft Edge, and each type I inputted my email into the field, it would not capitalize the first letter. Being on a Windows computer, I do not have access to Safari (As mentioned in the issue), so I presume that the fix should help resolve the issue in Safari.