### PR TITLE
fix: reset saving flag anyway

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
@@ -1049,9 +1049,9 @@ export default {
             } else {
               this.$toast.error(`Failed to save row : ${e.message}`).goAway(3000)
             }
+          } finally {
+            this.$set(this.data[row], 'saving', false)
           }
-
-          this.$set(this.data[row], 'saving', false)
         }
       }
     },


### PR DESCRIPTION
Ref: #828 

## Change Summary

If there are multiple NN cells, once we input something, it will trigger ``save()``. In this function, it may return early if some conditions are not met, such as not all NN cells have values. Due to this early exit, the ``saving`` is still set as ``true`` which blocking the current row operation.

No matter there is an early return or not, we have to mark it ``false`` anyway at the end. Hence, putting the reset statement to finally block.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Edit the first row. Two cells with red outliner are NN cells without values.

![image](https://user-images.githubusercontent.com/35857179/151759644-92915d80-4ae1-46a3-af54-8f2992bddaac.png)

Input ``A`` to ``title1``. The red outliner for ``title1`` is gone as there is a value. No loading spinner is here as we are not saving.

![image](https://user-images.githubusercontent.com/35857179/151759699-312a0f7c-3138-4c53-9a6d-5f461ab80c50.png)

Input ``A`` to ``title3``. As all required fields are not null, it will trigger the save function. 

![image](https://user-images.githubusercontent.com/35857179/151759941-3111a425-2869-468c-8795-08bb4a284a49.png)

Reload the view. The data persists in GUI and DB. 
