### PR TITLE
Use fastest-levensthein

### DIFF
--- a/packages/nc-gui/components/project/tableTabs/mocks.vue
+++ b/packages/nc-gui/components/project/tableTabs/mocks.vue
@@ -129,7 +129,7 @@
 import { mapGetters } from 'vuex'
 import fakerFunctionList from '../../../helpers/fakerFunctionList'
 import dataTypeMapping from '../../../helpers/findDataTypeMapping'
-const levenshtein = require('fast-levenshtein')
+const levenshtein = require('fastest-levenshtein')
 
 export default {
   components: {},
@@ -192,14 +192,14 @@ export default {
           if (nativeType !== 'string' && nativeType !== fakerFn.type) { return }
 
           if (i) {
-            const ls = levenshtein.get(col.column_name.toLowerCase(), fakerFn.name.toLowerCase())
+            const ls = levenshtein.distance(col.column_name.toLowerCase(), fakerFn.name.toLowerCase())
             if (lScore > ls) {
               lScore = ls
               suggestion = fakerFn
             }
           } else {
             suggestion = fakerFn
-            lScore = levenshtein.get(col.column_name.toLowerCase(), fakerFn.name.toLowerCase())
+            lScore = levenshtein.distance(col.column_name.toLowerCase(), fakerFn.name.toLowerCase())
           }
         })
 

--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -37,7 +37,7 @@
         "express-graphql": "^0.11.0",
         "express-status-monitor": "^1.3.3",
         "extract-zip": "^2.0.1",
-        "fast-levenshtein": "^2.0.6",
+        "fastest-levenshtein": "^1.0.12",
         "fs-extra": "^9.0.1",
         "glob": "^7.1.6",
         "graphql": "^15.3.0",
@@ -9776,6 +9776,11 @@
         "type": "paypal",
         "url": "https://paypal.me/naturalintelligence"
       }
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -32606,6 +32611,11 @@
       "requires": {
         "strnum": "^1.0.4"
       }
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "fastq": {
       "version": "1.13.0",

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -119,7 +119,7 @@
     "express-graphql": "^0.11.0",
     "express-status-monitor": "^1.3.3",
     "extract-zip": "^2.0.1",
-    "fast-levenshtein": "^2.0.6",
+    "fastest-levenshtein": "^1.0.12",
     "fs-extra": "^9.0.1",
     "glob": "^7.1.6",
     "graphql": "^15.3.0",


### PR DESCRIPTION
## Change Summary

`fast-levenshtein` uses `fastest-levenshtein` under the hood in the newest version (v3.0.0) offering much better performance (15x faster in some cases). Since `fast-levenshtein` is just a wrapper of `fastest-levenshtein`, this package should just use [`fastest-levenshtein`](https://github.com/ka-weihe/fastest-levenshtein) directly instead. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
