### PR TITLE
fix: update hook list after deleting webhook

### DIFF
--- a/packages/nocodb/src/lib/noco/NcProjectBuilder.ts
+++ b/packages/nocodb/src/lib/noco/NcProjectBuilder.ts
@@ -304,10 +304,6 @@ export default class NcProjectBuilder {
         break;
 
       case 'tableXcHooksSet':
-        await curBuilder.onHooksUpdate(data.req.args.tn);
-        console.log(`Updated validations for table : ${data.req.args.tn}`);
-        break;
-
       case 'tableXcHooksDelete':
         await curBuilder.onHooksUpdate(data.req.args.tn);
         console.log(`Updated validations for table : ${data.req.args.tn}`);

--- a/packages/nocodb/src/lib/noco/NcProjectBuilder.ts
+++ b/packages/nocodb/src/lib/noco/NcProjectBuilder.ts
@@ -308,6 +308,11 @@ export default class NcProjectBuilder {
         console.log(`Updated validations for table : ${data.req.args.tn}`);
         break;
 
+      case 'tableXcHooksDelete':
+        await curBuilder.onHooksUpdate(data.req.args.tn);
+        console.log(`Updated validations for table : ${data.req.args.tn}`);
+        break;
+
       case 'xcModelSwaggerDocSet':
         await (curBuilder as RestApiBuilder).onSwaggerDocUpdate(
           data.req.args.tn


### PR DESCRIPTION
Ref: #1034 

## Change Summary

Currently the hooks can still be found in ``this.builder.hooks`` after deleting them. This PR is to add one more case ``tableXcHooksDelete`` in NcProjectBuilder listener to trigger ``onHooksUpdate()`` to load the latest hook from ``nc_hooks``.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
