### PR TITLE
feat: DATEADD formula for date arithmetics 

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/dateTimePickerCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/dateTimePickerCell.vue
@@ -42,7 +42,11 @@ export default {
           .format('YYYY-MM-DD HH:mm')
       },
       set(val) {
-        this.$emit('input', val && dayjs(val).format('YYYY-MM-DD HH:mm:ssZ'))
+        if(this.$parent.sqlUi.name == 'MysqlUi') {
+          this.$emit('input', val && dayjs(val).format('YYYY-MM-DD HH:mm:ss'))
+        } else {
+          this.$emit('input', val && dayjs(val).format('YYYY-MM-DD HH:mm:ssZ'))
+        }
       }
     },
     parentListeners() {

--- a/packages/nc-gui/helpers/formulaList.js
+++ b/packages/nc-gui/helpers/formulaList.js
@@ -55,6 +55,7 @@ const validations = {
   IF: { validation: { args: { min: 2, max: 3 } } },
   SWITCH: { validation: { args: { min: 3 } } },
   URL: { validation: { args: { rqd: 1 } } },
+  DATEADD: { validation: { args: { rqd: 3 } } },
 };
 
 export default Object.keys(validations);

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/formulaQueryBuilderFromString.ts
@@ -90,6 +90,15 @@ export default function formulaQueryBuilder(
             prevBinaryOp
           );
           break;
+        case 'DATEADD':
+          if(pt.arguments[1].value) {
+            pt.callee.name = "DATE_ADD";
+            return fn(pt, a, prevBinaryOp);
+          } else if(pt.arguments[1].operator == '-') {
+            pt.callee.name = "DATE_SUB";
+            return fn(pt, a, prevBinaryOp);
+          }
+          break;
         default:
           {
             const res = mapFunctionName({

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/mssql.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/mssql.ts
@@ -88,6 +88,30 @@ const mssql = {
     return args.knex
       .raw(`CAST(${args.fn(args.pt.arguments[0])} as FLOAT)${args.colAlias}`)
       .wrap('(', ')');
+  },
+  DATE_ADD: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN
+        FORMAT(DATEADD(${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}, 
+        +${args.fn(args.pt.arguments[1])}, ${args.fn(args.pt.arguments[0])}), 'yyyy-MM-dd HH:mm')
+      ELSE
+       FORMAT(DATEADD(${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}, 
+        +${args.fn(args.pt.arguments[1])}, ${args.fn(args.pt.arguments[0])}), 'yyyy-MM-dd')
+      END${args.colAlias}`
+    );
+  },
+  DATE_SUB: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN
+        FORMAT(DATEADD(${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}, 
+        -${args.fn(args.pt.arguments[1])}.argument.value, ${args.fn(args.pt.arguments[0])}), 'yyyy-MM-dd HH:mm')
+      ELSE
+       FORMAT(DATEADD(${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}, 
+        -${args.fn(args.pt.arguments[1])}.argument.value, ${args.fn(args.pt.arguments[0])}), 'yyyy-MM-dd')
+      END${args.colAlias}`
+    );
   }
 };
 

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/mysql.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/mysql.ts
@@ -36,6 +36,32 @@ const mysql2 = {
     return args.knex
       .raw(`CAST(${args.fn(args.pt.arguments[0])} as DOUBLE)${args.colAlias}`)
       .wrap('(', ')');
+  },
+  DATE_ADD: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN
+        DATE_FORMAT(DATE_ADD(${args.fn(args.pt.arguments[0])}, INTERVAL 
+        ${args.fn(args.pt.arguments[1])} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}), '%Y-%m-%d %H:%i')
+      ELSE
+        DATE(DATE_ADD(${args.fn(args.pt.arguments[0])}, INTERVAL 
+        ${args.fn(args.pt.arguments[1])} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}))
+      END${args.colAlias}`
+    );
+  },
+  DATE_SUB: (args: MapFnArgs) => {
+    return args.knex.raw(
+       `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN
+        DATE_FORMAT(DATE_ADD(${args.fn(args.pt.arguments[0])}, INTERVAL 
+        ${args.fn(args.pt.arguments[1])}.argument.value 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}), '%Y-%m-%d %H:%i')
+      ELSE
+        DATE(DATE_ADD(${args.fn(args.pt.arguments[0])}, INTERVAL 
+        ${args.fn(args.pt.arguments[1])}.argument.value 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}))
+      END${args.colAlias}`
+    );
   }
 };
 

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/pg.ts
@@ -36,6 +36,30 @@ const pg = {
         }`
       )
       .wrap('(', ')');
