### PR TITLE
fix: disable syncDataDebounce for currency field

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell.vue
@@ -182,7 +182,9 @@ export default {
           if (this.isAttachment || this.isEnum || this.isBoolean || this.isSet || this.isTime || this.isDateTime || this.isDate) {
             this.syncData()
           } else {
-            this.syncDataDebounce(this)
+            if (!this.isCurrency) {
+              this.syncDataDebounce(this)
+            }
           }
         }
       }

--- a/packages/nc-gui/components/project/spreadsheet/mixins/cell.js
+++ b/packages/nc-gui/components/project/spreadsheet/mixins/cell.js
@@ -57,6 +57,9 @@ export default {
     },
     isAttachment() {
       return this.column.uidt === 'Attachment'
+    },
+    isCurrency() {
+      return this.column.uidt == 'Currency'
     }
 
   }


### PR DESCRIPTION
Ref: #1042 

## Change Summary

Currency field is saved immediately which triggers validation if there is no further input (~1000ms) after the first change. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)