### PR TITLE
fix: toast error corrections & cache flush on delete

### DIFF
--- a/packages/nc-gui/components/createOrEditProject.vue
+++ b/packages/nc-gui/components/createOrEditProject.vue
@@ -1394,7 +1394,7 @@ export default {
         this.projectCreated = true
       } catch (e) {
         this.$toast.error(await this._extractSdkResponseErrorMsg(e)).goAway(3000)
-        toast.goAway(100)
+        toast.goAway(0)
       }
 
       this.projectReloading = false

--- a/packages/nc-gui/components/createOrEditProject.vue
+++ b/packages/nc-gui/components/createOrEditProject.vue
@@ -87,12 +87,8 @@
                       :height="20"
                       :label="$t('placeholder.projName')"
                       autofocus
-                    >
-                    </v-text-field>
-
-
+                    />
                   </div>
-
                 </v-col>
 
                 <v-col
@@ -631,11 +627,8 @@
                         </v-col>
                       </v-expansion-panel-content>
                     </v-expansion-panel>
-
-
                   </v-expansion-panels>
                 </v-col>
-
               </v-row>
             </v-container>
           </div>
@@ -1154,7 +1147,6 @@ export default {
     },
     selectFile(db, obj, key, index) {
       this.$refs[key][index].click()
-
     },
     onPanelToggle(panelIndex, envKey) {
       this.$nextTick(() => {
@@ -1289,7 +1281,6 @@ export default {
     },
 
     constructProjectJsonFromProject(project) {
-
       const p = project // JSON.parse(JSON.stringify(project.projectJson));
 
       p.ui = {
@@ -1403,6 +1394,7 @@ export default {
         this.projectCreated = true
       } catch (e) {
         this.$toast.error(await this._extractSdkResponseErrorMsg(e)).goAway(3000)
+        toast.goAway(100)
       }
 
       this.projectReloading = false
@@ -1882,7 +1874,6 @@ export default {
           }
         }
       }
-
     }
   },
   beforeMount() {

--- a/packages/nc-gui/pages/project/xcdb.vue
+++ b/packages/nc-gui/pages/project/xcdb.vue
@@ -156,7 +156,7 @@ export default {
             }
           })
         } catch (e) {
-          this.$toast.error(e.message).goAway(3000)
+          this.$toast.error(await this._extractSdkResponseErrorMsg(e)).goAway(3000)
         }
         this.loading = false
       } else {

--- a/packages/nocodb/src/lib/noco-models/Project.ts
+++ b/packages/nocodb/src/lib/noco-models/Project.ts
@@ -184,6 +184,10 @@ export default class Project implements ProjectType {
     }
     if (o) await NocoCache.del(`${CacheScope.PROJECT}:${projectId}`);
 
+    if (o?.title) {
+      await NocoCache.del(`${CacheScope.PROJECT}:${o.title}`);
+    }
+
     // remove item in cache list
     await NocoCache.deepDel(
       CacheScope.PROJECT,


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
- ext db: project created with same name, toast persisted
- xcdb: project created with same name - error message corrected
- cache issue: insert record was failing for following scenario [was working with cache disabled]
  - create project, delete project, create another project with same name
  - insert record using bulk create api (failing while trying to retrieve project id using project title) 

## Change type
- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
Locally verified
