### PR TITLE
fix: removal of physical relationships on metadata recreate

### DIFF
--- a/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
@@ -727,7 +727,8 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
     );
     let tables;
     /* Get all relations */
-    const relations = await this.relationsSyncAndGet();
+    let [relations, missingRelations] = await this.getRelationsAndMissingRelations()
+    relations = relations.concat(missingRelations);
 
     // set table name alias
     relations.forEach(r => {
@@ -838,6 +839,7 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
     }
 
     this.tablesCount = tables.length;
+    this.syncRelations()
 
     if (tables.length) {
       relations.forEach(rel => (rel.enabled = true));

--- a/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
@@ -356,7 +356,8 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
     const swaggerRefs: { [table: string]: any[] } = {};
 
     /* Get all relations */
-    const relations = await this.relationsSyncAndGet();
+    let [relations, missingRelations] = await this.getRelationsAndMissingRelations()
+    relations = relations.concat(missingRelations);
 
     // set table name alias
     relations.forEach(r => {
@@ -438,6 +439,8 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
       r._tn = this.getTableNameAlias(r.tn);
       r._rtn = this.getTableNameAlias(r.rtn);
     });
+
+    this.syncRelations()
 
     const tableRoutes = tables.map(table => {
       return async () => {


### PR DESCRIPTION
## Change Summary

It's fixing the issue of relationships getting removed whenever table metadata is recreated from Meta management. 
The same is also mentioned in the comment of https://github.com/nocodb/nocodb/issues/712. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

It's changing how `nc_relations` entries are made when table metadata is recreated. 

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
