### PR TITLE
Add page to explain role permissions, user mgmt

### DIFF
--- a/packages/noco-docs/content/en/setup-and-usages/user-management.md
+++ b/packages/noco-docs/content/en/setup-and-usages/user-management.md
@@ -1,0 +1,85 @@
+---
+title: 'User Management - Team & Auth Roles & Permissions'
+description: 'Breakdown of roles & permissions for team user management'
+position: 44
+category: 'Usage'
+menuTitle: 'User Management - Team & Auth Roles & Permissions'
+---
+
+
+## How to Add a User
+On the left panel, click on "Team & Auth":
+
+![image](https://user-images.githubusercontent.com/55474996/142497814-c52e12e5-5ab5-41e7-ac48-2b6af5f31fdd.png)
+
+
+Make sure you are on the "Users Management" tab. Click on "New User":
+
+![image](https://user-images.githubusercontent.com/55474996/142498070-60c5a861-0e8e-49e9-8830-42f54aa1fbf1.png)
+
+
+Enter the person's email, select their user role, and hit "Invite":
+
+![image](https://user-images.githubusercontent.com/55474996/142498163-032187e4-d375-4542-8211-e986880a2bb0.png)
+
+
+
+If you do not have an SMTP sender configured, make sure to copy the invite link and manually send it to your collaborator:
+
+![image](https://user-images.githubusercontent.com/55474996/142498376-ff52276b-92d8-4aca-8c47-fd7efea50ab6.png)
+
+
+
+## Explanation of User Role Permissions
+> TODO
+
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Access/view the entire base | . | . | . | . | . |
+
+### Record actions
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Comment on records | . | . | . | . | . |
+| Add, delete, modify records | . | . | . | . | . |
+
+### View actions
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Add, delete, modify table views | . | . | . | . | . |
+| Lock and unlock table views | . | . | . | . | . |
+| Delete other collaborators' personal views | . | . | . | . | . |
+
+### Column actions
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Add, delete, rename and customize columns | . | . | . | . | . |
+
+### Table actions
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Add, delete, and rename tables | . | . | . | . | . |
+
+### Other actions
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Create or remove a view share link | . | . | . | . | . |
+| Rename the project | . | . | . | . | . |
+| Create or remove a project collaborator invite link | . | . | . | . | . |
+
+### Automations
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Create, delete, or duplicate an automation | . | . | . | . | . |
+| Configure an automation | . | . | . | . | . |
+| Rename an automation | . | . | . | . | . |
+| Edit an automation description | . | . | . | . | . |
+| View automation configuration | . | . | . | . | . |
+| Copy automation URL | . | . | . | . | . |
+
+### App store
+|  | Owner | Creator | Editor | Commenter | Viewer |
+|---|---|---|---|---|---|
+| Install an app | . | . | . | . | . |
+| Configure an app's settings | . | . | . | . | . |
+| Uninstall an app | . | . | . | . | . |


### PR DESCRIPTION
Hello! I'm new to this, so forgive me if this is the incorrect way to contribute.

I wanted to add a page that explained the user permissions because I couldn't find this info anywhere. The tables were largely inspired from this page: https://support.airtable.com/hc/en-us/articles/202887099-Permissions-overview.

Please complete the table with check-marks and x's to indicate what the various roles can or can't do.

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
