### PR TITLE
fix: remove duplicate and add missing delete api

### DIFF
--- a/packages/nocodb/src/lib/noco/meta/api/dataApis/dataAliasApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/dataApis/dataAliasApis.ts
@@ -152,9 +152,9 @@ router.patch(
   '/api/v1/db/data/:orgs/:projectName/:tableName/:rowId',
   ncMetaAclMw(dataUpdate, 'dataUpdate')
 );
-router.patch(
+router.delete(
   '/api/v1/db/data/:orgs/:projectName/:tableName/:rowId',
-  ncMetaAclMw(dataUpdate, 'dataUpdate')
+  ncMetaAclMw(dataDelete, 'dataDelete')
 );
 
 router.get(


### PR DESCRIPTION
## Change Summary

There was a duplicate endpoint for dataUpdate which I think supposed to be delete endpoint.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
