### PR TITLE
fix: reorder key search in related table

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSql.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSql.ts
@@ -1336,9 +1336,9 @@ class BaseModelSql extends BaseModel {
       driver.union(
         parent.map(p => {
           const id =
-            p[_cn] ||
             p[this.columnToAlias?.[this.pks[0].cn] || this.pks[0].cn] ||
-            p[this.pks[0].cn];
+            p[this.pks[0].cn] ||
+            p[_cn];
           const query = driver(this.dbModels[child].tnPath)
             .where(cn, id)
             .xwhere(where, this.dbModels[child].selectQuery(''))


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

There's a bug in listing API call, which causes it to fail. This PR is to fix it.

### steps to reproduce 

1. Create a table `violations_violation` (it can be any name I am using this name in this example)
2. Create another table `violations_ticket`
3. Create a new hasMany relationship in `violations_violation`, it has many `violations_ticket`
4. Go to `violations_ticket` table and display system fields. Notice the field name which was created to facilitate the relationship. It would be `violations_violation_id` in this case.
5. Create a new text field `violations_violation_id` in `violations_violation`
6. Add a row in `violations_violation`
7. Try to list all the rows in `violations_violation`, You will see an error like
```
{"msg":"(select \"violations_ticket\".\"id\" as \"id\", \"violations_ticket\".\"title\" as \"title\", \"violations_ticket\".\"violations_violation_id\" as \"violations_violation_id\" from \"violations_ticket\" where \"violations_violation_id\" = $1 limit $2) - invalid input syntax for type integer: \"A\""}
```


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

I am using `pg` database as data source.
