### PR TITLE
Clarify "vertical" = "department" for US eng. speakers. (Used in imgs…

### DIFF
--- a/packages/noco-docs/content/en/setup-and-usages/lookup.md
+++ b/packages/noco-docs/content/en/setup-and-usages/lookup.md
@@ -10,7 +10,7 @@ menuTitle: "Lookup"
 
 ### Sample simple Organization structure
 
-- 5 verticals, each vertical has a team name & associated team code. Vertical **has many** Employees - relationship has been defined
+- 5 verticals (company departments), each vertical/department has a team name & associated team code. Vertical **has many** Employees - relationship has been defined
 
 <img src="https://user-images.githubusercontent.com/35857179/161894091-6b6092c2-7184-4fe6-aa17-64ce5a7e97d5.png" width="70%"/>
 

--- a/packages/noco-docs/content/en/setup-and-usages/rollup.md
+++ b/packages/noco-docs/content/en/setup-and-usages/rollup.md
@@ -10,7 +10,7 @@ menuTitle: "Rollup"
 
 Sample simple Organization structure:
 
-- 5 verticals, each vertical has a team name & associated team code
+- 5 verticals (company departments), each vertical/department has a team name & associated team code
 - 5 employees working at different verticals
 - Vertical **has many** Employees : relationship has been defined
 


### PR DESCRIPTION
In the documentation for **Lookup** and **Rollup**,  the term "Vertical" is used to describe what in US english would be either a "Company department" or "role". The use of Vertical in this way not a common usage in US english. Especially considering the "Vertical Lookup" `VLOOKUP` feature available in common spreadsheets, this example is a bit confusing!

I'd wanted to actually *change* these, but *Vertical* is used in the images (in column names), so, it would be even MORE unclear if I didn't retain the term *Vertical*.

## Change Summary

Added phrasing to clarify "Vertical" is a term for "company department" when being introduced.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


## Additional information / screenshots (optional)

IMO, as a native US english speaker, I think should probably be changed to *Department* - that's the example I tend to see in documentation for other projects.

The relevant definition is [here](https://dictionary.cambridge.org/dictionary/english/vertical):

> HR
> used to [describe](https://dictionary.cambridge.org/dictionary/english/describe) the different ranks of managers  and workers in an organization:
> * The vertical [structures](https://dictionary.cambridge.org/dictionary/english/structure) of the past are less popular now that decision-making and innovation are encouraged at all operating levels.
> * If there are more than five levels of management, the organization is said to be high in vertical differentiation.