### PR TITLE
fix: keep dtxp property on table create/update

### DIFF
--- a/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/gql/GqlApiBuilder.ts
@@ -195,11 +195,12 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
 
     const columns = args.columns
       ? {
-          [tn]: args.columns?.map(({ altered: _al, ...rest }) => ({
-            ...rest,
-            // find and overwrite column property from db
-            ...columnsFromDb?.find(c => c.cn === rest.cn)
-          }))
+          [tn]: args.columns?.map(({ altered: _al, ...rest }) =>
+            this.mergeUiColAndDbColMetas(
+              rest,
+              columnsFromDb?.find(c => c.cn === rest.cn)
+            )
+          )
         }
       : {};
 

--- a/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
+++ b/packages/nocodb/src/lib/noco/rest/RestApiBuilder.ts
@@ -881,11 +881,12 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
 
     const columns = args.columns
       ? {
-          [tn]: args.columns?.map(({ altered: _al, ...rest }) => ({
-            ...rest,
-            // find and overwrite column property from db
-            ...(columnsFromDb?.find(c => c.cn === rest.cn) || {})
-          }))
+          [tn]: args.columns?.map(({ altered: _al, ...rest }) =>
+            this.mergeUiColAndDbColMetas(
+              rest,
+              columnsFromDb?.find(c => c.cn === rest.cn)
+            )
+          )
         }
       : {};
 


### PR DESCRIPTION
## Change Summary

New MultiSelect / SingleSelect columns are not working properly in the latest version. The root cause was overwritting `dtxp` property on the table create/update.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

New Single/Multi-select column creation working with `text` type in MySQL.



re #1132
