### PR TITLE
Fix incorrect HTTP method in REST API docs

### DIFF
--- a/packages/noco-docs/content/en/developer-resources/rest-apis.md
+++ b/packages/noco-docs/content/en/developer-resources/rest-apis.md
@@ -422,7 +422,7 @@ PUT  /api/v1/country/1
   <code-block label="Request" active> 
   
 ```
-DELETE  /api/v1/country/1/exists
+GET  /api/v1/country/1/exists
 ```
 
 </code-block>


### PR DESCRIPTION
## Change Summary

The example for the `Exists` REST API endpoint uses `DELETE` instead of `GET`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

N/A
