### PR TITLE
change default pool size of knex

### DIFF
--- a/packages/nocodb/src/lib/noco/common/NcConnectionMgr.ts
+++ b/packages/nocodb/src/lib/noco/common/NcConnectionMgr.ts
@@ -5,7 +5,10 @@ import Knex from 'knex';
 
 import { SqlClientFactory } from 'nc-help';
 import NcMetaIO from '../meta/NcMetaIO';
-import { defaultConnectionConfig } from '../../utils/NcConfigFactory';
+import {
+  defaultConnectionConfig,
+  defaultConnectionOptions
+} from '../../utils/NcConfigFactory';
 
 export default class NcConnectionMgr {
   private static connectionRefs: {
@@ -105,6 +108,7 @@ export default class NcConnectionMgr {
         isSqlite
           ? (connectionConfig.connection as Knex.Config)
           : ({
+              ...defaultConnectionOptions,
               ...connectionConfig,
               connection: {
                 ...defaultConnectionConfig,

--- a/packages/nocodb/src/lib/utils/NcConfigFactory.ts
+++ b/packages/nocodb/src/lib/utils/NcConfigFactory.ts
@@ -32,6 +32,14 @@ const defaultClientPortMapping = {
   mssql: 1433
 };
 
+// default knex options
+const defaultConnectionOptions = {
+  pool: {
+    min: 0,
+    max: 10
+  }
+};
+
 const defaultConnectionConfig: any = {
   // https://github.com/knex/knex/issues/97
   // timezone: process.env.NC_TIMEZONE || 'UTC',
@@ -609,7 +617,7 @@ export default class NcConfigFactory implements NcConfig {
   // }
 }
 
-export { defaultConnectionConfig };
+export { defaultConnectionConfig, defaultConnectionOptions };
 
 /**
  * @copyright Copyright (c) 2021, Xgene Cloud Ltd


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

When trying to deploy NocoDB on serverless (ECS fargate), we started experiencing `connection terminated unexpectedly` intermittently.  This PR fixes it by setting `min` connections in pool to `0`. Knex Default `min` is `2` and max is `10`.
You can read in more detail about the issue [here](https://github.com/knex/knex/issues/3523)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

I am using `pg` as data source.
