### PR TITLE
fix: undefined parent id when calling paginatedM2mNotChildrenList

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/virtualCell/components/listItems.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/virtualCell/components/listItems.vue
@@ -162,7 +162,7 @@ export default {
             offset: this.size * (this.page - 1),
             ...this.queryParams,
             where
-          }, this.mm.vtn, this.parentId)
+          }, this.mm.vtn, this.parentId || -1)
         } else {
           this.data = await this.api.paginatedList({
             limit: this.size,


### PR DESCRIPTION
Ref: #781 

## Change Summary

If we add a new row and link record before saving, the option list is empty. If you click reload button, it will throw an error as well. This is because the list is retrieved by calling ``paginatedM2mNotChildrenList`` where one of the parameters is ``pid``, i.e. the row id. It is used in ``whereNotIn`` in ``m2mNotChildren``. If we haven't saved the record, ``pid`` would be ``undefined``, which results in this issue. 

The change in this PR is to assign a default value to ``pid`` if it is not defined. If we add a new record, then the list should include all options as there is no selected one. The default value should be a non-existing row id to avoid collision. Hence, ``-1`` is chosen. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/153705730-6b1590dd-8cba-4ab7-96ac-799a0e0f2fb9.png)