### PR TITLE
fix: uppercase formula column names on postgresql

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
@@ -14,7 +14,7 @@ export default function formulaQueryBuilder(
   aliasToColumn = {}
 ) {
   const fn = (pt, a?, prevBinaryOp?) => {
-    const colAlias = a ? ` as ${a}` : '';
+    const colAlias = a ? ` as "${a}"` : '';
     if (pt.type === 'CallExpression') {
       switch (pt.callee.name) {
         case 'ADD':


### PR DESCRIPTION
## Change Summary

Uppercase formula column names wasn't working because if you select as without quotes on pg it pretends case-insensitive. Added quotes around column name selector to get around this.
Ref: fixes #1332 

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Same result with or without uppercase letters on formula columns:
![image](https://user-images.githubusercontent.com/59797957/155420198-5995c1df-59a6-482d-a031-8afe5eac002c.png)

## Additional information / screenshots (optional)

This commit effect queries:
SELECT 1 as Formula, 1 as formula FROM table; -> SELECT 1 as "Formula", 1 as "formula" FROM table;
