### PR TITLE
use correct event on checkbox

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
@@ -206,7 +206,7 @@
                                           dense
                                           hide-details
                                           label="NN"
-                                          @input="newColumn.altered = newColumn.altered || 2"
+                                          @change="newColumn.altered = newColumn.altered || 2"
                                         >
                                           <template #label>
                                             <span class="caption font-weight-bold">NN</span>
@@ -227,7 +227,7 @@
                                           dense
                                           hide-details
                                           label="PK"
-                                          @input="newColumn.altered = newColumn.altered || 2"
+                                          @change="newColumn.altered = newColumn.altered || 2"
                                         >
                                           <template #label>
                                             <span class="caption font-weight-bold">PK</span>
@@ -248,7 +248,7 @@
                                           dense
                                           hide-details
                                           label="AI"
-                                          @input="newColumn.altered = newColumn.altered || 2"
+                                          @change="newColumn.altered = newColumn.altered || 2"
                                         >
                                           <template #label>
                                             <span class="caption font-weight-bold">AI</span>
@@ -269,7 +269,7 @@
                                           hide-details
                                           label="UN"
                                           :disabled="sqlUi.colPropUNDisabled(newColumn) || !sqlUi.columnEditable(newColumn)"
-                                          @input="newColumn.altered = newColumn.altered || 2"
+                                          @change="newColumn.altered = newColumn.altered || 2"
                                         >
                                           <template #label>
                                             <span class="caption font-weight-bold">UN</span>
@@ -290,7 +290,7 @@
                                           hide-details
                                           label="UN"
                                           :disabled=" sqlUi.colPropAuDisabled(newColumn) || !sqlUi.columnEditable(newColumn)"
-                                          @input="newColumn.altered = newColumn.altered || 2"
+                                          @change="newColumn.altered = newColumn.altered || 2"
                                         >
                                           <template #label>
                                             <span class="caption font-weight-bold">AU</span>


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

`@input` event does not work for checkboxes.Checkboxes in advance options while edit column are not working because of it.
This PR fixes it and uses `@change` event.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
