### PR TITLE
Fix incorrect response while wrong credentials was provided

### DIFF
--- a/packages/nocodb/src/lib/noco/rest/RestAuthCtrl.ts
+++ b/packages/nocodb/src/lib/noco/rest/RestAuthCtrl.ts
@@ -635,16 +635,18 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              // This exception was thrown directly before.
+              // err: { msg: string }
+              return res.status(400).send(err);
+            }
+            if (info) {
+              // info: { message: string }
+              // Info was thrown directly before.
               // In order to avoid breaking change, both "msg" and "message" are returned.
-              const message = err.message ?? ''
+              const message = info.message ?? '';
               return res.status(400).send({
                 msg: message,
                 message
               });
-            }
-            if (info) {
-              return res.status(400).send(info);
             }
             return res.status(400).send({ msg: 'Your signin has failed' });
           }
@@ -700,13 +702,7 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              // This exception was thrown directly before.
-              // In order to avoid breaking change, both "msg" and "message" are returned.
-              const message = err.message ?? ''
-              return res.status(400).send({
-                msg: message,
-                message
-              });
+              return res.status(400).send(err);
             }
             if (info) {
               return res.status(400).send(info);
@@ -765,13 +761,7 @@ export default class RestAuthCtrl {
         try {
           if (!user || !user.email) {
             if (err) {
-              // This exception was thrown directly before.
-              // In order to avoid breaking change, both "msg" and "message" are returned.
-              const message = err.message ?? ''
-              return res.status(400).send({
-                msg: message,
-                message
-              });
+              return res.status(400).send(err);
             }
             if (info) {
               return res.status(400).send(info);


### PR DESCRIPTION
## Change Summary

I have made a mistake in PR #1274 and it responses incorrect message when wrong credentials was provided when signing in.

It has been fixed. Sorry for making mistakes.

And I have added the type annotation in the comment. However I think it's better to make sure that the TypeScript is working for lib "passport". Now it's AnyScript and quite misleading.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Update /auth/signin handler to make sure it returns the correct json.

