### PR TITLE
fix typo to preserve column types

### DIFF
--- a/packages/nocodb/src/lib/sqlMgr/code/models/xc/BaseModelXcMeta.ts
+++ b/packages/nocodb/src/lib/sqlMgr/code/models/xc/BaseModelXcMeta.ts
@@ -57,7 +57,7 @@ abstract class BaseModelXcMeta extends BaseRender {
       }
 
       const oldColMeta = this.ctx?.oldMeta?.columns?.find(c => {
-        return columnObj.cn == c.cn && columnObj.tpe == c.type;
+        return columnObj.cn == c.cn && columnObj.type == c.type;
       });
 
       if (oldColMeta) {


### PR DESCRIPTION
Signed-off-by: vijayrathore8492 <professional.vijay8492@gmail.com>

## Change Summary

Fix typo in `BaseModelXcMeta.ts` to preserve column types

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
