### PR TITLE
correct uidt check to preserve select column options after metadata sync

### DIFF
--- a/packages/nocodb/src/lib/sqlMgr/code/models/xc/BaseModelXcMeta.ts
+++ b/packages/nocodb/src/lib/sqlMgr/code/models/xc/BaseModelXcMeta.ts
@@ -64,8 +64,8 @@ abstract class BaseModelXcMeta extends BaseRender {
         columnObj._cn = oldColMeta._cn || columnObj._cn;
         columnObj.uidt = oldColMeta.uidt;
         if (
-          (columnObj.dtxp === UITypes.MultiSelect ||
-            columnObj.dtxp === UITypes.SingleSelect) &&
+          (columnObj.uidt === UITypes.MultiSelect ||
+            columnObj.uidt === UITypes.SingleSelect) &&
           columnObj.dt !== 'set' &&
           columnObj.dt !== 'enum'
         ) {


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

Options added for Single Select and Multi select columns are getting lost after metadata refresh. This PR fixes a simple error in checking column types to preserve options.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
