### PR TITLE
Feature: Downloading multiple attachments

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
@@ -1,0 +1,77 @@
+<template>
+  <v-dialog v-model="showModal" max-width="600">
+    <v-card max-width="600" class="pa-6">
+      <v-card-title>Download Multiple Attachments</v-card-title>
+      <v-select
+        label="Attachments Field"
+        :items="items"
+      />
+      <v-btn>Download</v-btn>
+      </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+
+export default {
+  name: 'DownloadAttachmentsModal',
+  components: {},
+  props: {
+    value: Boolean,
+    accept: String,
+    text: String
+  },
+  data() {
+    return {
+      items: []
+    }
+  },
+  computed: {
+    showModal: {
+      set(v) {
+        this.$emit('input', v)
+      },
+      get() {
+        return this.value
+      }
+    }
+  },
+  methods: {
+  }
+}
+</script>
+
+<style scoped>
+
+/*.nc-droppable {
+  width: 100%;
+  min-height: 200px;
+  border-radius: 4px;
+  border: 2px dashed var(--v-textColor-lighten5);
+}*/
+</style>
+
+<!--
+/**
+ * @copyright Copyright (c) 2022, Matthew Lu
+ *
+ * @author Matthew Lu <seedmachinegun@gmail.com>
+ * 
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+-->

--- a/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
@@ -1,12 +1,24 @@
 <template>
   <v-dialog v-model="showModal" max-width="600">
-    <v-card max-width="600" class="pa-6">
+    <v-card max-width="600" class="pa-6 d-flex flex-column align-center">
       <v-card-title>Download Multiple Attachments</v-card-title>
       <v-select
         label="Attachments Field"
-        :items="items"
+        v-model="selectedAttachmentField"
+        :items="availableAttachmentFields"
+        item-text="cn"
+        class="flex"
       />
-      <v-btn>Download</v-btn>
+      <!--v-select
+        label="Filename Field"
+        v-model="selectedFilenameField"
+        :items="availableColumns"
+        item-text="cn"
+        class="flex"
+      /-->
+      <v-btn
+        @click="onSubmit"
+      >Download</v-btn>
       </v-container>
     </v-card>
   </v-dialog>
@@ -19,12 +31,14 @@ export default {
   components: {},
   props: {
     value: Boolean,
-    accept: String,
-    text: String
+    availableColumns: [Object, Array]
   },
   data() {
     return {
-      items: []
+      attachmentOptions: [],
+      filenameOptions: [],
+      selectedAttachmentField: '',
+      selectedFilenameField: ''
     }
   },
   computed: {
@@ -35,21 +49,24 @@ export default {
       get() {
         return this.value
       }
+    },
+    availableAttachmentFields() {
+      return this.availableColumns && this.availableColumns.filter(col => col.uidt === 'Attachment')
     }
   },
   methods: {
+    onSubmit () {
+      this.$emit('download', {
+        selectedAttachmentField: this.selectedAttachmentField
+        // selectedFilenameField: this.selectedFilenameField
+      })
+    }
   }
 }
 </script>
 
 <style scoped>
 
-/*.nc-droppable {
-  width: 100%;
-  min-height: 200px;
-  border-radius: 4px;
-  border: 2px dashed var(--v-textColor-lighten5);
-}*/
 </style>
 
 <!--

