### PR TITLE
fix: Cannot read properties of undefined (reading 'toLowerCase') in App Store

### DIFF
--- a/packages/nc-gui/components/project/appStore.vue
+++ b/packages/nc-gui/components/project/appStore.vue
@@ -200,7 +200,7 @@ export default {
       return this.apps.reduce((arr, app) => arr.concat(app.tags || []), []).filter((f, i, arr) => i === arr.indexOf(f)).sort()
     },
     filteredApps() {
-      return this.apps.filter(app => (!this.query.trim() || app.name.toLowerCase().includes(this.query.trim().toLowerCase())) &&
+      return this.apps.filter(app => (!this.query.trim() || app.title.toLowerCase().includes(this.query.trim().toLowerCase())) &&
         (!this.selectedTags.length || this.selectedTags.some(t => app.tags && app.tags.includes(t)))
       )
     }


### PR DESCRIPTION
## Change Summary

Plugin search is broken after typing a letter. It throws ``Cannot read properties of undefined (reading 'toLowerCase') ``.

Use ``title`` instead of ``name``. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/150166221-ea479767-92b6-4f9f-bae8-c2b98657b854.png)

