### PR TITLE
fix: cast search column in custom knex for uuid & fix search issue for bigint

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/mixins/spreadsheet.js
+++ b/packages/nc-gui/components/project/spreadsheet/mixins/spreadsheet.js
@@ -163,7 +163,10 @@ export default {
     concatenatedXWhere() {
       let where = ''
       if (this.searchField && this.searchQuery.trim()) {
-        if (['text', 'string'].includes(this.sqlUi.getAbstractType(this.availableColumns.find(({ _cn }) => _cn === this.searchField) || this.availableColumns[0]))) {
+        const col = this.availableColumns.find(({ _cn }) => _cn === this.searchField) || this.availableColumns[0]
+        // bigint values are displayed in string format in UI
+        // when searching bigint values, the operator should be 'eq' instead of 'like'
+        if (['text', 'string'].includes(this.sqlUi.getAbstractType(col)) && col.dt !== 'bigint') {
           where = `(${this.searchField},like,%${this.searchQuery.trim()}%)`
         } else {
           where = `(${this.searchField},eq,${this.searchQuery.trim()})`

--- a/packages/nc-gui/helpers/sqlUi/MssqlUi.js
+++ b/packages/nc-gui/helpers/sqlUi/MssqlUi.js
@@ -921,16 +921,14 @@ export class MssqlUi {
 
   static getAbstractType(col) {
     switch ((col.dt || col.dt).toLowerCase()) {
-      case 'bigint':
       case 'smallint':
       case 'bit':
       case 'tinyint':
       case 'int':
         return 'integer'
 
+      case 'bigint':
       case 'binary':
-        return 'string'
-
       case 'char':
         return 'string'
 

--- a/packages/nc-gui/helpers/sqlUi/MysqlUi.js
+++ b/packages/nc-gui/helpers/sqlUi/MysqlUi.js
@@ -842,7 +842,6 @@ export class MysqlUi {
       case 'int':
       case 'smallint':
       case 'mediumint':
-      case 'bigint':
       case 'bit':
         return 'integer'
 
@@ -897,6 +896,7 @@ export class MysqlUi {
       case 'set':
         return 'set'
 
+      case 'bigint':
       case 'geometry':
       case 'point':
       case 'linestring':

--- a/packages/nc-gui/helpers/sqlUi/SqliteUi.js
+++ b/packages/nc-gui/helpers/sqlUi/SqliteUi.js
@@ -683,7 +683,6 @@ export class SqliteUi {
       case 'tinyint':
       case 'smallint':
       case 'mediumint':
-      case 'bigint':
       case 'int2':
       case 'int8':
         return 'integer'
@@ -702,6 +701,7 @@ export class SqliteUi {
       case 'blob':
         return 'blob'
 
+      case 'bigint':
       case 'character':
       case 'varchar':
         return 'string'

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
@@ -92,9 +92,10 @@ const appendWhereCondition = function(
   knexRef,
   isHaving = false
 ) {
+  const clientType = knexRef?.client?.config?.client;
   const opMapping = {
     ...opMappingGen,
-    ...(knexRef?.client?.config?.client === 'pg' ? { like: 'ilike' } : {})
+    ...(clientType === 'pg' ? { like: 'ilike' } : {})
   };
   const camKey = isHaving ? 'Having' : 'Where';
   const key = isHaving ? 'having' : 'where';
@@ -433,7 +434,7 @@ const appendWhereCondition = function(
               const column = columnAliases[matches[2]] || matches[2];
               const operator = opMapping[matches[3]];
               const target = matches[4];
-              if (matches[3] == 'like') {
+              if (matches[3] == 'like' && clientType === 'pg') {
                 // handle uuid case
                 knexRef[`${key}`](
                   knexRef?.client.raw(`??::TEXT ${operator} '${target}'`, [

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
@@ -430,7 +430,7 @@ const appendWhereCondition = function(
               );
               break;
             case '':
-              const column = (columnAliases[matches[2]] || matches[2]);
+              const column = columnAliases[matches[2]] || matches[2];
               const operator = opMapping[matches[3]];
               const target = matches[4];
               if (matches[3] == 'like') {

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/CustomKnex.ts
@@ -430,11 +430,19 @@ const appendWhereCondition = function(
               );
               break;
             case '':
-              knexRef[`${key}`](
-                columnAliases[matches[2]] || matches[2],
-                opMapping[matches[3]],
-                matches[4]
-              );
+              const column = (columnAliases[matches[2]] || matches[2]);
+              const operator = opMapping[matches[3]];
+              const target = matches[4];
+              if (matches[3] == 'like') {
+                // handle uuid case
+                knexRef[`${key}`](
+                  knexRef?.client.raw(`??::TEXT ${operator} '${target}'`, [
+                    column
+                  ])
+                );
+              } else {
+                knexRef[`${key}`](column, operator, target);
+              }
               break;
             default:
               throw new Error(`${matches[1] || ''} Invalid operation.`);
@@ -991,6 +999,7 @@ export { Knex };
  *
  * @author Naveen MR <oof1lab@gmail.com>
  * @author Pranav C Balan <pranavxc@gmail.com>
+ * @author Wing-Kam Wong <wingkwong.code@gmail.com>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/packages/nocodb/src/lib/sqlUi/MssqlUi.ts
+++ b/packages/nocodb/src/lib/sqlUi/MssqlUi.ts
@@ -937,16 +937,14 @@ export class MssqlUi {
 
   static getAbstractType(col): any {
     switch ((col.dt || col.dt).toLowerCase()) {
-      case 'bigint':
       case 'smallint':
       case 'bit':
       case 'tinyint':
       case 'int':
         return 'integer';
 
+      case 'bigint':
       case 'binary':
-        return 'string';
-
       case 'char':
         return 'string';
 

--- a/packages/nocodb/src/lib/sqlUi/MysqlUi.ts
+++ b/packages/nocodb/src/lib/sqlUi/MysqlUi.ts
@@ -868,7 +868,6 @@ export class MysqlUi {
       case 'int':
       case 'smallint':
       case 'mediumint':
-      case 'bigint':
       case 'bit':
         return 'integer';
 
@@ -922,6 +921,7 @@ export class MysqlUi {
       case 'set':
         return 'set';
 
+      case 'bigint':
       case 'geometry':
       case 'point':
       case 'linestring':

--- a/packages/nocodb/src/lib/sqlUi/SqliteUi.ts
+++ b/packages/nocodb/src/lib/sqlUi/SqliteUi.ts
@@ -694,7 +694,6 @@ export class SqliteUi {
       case 'tinyint':
       case 'smallint':
       case 'mediumint':
-      case 'bigint':
       case 'int2':
       case 'int8':
         return 'integer';
@@ -713,6 +712,7 @@ export class SqliteUi {
       case 'blob':
         return 'blob';
 
+      case 'bigint':
       case 'character':
       case 'varchar':
         return 'string';


### PR DESCRIPTION
Ref: #589 & #996 

## Change Summary

Some types like ``bigint`` or ``uuid`` need to be casted when comparing the target value. Currently there is no such handlng. This PR is to cast it as TEXT and compare with the target value (p.s. also string type).

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Before specifying search value

![image](https://user-images.githubusercontent.com/35857179/153539195-b269679a-da27-41c2-8859-0d76a08d05cf.png)

Searching ``bigint`` column 

<img width="953" alt="image" src="https://user-images.githubusercontent.com/35857179/153588262-47bdf0d6-4839-424a-81ed-08ca1e75b347.png">

Searching ``uuid`` column

![image](https://user-images.githubusercontent.com/35857179/153539267-060a92ee-8af2-41cc-92c2-1bc868af399d.png)

Searching normal column

![image](https://user-images.githubusercontent.com/35857179/153539303-dc5d6af3-ac76-4b9f-8fb4-4540a755d718.png)

