### PR TITLE
Add dumb-init: catch signals

### DIFF
--- a/packages/nocodb/Dockerfile
+++ b/packages/nocodb/Dockerfile
@@ -50,7 +50,8 @@ ENV NC_TOOL_DIR=/usr/app/data/
 
 RUN apk --update --no-cache add \
     nodejs \
-    tar
+    tar \
+    dumb-init
 
 # Copy litestream binary build
 COPY  --from=lt-builder /usr/src/lt /usr/src/appEntry/litestream
@@ -58,6 +59,7 @@ COPY  --from=lt-builder /usr/src/lt /usr/src/appEntry/litestream
 COPY --from=builder /usr/src/appEntry/ /usr/src/appEntry/
 
 EXPOSE 8080
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Start Nocodb
-ENTRYPOINT ["sh", "/usr/src/appEntry/start.sh"]
+CMD ["/usr/src/appEntry/start.sh"]


### PR DESCRIPTION
## Change Summary

Add [dumb-init](https://github.com/Yelp/dumb-init#why-you-need-an-init-system)
Fixes https://github.com/nocodb/nocodb/issues/1661

## Change type

- [*] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

```
~/dev/js/nocodb/packages/nocodb robinfrcd/catch-sigint
❯ docker run nocodb/nocodb:latest
select * from `nc_api_tokens`
App started successfully.
Visit -> http://localhost:8080/dashboard
^C
~/dev/js/nocodb/packages/nocodb robinfrcd/catch-sigint
❯ 
```
