### PR TITLE
refactor: show LTAR column name instead of table name in Lookup/Rollup

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/lookupOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/lookupOptions.vue
@@ -18,9 +18,9 @@
             dense
           >
             <template #item="{item}">
-              <span class="caption"><span class="font-weight-bold"> {{
+              <span class="caption"><span class="font-weight-bold">{{ item.column.title }}</span> <small>({{ relationNames[item.col.type] }} {{
                 item.title || item.table_name
-              }}</span> <small>({{ relationNames[item.col.type] }})
+              }})
               </small></span>
             </template>
           </v-autocomplete>
@@ -74,6 +74,7 @@ export default {
         c.uidt === UITypes.LinkToAnotherRecord && !c.system
       ).map(c => ({
         col: c.colOptions,
+        column: c,
         ...this.tables.find(t => t.id === c.colOptions.fk_related_model_id)
       }))
 

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/rollupOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/rollupOptions.vue
@@ -18,9 +18,9 @@
             dense
           >
             <template #item="{item}">
-              <span class="caption"><span class="font-weight-bold"> {{
+              <span class="caption"><span class="font-weight-bold">{{ item.column.title }}</span> <small>({{ relationNames[item.col.type] }} {{
                 item.title || item.table_name
-              }}</span> <small>({{ relationNames[item.col.type] }})
+              }})
               </small></span>
             </template>
           </v-autocomplete>
@@ -98,6 +98,7 @@ export default {
         c.uidt === UITypes.LinkToAnotherRecord && c.colOptions.type !== 'bt' && !c.system
       ).map(c => ({
         col: c.colOptions,
+        column: c,
         ...this.tables.find(t => t.id === c.colOptions.fk_related_model_id)
       }))
 


### PR DESCRIPTION
Show LTAR column name instead of the table name in Lookup/Rollup column creation options.


<img width="207" alt="Screenshot 2022-04-26 at 12 10 35 PM" src="https://user-images.githubusercontent.com/61551451/165237678-d709c017-ae98-4df9-820b-d4fa157864ea.png">



re #1811 #1768