### PR TITLE
fix: use alias instead of _cn

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/mixins/spreadsheet.js
+++ b/packages/nc-gui/components/project/spreadsheet/mixins/spreadsheet.js
@@ -145,7 +145,7 @@ export default {
     concatenatedXWhere() {
       let where = ''
       if (this.searchField && this.searchQuery.trim()) {
-        const col = this.availableColumns.find(({ _cn }) => _cn === this.searchField) || this.availableColumns[0]
+        const col = this.availableColumns.find(({ alias }) => alias === this.searchField) || this.availableColumns[0]
         // bigint values are displayed in string format in UI
         // when searching bigint values, the operator should be 'eq' instead of 'like'
         if (['text', 'string'].includes(this.sqlUi.getAbstractType(col)) && col.dt !== 'bigint') {


### PR DESCRIPTION
ref: #1784

## Change Summary

`_cn` was the previous implementation. Use `alias` now.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)