### PR TITLE
feat: add URL formula

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/virtualCell/formulaCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/virtualCell/formulaCell.vue
@@ -9,6 +9,7 @@
     </template>
     <span class=" font-weight-bold">{{ column.formula.error.join(', ') }}</span>
   </v-tooltip>
+  <div v-else-if="urls" v-html="urls"></div>
   <div v-else>
     {{ row[column._cn] }}
   </div>
@@ -17,7 +18,23 @@
 <script>
 export default {
   name: 'FormulaCell',
-  props: ['column', 'row']
+  props: ['column', 'row'],
+  computed: {
+    urls: function() {
+      if(this.row[this.column._cn] ) {
+        let rawText = this.row[this.column._cn].toString();
+        let matchURLs = rawText.match(/URI::\((.*?)\)/g);
+        if(matchURLs) {
+          for(const url of matchURLs) {
+            let tmpuri = url.match(/URI::\((.*?)\)/)[1];
+            rawText = rawText.replace(url, '<a href="' + tmpuri + '" target="_blank">' + tmpuri + '</a>');
+          }
+          return rawText;
+        }
+      }
+      return false;
+    }
+  }
 }
 </script>
 

--- a/packages/nc-gui/helpers/formulaList.js
+++ b/packages/nc-gui/helpers/formulaList.js
@@ -54,6 +54,7 @@ const validations = {
   MID: { validation: { args: { rqd: 1 } } },
   IF: { validation: { args: { min: 2, max: 3 } } },
   SWITCH: { validation: { args: { min: 3 } } },
+  URL: { validation: { args: { rqd: 1 } } },
 };
 
 export default Object.keys(validations);

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
@@ -64,6 +64,32 @@ export default function formulaQueryBuilder(
             }
           }
           break;
+        case 'URL':
+          return fn(
+            {
+              type: 'CallExpression',
+              arguments: [
+                {
+                  type: 'Literal',
+                  value: 'URI::(',
+                  raw: '"URI::("'
+                },
+                pt.arguments[0],
+                {
+                  type: 'Literal',
+                  value: ')',
+                  raw: '")"'
+                }
+              ],
+              callee: {
+                type: 'Identifier',
+                name: 'CONCAT'
+              }
+            },
+            a,
+            prevBinaryOp
+          );
+          break;
         default:
           {
             const res = mapFunctionName({


### PR DESCRIPTION
## Change Summary

Added a new formula called URL() which is compatible with other formulas.
Example usage: URL("https://google.com")

ref: closes #1028 

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

![table](https://user-images.githubusercontent.com/59797957/155024748-3fc9886a-4d56-459a-a5ba-130e879a2114.png)
![urlfield](https://user-images.githubusercontent.com/59797957/155024758-86bbabe4-64bc-4fe4-9878-8cf84d16c488.png)
![urlfield2](https://user-images.githubusercontent.com/59797957/155024764-23f27365-d2ab-4fc2-acfb-c1e0e9506074.png)


## Additional information / screenshots (optional)

Uses URI::(url) syntax for handling URLs.