+  },
+  DATE_ADD: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN CAST(${args.fn(args.pt.arguments[0])} AS text) LIKE '%:%' THEN
+        to_char(${args.fn(args.pt.arguments[0])} + INTERVAL '${args.fn(args.pt.arguments[1])} 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}', 'YYYY-MM-DD HH24:MI')
+      ELSE
+        to_char(${args.fn(args.pt.arguments[0])} + INTERVAL '${args.fn(args.pt.arguments[1])} 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}', 'YYYY-MM-DD')
+      END${args.colAlias}`
+    );
+  },
+  DATE_SUB: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN CAST(${args.fn(args.pt.arguments[0])} AS text) LIKE '%:%' THEN
+        to_char(${args.fn(args.pt.arguments[0])} - INTERVAL '${args.fn(args.pt.arguments[1]).argument.value} 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}', 'YYYY-MM-DD HH24:MI')
+      ELSE
+        to_char(${args.fn(args.pt.arguments[0])} - INTERVAL '${args.fn(args.pt.arguments[1]).argument.value} 
+        ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}', 'YYYY-MM-DD')
+      END${args.colAlias}`
+    );
   }
 };
 

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/sqlite.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/sqlite.ts
@@ -55,6 +55,30 @@ const sqlite3 = {
     return args.knex
       .raw(`CAST(${args.fn(args.pt.arguments[0])} as FLOAT)${args.colAlias}`)
       .wrap('(', ')');
+  },
+  DATE_ADD: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN 
+        STRFTIME('%Y-%m-%d %H:%M', DATETIME(DATETIME(${args.fn(args.pt.arguments[0])}, 'localtime'), 
+        '+${args.fn(args.pt.arguments[1])} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}'))
+      ELSE 
+        DATE(DATETIME(${args.fn(args.pt.arguments[0])}, 'localtime'), 
+        '+${args.fn(args.pt.arguments[1])} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}')
+      END${args.colAlias}`
+    );
+  },
+  DATE_SUB: (args: MapFnArgs) => {
+    return args.knex.raw(
+      `CASE
+      WHEN ${args.fn(args.pt.arguments[0])} LIKE '%:%' THEN 
+        STRFTIME('%Y-%m-%d %H:%M', DATETIME(DATETIME(${args.fn(args.pt.arguments[0])}, 'localtime'),
+        '-${args.fn(args.pt.arguments[1]).argument.value} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}'))
+      ELSE 
+        DATE(DATETIME(${args.fn(args.pt.arguments[0])}, 'localtime'), 
+        '-${args.fn(args.pt.arguments[1]).argument.value} ${String(args.fn(args.pt.arguments[2])).replace(/["']/g, "")}')
+      END${args.colAlias}`
+    );
   }
 };
 


### PR DESCRIPTION
## Change Summary

Added a new formula called DATEADD which supports date arithmetics.
It takes 3 arguments DATEADD(date, number, 'interval')

- Date can be date or datetime, result changes according to given type
- Interval values depends on database but common ones work for each (day, month etc.)
- Number can be negative for subtraction.


Ref: closes #1389 

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

![image](https://user-images.githubusercontent.com/59797957/156948866-f5e913cc-ec9a-47bb-b298-dd9abe936b8d.png)
daytodate: DATEADD(date, 1, 'day')
monthtodatetime: DATEADD(datetime, 2, 'month')
isDateAfter: IF(NOW() < date, "true", "false")
isDatePlus10After: IF(NOW() < DATEADD(date,10,'day'), "true", "false")
(Date of execution: 2022-03-07)

## Additional information / screenshots (optional)

DateTime Picker was giving an error on MySQL (timezone part) so I implemented a work around for it. Although I tried this with different versions, this error needs confirming it might be caused by my setup.

MSSQL date picker isn't working too(As much as I can inspect it tries to create a varchar without proper length as date column). I couldn't find a way to fix this but implemented the DATEADD function anyway.
