### PR TITLE
Fix incorrect auth token name in docs

### DIFF
--- a/packages/noco-docs/content/en/developer-resources/api-tokens.md
+++ b/packages/noco-docs/content/en/developer-resources/api-tokens.md
@@ -21,4 +21,4 @@ NocoDB allows creating API tokens which allow it to be integrated seamlessly wit
 
 
 ### Using API Tokens
-Invoke NocoDB APIs with ```xc-token``` header
+Invoke NocoDB APIs with ```xc-auth``` header


### PR DESCRIPTION
Nocodb uses an auth token called `xc-auth` not `xc-token`

## Change Summary

Corrects the name of the auth token in the docs

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [X] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
