### PR TITLE
fix: using functions for DATEADD interval

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/pg.ts
@@ -35,17 +35,8 @@ const pg = {
   },
   DATEADD: ({ fn, knex, pt, colAlias }: MapFnArgs) => {
     return knex.raw(
-      `CASE
-      WHEN CAST(${fn(pt.arguments[0])} AS text) LIKE '%:%' THEN
-        ${fn(pt.arguments[0])} + INTERVAL '${fn(pt.arguments[1])} 
-        ${String(fn(pt.arguments[2])).replace(
-          /["']/g,
-          ''
-        )}'
-      ELSE
-        ${fn(pt.arguments[0])} + INTERVAL '${fn(pt.arguments[1])} 
-        ${String(fn(pt.arguments[2])).replace(/["']/g, '')}'
-      END${colAlias}`
+      `${fn(pt.arguments[0])} + (${fn(pt.arguments[1])} || 
+      '${String(fn(pt.arguments[2])).replace(/["']/g, '')}')::interval${colAlias}`
     );
   }
 };

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/sqlite.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/functionMappings/sqlite.ts
@@ -64,13 +64,13 @@ const sqlite3 = {
         STRFTIME('%Y-%m-%d %H:%M', DATETIME(DATETIME(${fn(
           pt.arguments[0]
         )}, 'localtime'), 
-        '${dateIN > 0 ? '+' : ''}${fn(pt.arguments[1])} ${String(fn(pt.arguments[2])).replace(
+        ${dateIN > 0 ? '+' : ''}${fn(pt.arguments[1])} || ' ${String(fn(pt.arguments[2])).replace(
         /["']/g,
         ''
       )}'))
       ELSE 
         DATE(DATETIME(${fn(pt.arguments[0])}, 'localtime'), 
-        '${dateIN > 0 ? '+' : ''}${fn(pt.arguments[1])} ${String(fn(pt.arguments[2])).replace(
+        ${dateIN > 0 ? '+' : ''}${fn(pt.arguments[1])} || ' ${String(fn(pt.arguments[2])).replace(
         /["']/g,
         ''
       )}')


### PR DESCRIPTION
## Change Summary

Re https://github.com/nocodb/nocodb/issues/1865
Allow using functions (max, min etc.) for DATEADD interval argument which wasn't working for postgreSQL and SQLite.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Notes
Dropped case part for pg as it is not used anymore.

