### PR TITLE
docs: Fix typo in rollup.md

### DIFF
--- a/packages/noco-docs/content/en/setup-and-usages/rollup.md
+++ b/packages/noco-docs/content/en/setup-and-usages/rollup.md
@@ -24,7 +24,7 @@ Sample simple Organization structure:
 - Average
 - Sum
 - Count Distinct
-- Sum Distrinct
+- Sum Distinct
 - Average Distinct
 
 Now, we can explore how to extract employee count information per vertical using **"ROLLUP"** columns


### PR DESCRIPTION
## Change Summary

Fixes a typing error on the Rollup documentation page.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

"Distrinct" was misspelled and has been replaced with "Distinct"

## Additional information / screenshots (optional)

N/A
