### PR TITLE
fix: allow different boolean values for checkbox type

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/importExport/columnMappingModal.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/importExport/columnMappingModal.vue
@@ -158,8 +158,28 @@ export default {
             return 'Source data contains some invalid numbers'
           }
           break
+        case UITypes.Checkbox:
+          if (
+            this.parsedCsv && this.parsedCsv.data && this.parsedCsv.data.slice(0, 500)
+            .some((r) => {
+              if (r => r[row.sourceCn] !== null && r[row.sourceCn] !== undefined) {
+                var input = r[row.sourceCn]
+                if (typeof input === 'string') {
+                  input = input.replace(/["']/g, "").toLowerCase().trim()
+                  return (
+                    input == "false" || input == "no" || input == "n" || input == "0" ||
+                    input == "true" || input == "yes" || input == "y" || input == "1"
+                  ) ? false : true
+                }
+                return input != 1 && input != 0 && input != true && input != false
+              }
+              return false
+            })
+          ) {
+            return 'Source data contains some invalid boolean values'
+          }
+          break
       }
-
       return true
     },
     mapDefaultColumns() {

--- a/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
@@ -106,6 +106,7 @@ import FileSaver from 'file-saver'
 import DropOrSelectFileModal from '~/components/import/dropOrSelectFileModal'
 import ColumnMappingModal from '~/components/project/spreadsheet/components/importExport/columnMappingModal'
 import CSVTemplateAdapter from '~/components/import/templateParsers/CSVTemplateAdapter'
+import { UITypes } from '~/components/project/spreadsheet/helpers/uiTypes'
 
 export default {
   name: 'ExportImport',
@@ -276,9 +277,19 @@ export default {
         for (let i = 0, progress = 0; i < data.length; i += 500) {
           const batchData = data.slice(i, i + 500).map(row => columnMappings.reduce((res, col) => {
             // todo: parse data
-
             if (col.enabled && col.destCn) {
-              res[col.destCn] = row[col.sourceCn]
+              const v = this.meta && this.meta.columns.find(c => c._cn === col.destCn)
+              var input = row[col.sourceCn]
+              // parse potential boolean values 
+              if (v.uidt == UITypes.Checkbox) {
+                input = input.replace(/["']/g, "").toLowerCase().trim()
+                if (input == "false" || input == "no" || input == "n") {
+                  input = "0"
+                } else if (input == "true" || input == "yes" || input == "y") {
+                  input = "1"
+                }
+              }
+              res[col.destCn] = input
             }
             return res
           }, {}))


### PR DESCRIPTION
Ref: #880 

## Change Summary

Currently boolean values like True, Yes, No are not accepted as the DB type is like tinyint(1). The changes in this PR are to validate if incoming values are boolean type as well as converting to either 0 or 1 before inserting.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Some test data

```
Id,Bool,Num
1,'Yes',1
2,"Y",1
3,'NO',1
4,"0",1
5,1,1
6,0,1
7,true,1
8,false,1
9,1,1
```

```
10,bad,1
```