### PR TITLE
fix: wrong parent node for SQL Views

### DIFF
--- a/packages/nc-gui/store/tabs.js
+++ b/packages/nc-gui/store/tabs.js
@@ -171,7 +171,7 @@ export const actions = {
               .list[0] // project
               .children[0] //  environment
               .children[0] // db
-              .children.find(n => n.type === 'viewDir') // parent node
+              .children.find(n => n.type === 'tableDir') // parent node
               .children.find(t => t.name === name)
 
             break


### PR DESCRIPTION
Ref: #1126 

## Change Summary

Previously treeview contains View section. However, now it has been merged under Tables. Therefore, the parent node should be ``tableDir`` instead of ``viewDir``.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

SQL Views can be rendered after hard refresh.

![image](https://user-images.githubusercontent.com/35857179/152979405-16bf1e26-99a7-4cbe-a0ea-60d71ae05d02.png)

