### PR TITLE
handle commas correctly in multi select options

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/customSelectOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/customSelectOptions.vue
@@ -8,7 +8,14 @@
       >
         mdi-arrow-down-drop-circle
       </v-icon>
-      <v-text-field v-model="localState[i]" class="caption" outlined dense />
+      <v-text-field
+        :autofocus="true"
+        :value="localState[i]"
+        @input="listenForComma(i, $event)"
+        class="caption"
+        dense
+        outlined
+      />
       <v-icon class="ml-2" color="error lighten-2" size="13" @click="localState.splice(i,1)">
         mdi-close
       </v-icon>
@@ -60,6 +67,14 @@ export default {
   methods: {
     syncState() {
       this.localState = (this.value || '').split(',').map(v => v.replace(/\\'/g, '\'').replace(/^'|'$/g, ''))
+    },
+    listenForComma(index, value) {
+      const normalisedValue = value.trim()
+      if (normalisedValue.endsWith(',')) {
+        this.localState.push('')
+        return
+      }
+      this.localState[index] = normalisedValue
     }
   }
 }


### PR DESCRIPTION
## Change Summary

Handle the commas correctly when adding new options in multi select options. Fixes ref: #1282 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Before, the comma was handled weirdly resulting in such views: 
![image](https://user-images.githubusercontent.com/5158554/160152105-1ac5ddcf-4e95-420e-884a-8bc9d05efbd7.png)

Now, when you try to add a comma, it adds a new field automatically and auto focuses that field so user can type the next option.

