### PR TITLE
enhancement(ui): add checkbox field to app store input 

### DIFF
--- a/packages/nc-gui/components/project/appStore/FormInput.vue
+++ b/packages/nc-gui/components/project/appStore/FormInput.vue
@@ -14,6 +14,11 @@
     v-model="localState"
     :input-details="inputDetails"
   />
+  <checkbox-field
+    v-else-if="inputDetails.type === 'Checkbox'"
+    v-model="localState"
+    :input-details="inputDetails"
+  />
   <text-field v-else v-model="localState" :input-details="inputDetails" />
 </template>
 
@@ -21,11 +26,12 @@
 import TextField from '@/components/project/appStore/inputs/textField'
 import Attachment from '@/components/project/appStore/inputs/attachment'
 import PasswordField from '@/components/project/appStore/inputs/passwordField'
-import TextAreaCell from '~/components/project/spreadsheet/components/editableCell/textAreaCell'
+import TextAreaCell from '@/components/project/spreadsheet/components/editableCell/textAreaCell'
+import CheckboxField from '@/components/project/appStore/inputs/checkboxField'
 
 export default {
   name: 'FormInput',
-  components: { PasswordField, TextAreaCell, Attachment, TextField },
+  components: { PasswordField, TextAreaCell, Attachment, TextField, CheckboxField },
   props: {
     value: String,
     inputDetails: Object

--- a/packages/nc-gui/components/project/appStore/inputs/checkboxField.vue
+++ b/packages/nc-gui/components/project/appStore/inputs/checkboxField.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-checkbox
+    v-model="localState"
+    color="primary lighten-1"
+    hide-details
+    dense
+    v-on="parentListeners"
+  />
+</template>
+
+<script>
+export default {
+  name: 'CheckBoxField',
+  props: {
+    value: String,
+    inputDetails: Object
+  },
+  computed: {
+    localState: {
+      get() {
+        return this.value
+      },
+      set(val) {
+        this.$emit('input', val)
+      }
+    },
+    parentListeners() {
+      const $listeners = {}
+      return $listeners
+    }
+  },
+  created() {
+    this.localState = false 
+  },
+}
+</script>
+
+<style scoped>
+</style>
+<!--
+/**
+ * @copyright Copyright (c) 2021, Xgene Cloud Ltd
+ *
+ * @author Wing-Kam Wong <wingkwong.code@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+-->

--- a/packages/nocodb/src/plugins/mino/Minio.ts
+++ b/packages/nocodb/src/plugins/mino/Minio.ts
@@ -60,7 +60,7 @@ export default class Minio implements IStorageAdapter {
   public async init(): Promise<any> {
     // todo:  update in ui(checkbox and number field)
     this.input.port = +this.input.port || 9000;
-    this.input.useSSL = this.input.useSSL ==='true';
+    this.input.useSSL = this.input.useSSL === true;
     this.input.accessKey = this.input.access_key;
     this.input.secretKey = this.input.access_secret;
 


### PR DESCRIPTION
## Change Summary

Currently in "Configure Minio", the field "Use SSL" is using text field which is not a good idea as users don't know whether they should input. This PR includes the changes to cater this case.

Before: 

![image](https://user-images.githubusercontent.com/35857179/149802133-42bfc2f2-02ba-40ce-8197-865f131ee4a4.png)

After:

![image](https://user-images.githubusercontent.com/35857179/149802543-f9e1e459-248c-4674-888a-d722549fb361.png)