### PR TITLE
Adding deploy to AWS using Opta as a deployment option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadshe
 <br>
 
 #### Opta
-[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)
+[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-using-opta.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)
 <br>
 
 ### Using Docker

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart-spreadshe
 </a>
 <br>
 
+#### Opta
+[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnocodb%2Fnocodb-seed-heroku%2Fblob%2Fmain%2Fopta.yaml&name=NocoDB)
+<br>
+
 ### Using Docker
 ```bash
 docker run -d --name nocodb -p 8080:8080 nocodb/nocodb:latest


### PR DESCRIPTION
## Change Summary

This PR adds a button that allows users to deploy NocoDB to AWS using a tool called [Opta](https://github.com/run-x/opta). It works as follows:

The button links a user to a form, where the user fills out some configuration that Opta requires (similar to Heroku's deploy button). This configuration is used to generate an Opta configuration file, which is generated from this template.
The user downloads the generated configuration file and the Opta CLI, and then prepares their AWS credentials locally
The user deploys using the Opta CLI and the generated configuration file!
The NocoDB instance created by this tool will have persistent storage, as well as a robust database managed by RDS.


## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

**Note that the HTML for the button in this PR does not work yet, as it points to a file at the path https://github.com/nocodb/nocodb-seed-heroku/blob/main/opta.yaml. This path will become valid after this PR and [related PR](https://github.com/nocodb/nocodb-seed-heroku/pull/3) is merged. In order to help in testing, I've added a button below which is equivalent, but points to the forked repo that this request is coming from:

[![Deploy](https://gist.githubusercontent.com/nsarupr/956a67a4ea5ebd0858d0d612cfc47062/raw/87fe60286f00c6c3fc3887f0ed41280d03054e50/deploy-to-aws-with-opta.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fnsarupr%2Fnocodb-seed-heroku%2Fblob%2Fadding-opta-deploy%2Fopta.yaml&name=NocoDB)


## Additional information / screenshots (optional)

Related PRs: https://github.com/nocodb/nocodb-seed-heroku/pull/3 


<img width="1792" alt="Screenshot 2022-02-08 at 6 34 27 PM" src="https://user-images.githubusercontent.com/20905988/152992668-1415bf0b-7e62-4f53-89e4-dddc07b2efc7.png">


<img width="1792" alt="Screenshot 2022-02-08 at 6 32 25 PM" src="https://user-images.githubusercontent.com/20905988/152992451-8c826ffc-6e0b-4962-a125-8dbeeef9c49c.png">

