### PR TITLE
fix: select field default value removal

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn.vue
@@ -353,7 +353,7 @@
                                   outlined
                                   dense
                                   class="caption"
-                                  @input="newColumn.altered = newColumn.altered || 2"
+                                  @input="(newColumn.altered = newColumn.altered || 2); (newColumn.cdf = newColumn.cdf || null);"
                                 />
                               </v-col>
                             </v-row>

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/customSelectOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/customSelectOptions.vue
@@ -10,7 +10,7 @@
       </v-icon>
       <v-text-field
         :autofocus="true"
-        :value="localState[i]"
+        v-model="localState[i]"
         @input="listenForComma(i, $event)"
         class="caption"
         dense


### PR DESCRIPTION
## Change Summary

An error was given when you delete default value from single select column, fixed it via making it null if default input is empty.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
