### PR TITLE
fix: cell saving

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/rowsXcDataTable.vue
@@ -1140,6 +1140,7 @@ export default {
           // return if there is no change
           if (
             !column ||
+            saving ||
             (oldRow[column.title] === rowObj[column.title] &&
               (lastSave || rowObj[column.title]) === rowObj[column.title])
           ) {

--- a/packages/nc-gui/components/project/spreadsheet/views/xcGridView.vue
+++ b/packages/nc-gui/components/project/spreadsheet/views/xcGridView.vue
@@ -245,7 +245,7 @@
               :is-locked="isLocked"
               :is-public="isPublicView"
               :view-id="viewId"
-              @save="editEnabled = {}"
+              @save="editEnabled = {}; onCellValueChange(col, row, columnObj, true);"
               @cancel="editEnabled = {}"
               @update="onCellValueChange(col, row, columnObj, false)"
               @blur="onCellValueChange(col, row, columnObj, true)"


### PR DESCRIPTION
## Change Summary

Ref #1813
- Binded onCellValueChange with save event of editable-cell (to cover firefox's enter save)
- Added saving check for cell editing (prevents multiple saving for chrome)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