--- a/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/downloadAttachmentsModal.vue
@@ -35,10 +35,16 @@ export default {
   },
   data() {
     return {
-      attachmentOptions: [],
-      filenameOptions: [],
       selectedAttachmentField: '',
       selectedFilenameField: ''
+    }
+  },
+  watch: {
+    availableAttachmentFields (newVal) {
+      // default to select the first item
+      if (newVal && newVal[0]) {
+        this.selectedAttachmentField = newVal[0]
+      }
     }
   },
   computed: {
@@ -56,6 +62,9 @@ export default {
   },
   methods: {
     onSubmit () {
+      if (this.selectedAttachmentField === '') {
+        return
+      }
       this.$emit('download', {
         selectedAttachmentField: this.selectedAttachmentField
         // selectedFilenameField: this.selectedFilenameField

--- a/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
@@ -87,9 +87,24 @@
             </span>
           </v-list-item-title>
         </v-list-item>
+        <v-list-item
+          dense
+          @click="downloadAttachmentsModal = true"
+        >
+          <v-list-item-title>
+            <v-icon small class="mr-1">
+              mdi-folder-download-outline
+            </v-icon>
+            <span class="caption">
+              <!-- Download Attachments -->
+              {{ $t('activity.downloadAttachments') }}
+            </span>
+          </v-list-item-title>
+        </v-list-item>
       </v-list>
     </v-menu>
     <drop-or-select-file-modal v-model="importModal" accept=".csv" text="CSV" @file="onCsvFileSelection" />
+    <download-attachments-modal v-model="downloadAttachmentsModal"/>
     <column-mapping-modal
       v-if="columnMappingModal && meta"
       v-model="columnMappingModal"
@@ -105,13 +120,14 @@
 
 import FileSaver from 'file-saver'
 import DropOrSelectFileModal from '~/components/import/dropOrSelectFileModal'
+import DownloadAttachmentsModal from './downloadAttachmentsModal'
 import ColumnMappingModal from '~/components/project/spreadsheet/components/importExport/columnMappingModal'
 import CSVTemplateAdapter from '~/components/import/templateParsers/CSVTemplateAdapter'
 import { UITypes } from '~/components/project/spreadsheet/helpers/uiTypes'
 
 export default {
   name: 'ExportImport',
-  components: { ColumnMappingModal, DropOrSelectFileModal },
+  components: { ColumnMappingModal, DropOrSelectFileModal, DownloadAttachmentsModal },
   props: {
     meta: Object,
     nodes: Object,
@@ -123,6 +139,7 @@ export default {
   data() {
     return {
       importModal: false,
+      downloadAttachmentsModal: false,
       columnMappingModal: false,
       parsedCsv: {}
     }

--- a/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
@@ -108,6 +108,7 @@
             showFields
           }"
           :selected-view="selectedView"
+          :available-columns="availableColumns"
           @showAdditionalFeatOverlay="showAdditionalFeatOverlay($event)"
           @webhook="showAdditionalFeatOverlay('webhooks')"
           @reload="reload"

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -304,6 +304,7 @@
     "importExcel": "Import Excel",
     "downloadCSV": "Download as CSV",
     "uploadCSV": "Upload CSV",
+    "downloadAttachments": "Download Attachments",
     "import": "Import",
     "importMetadata": "Import Metadata",
     "exportMetadata": "Export Metadata",

--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -13,6 +13,7 @@
         "@graphql-tools/merge": "^6.0.12",
         "@sentry/node": "^6.3.5",
         "archiver": "^5.0.2",
+        "async": "^3.2.3",
         "auto-bind": "^4.0.0",
         "aws-sdk": "^2.829.0",
         "axios": "^0.21.1",
@@ -3029,9 +3030,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "node_modules/async-each": {
       "version": "1.0.3",
@@ -27078,9 +27079,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
-      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
     },
     "async-each": {
       "version": "1.0.3",

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -94,6 +94,7 @@
     "@graphql-tools/merge": "^6.0.12",
     "@sentry/node": "^6.3.5",
     "archiver": "^5.0.2",
+    "async": "^3.2.3",
     "auto-bind": "^4.0.0",
     "aws-sdk": "^2.829.0",
     "axios": "^0.21.1",


### PR DESCRIPTION
## Change Summary

Implemented the feature - Multiselect for downloading attachments. ref: #335
Enable users to bulk download attachments of a column.

## Change type

- [x]  feat: (new feature for the user, not a new feature for build script)
- [ ]  fix: (bug fix for the user, not a fix to a build script)
- [ ]  docs: (changes to the documentation)
- [ ]  style: (formatting, missing semi colons, etc; no production code change)
- [ ]  refactor: (refactoring production code, eg. renaming a variable)
- [ ]  test: (adding missing tests, refactoring tests; no production code change)
- [ ]  chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Added a <downloadAttachmentsModal> component in the <moreAction> component. Users can select a field to download all attachments of the specified column.
- Added an API 'xcDownloadAttachments' in handleRequest in NcMetaMgr.ts. Used Archiver to create a zip file, stream add files, and pipe to response, which enables clients to download the zip file.
- It is implemented to be hidden in shared view for simplicity at the moment.

## Additional information / screenshots (optional)
https://user-images.githubusercontent.com/49985851/163179339-18308d87-7ac5-4d71-978e-5008aa4ab415.mov

## Anything for maintainers to be made aware of
I am new to this project and also new to open source, so I would love any feedback you have. Thank you so much!