### PR TITLE
Typo fixed

### DIFF
--- a/packages/noco-docs/content/en/setup-and-usages/formulas.md
+++ b/packages/noco-docs/content/en/setup-and-usages/formulas.md
@@ -55,7 +55,7 @@ menuTitle: "Formulas"
 | `+`      | `column1 + column2 + 2` | Addition of numeric values       |
 | `-`      | `column1 - column2`     | Subtraction of numeric values    |
 | `*`      | `column1 * column2`     | Multiplication of numeric values |
-| `-`      | `column1 / column2`     | Division of numeric values       |
+| `/`      | `column1 / column2`     | Division of numeric values       |
 
 > To change order of arithmetic operation, use round bracket parantheses `()`  
 > Example: `(column1 + (column2 * column3) / (3 - column4 ))`


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [x] docs: (changes to the documentation)

## Test/ Verification

Fixed a typo in the following section. "Division of numeric values" operator should be "/" but is "-". Production URL  [Provide summary of changes.](https://docs.nocodb.com/setup-and-usages/formulas#numeric-operators)

## Additional information / screenshots (optional)

![Screenshot 2022-01-15 at 06 57 22](https://user-images.githubusercontent.com/11807034/149610989-3153611a-b50a-498c-abce-7616bcc76b2e.png)

