### PR TITLE
refactor: renew old fetchReleaseInfo

### DIFF
--- a/packages/nc-gui/components/releaseInfo.vue
+++ b/packages/nc-gui/components/releaseInfo.vue
@@ -3,7 +3,7 @@
     <template #activator="{on}">
       <transition name="release">
         <v-btn
-          v-if="releaseAlert"
+          v-show="releaseAlert"
           text
           small
           class="mb-0 mr-2 py-0 "
@@ -54,10 +54,13 @@ export default {
   computed: {
     releaseAlert: {
       get() {
-        return !this.loading && this.$store.state.app.releaseVersion && this.$store.state.app.releaseVersion !== this.$store.state.app.hiddenRelease
+        return !this.loading && this.$store.state.app.releaseVersion &&
+          this.$store.state.app.latestRelease &&
+          this.$store.state.app.releaseVersion !== this.$store.state.app.latestRelease &&
+          this.$store.state.app.latestRelease !== this.$store.state.app.hiddenRelease
       },
       set(val) {
-        return this.$store.commit('app/MutHiddenRelease', val ? null : this.$store.state.app.releaseVersion)
+        return this.$store.commit('app/MutHiddenRelease', val ? null : this.$store.state.app.latestRelease)
       }
     },
     releaseVersion() {

--- a/packages/nc-gui/plugins/projectLoader.js
+++ b/packages/nc-gui/plugins/projectLoader.js
@@ -1,4 +1,4 @@
-export default async({ store, redirect, $axios, $toast, route }) => {
+export default async({ store, redirect, $axios, $toast, $api, route }) => {
   // if (!route.path || !route.path.startsWith('/nc/')) { await store.dispatch('plugins/pluginPostInstall', 'Branding') }
   if (window.location.search &&
     /\bscope=|\bstate=/.test(window.location.search) &&
@@ -63,11 +63,14 @@ export default async({ store, redirect, $axios, $toast, route }) => {
   // fetch latest release info
   const fetchReleaseInfo = async() => {
     try {
-      const releaseInfo = await store.dispatch('sqlMgr/ActSqlOp', [null, 'xcRelease'])
-      if (releaseInfo && releaseInfo.docker && releaseInfo.docker.upgrade) {
-        store.commit('app/MutReleaseVersion', releaseInfo.docker.name)
+      const releaseInfo = await $api.utils.appInfo()
+      const latestRelease = await $api.utils.appVersion()
+      if (releaseInfo && latestRelease && releaseInfo.version) {
+        store.commit('app/MutReleaseVersion', releaseInfo.version)
+        store.commit('app/MutLatestRelease', latestRelease.releaseVersion || null)
       } else {
         store.commit('app/MutReleaseVersion', null)
+        store.commit('app/MutLatestRelease', null)
       }
     } catch (e) {
       // ignore

--- a/packages/nc-gui/store/app.js
+++ b/packages/nc-gui/store/app.js
@@ -1,6 +1,7 @@
 export const state = () => ({
   releaseVersion: null,
-  hiddenRelease: null
+  hiddenRelease: null,
+  latestRelease: null
 })
 
 export const mutations = {
@@ -9,6 +10,9 @@ export const mutations = {
   },
   MutHiddenRelease(state, hiddenRelease) {
     state.hiddenRelease = hiddenRelease
+  },
+  MutLatestRelease(state, latestRelease) {
+    state.latestRelease = latestRelease
   }
 }
 

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -2946,6 +2946,22 @@ export class Api<
       }),
 
     /**
+     * No description
+     *
+     * @tags Utils
+     * @name AppVersion
+     * @request GET:/api/v1/db/meta/nocodb/version
+     * @response `200` `any` OK
+     */
+    appVersion: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/api/v1/db/meta/nocodb/version`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
      * @description Get All K/V pairs in NocoCache
      *
      * @tags Utils

--- a/packages/nocodb/src/lib/noco/meta/api/utilApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/utilApis.ts
@@ -7,6 +7,7 @@ import SqlMgrv2 from '../../../sqlMgr/v2/SqlMgrv2';
 import { defaultConnectionConfig } from '../../../utils/NcConfigFactory';
 import User from '../../../noco-models/User';
 import catchError from '../helpers/catchError';
+import axios from 'axios';
 
 export async function testConnection(req: Request, res: Response) {
   res.json(await SqlMgrv2.testConnection(req.body));
@@ -43,10 +44,20 @@ export async function appInfo(_req: Request, res: Response) {
   res.json(result);
 }
 
+export async function releaseVersion(_req: Request, res: Response) {
+  const result = await axios.get('https://github.com/nocodb/nocodb/releases/latest')
+    .then((response) => {
+      return { releaseVersion: response.request.res.responseUrl.replace('https://github.com/nocodb/nocodb/releases/tag/', '') }
+    })
+
+  res.json(result);
+}
+
 export default router => {
   router.post(
     '/api/v1/db/meta/connection/test',
     ncMetaAclMw(testConnection, 'testConnection')
   );
   router.get('/api/v1/db/meta/nocodb/info', catchError(appInfo));
+  router.get('/api/v1/db/meta/nocodb/version', catchError(releaseVersion));
 };

--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -4434,6 +4434,27 @@
         "description": ""
       }
     },
+    "/api/v1/db/meta/nocodb/version": {
+      "parameters": [],
+      "get": {
+        "summary": "",
+        "operationId": "utils-app-version",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
+        "tags": [
+          "Utils"
+        ],
+        "description": ""
+      }
+    },
     "/api/v1/db/meta/cache": {
       "get": {
         "summary": "Your GET endpoint",


### PR DESCRIPTION
## Change Summary

- Disables old xcRelease call which is from old API.
- Add new endpoint '/api/v1/db/meta/nocodb/version' to API which fetches latest release version of repo
- Refactor releaseInfo component to act on latest release fetched

## Change type

- [x] refactor: (refactoring production code, eg. renaming a variable)
