### PR TITLE
Uniform 400 response format of REST /auth/signin

### DIFF
--- a/packages/nocodb/src/__tests__/rest.test.ts
+++ b/packages/nocodb/src/__tests__/rest.test.ts
@@ -189,6 +189,13 @@ describe('{Auth, CRUD, HasMany, Belongs} Tests', () => {
         .send({ email: EMAIL_ID, password: 'wrongPassword' })
         .expect(400, done);
     });
+    
+    it('Signup with no credentials', done => {
+      request(app)
+        .post('/auth/signin')
+        .send({})
+        .expect(400, done)
+    })
 
     it('Forgot password with a non-existing email id', function(done) {
       request(app)

--- a/packages/nocodb/src/lib/noco/rest/RestAuthCtrl.ts
+++ b/packages/nocodb/src/lib/noco/rest/RestAuthCtrl.ts
@@ -635,7 +635,13 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              return res.status(400).send(err);
+              // This exception was thrown directly before.
+              // In order to avoid breaking change, both "msg" and "message" are returned.
+              const message = err.message ?? ''
+              return res.status(400).send({
+                msg: message,
+                message
+              });
             }
             if (info) {
               return res.status(400).send(info);
@@ -694,7 +700,13 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              return res.status(400).send(err);
+              // This exception was thrown directly before.
+              // In order to avoid breaking change, both "msg" and "message" are returned.
+              const message = err.message ?? ''
+              return res.status(400).send({
+                msg: message,
+                message
+              });
             }
             if (info) {
               return res.status(400).send(info);
@@ -753,7 +765,13 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              return res.status(400).send(err);
+              // This exception was thrown directly before.
+              // In order to avoid breaking change, both "msg" and "message" are returned.
+              const message = err.message ?? ''
+              return res.status(400).send({
+                msg: message,
+                message
+              });
             }
             if (info) {
               return res.status(400).send(info);


### PR DESCRIPTION
## Change Summary

This PR uniforms the format of some 400 responses of `/auth/signin`.

Issue: #1266 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [x] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Throwing exception directly has been replaced with returning a msg interface.

And a unit test case for no credentials has been added.

## Additional information / screenshots (optional)

"Missing credentials" now responses a json with both `msg` and `message` properties. This is because some people may rely on the property `message`.
