### PR TITLE
ignore m2m relations from missingRelations

### DIFF
--- a/packages/nocodb/src/lib/noco/common/BaseApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/common/BaseApiBuilder.ts
@@ -2205,10 +2205,15 @@ export default abstract class BaseApiBuilder<T extends Noco>
     // Relations in DB
     const dbRelations = (await this.sqlClient.relationListAll())?.data?.list;
 
+    const m2mTnPrefix = `${this.projectBuilder?.prefix ?? ''}_nc_m2m_`;
     // Relations missing in metadata
     const missingRelations = dbRelations
       .filter(dbRelation => {
-        return relations.every(relation => relation?.fkn !== dbRelation?.cstn);
+        return relations.every(relation => { 
+          return relation?.fkn !== dbRelation?.cstn 
+            && !(dbRelation?.tn || '').startsWith(m2mTnPrefix)
+            && !(dbRelation?.rtn || '').startsWith(m2mTnPrefix)
+        });
       })
       .map(relation => {
         relation.enabled = true;

--- a/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
@@ -730,12 +730,11 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
 
     let tables;
     /* Get all relations */
-    /*    let [
+    let [
       relations,
       missingRelations
     ] = await this.getRelationsAndMissingRelations();
-    relations = relations.concat(missingRelations);*/
-    const relations = await this.relationsSyncAndGet();
+    relations = relations.concat(missingRelations);
 
     // set table name alias
     relations.forEach(r => {
@@ -851,7 +850,7 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
     }
 
     this.tablesCount = tables.length;
-    // await this.syncRelations();
+    await this.syncRelations();
 
     if (tables.length) {
       relations.forEach(rel => (rel.enabled = true));

--- a/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
@@ -356,14 +356,13 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
     const swaggerRefs: { [table: string]: any[] } = {};
     let order = await this.getOrderVal();
 
-    /*    /!* Get all relations *!/
+    /*    /!* Get all relations *!/ */
     let [
       relations,
       // eslint-disable-next-line prefer-const
       missingRelations
     ] = await this.getRelationsAndMissingRelations();
-    relations = relations.concat(missingRelations);*/
-    const relations = await this.relationsSyncAndGet();
+    relations = relations.concat(missingRelations);
 
     // set table name alias
     relations.forEach(r => {
@@ -456,7 +455,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
       r._rtn = this.getTableNameAlias(r.rtn);
     });
 
-    // await this.syncRelations();
+    await this.syncRelations();
 
     const tableRoutes = tables.map(table => {
       return async () => {


### PR DESCRIPTION
## Change Summary

This is the fix to my previous [PR](https://github.com/nocodb/nocodb/pull/843) . 
Added logic to ignore m2m relationships to avoid duplicating them.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
