### PR TITLE
fix: use titles instead of table/column names on tooltips

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/virtualHeaderCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/virtualHeaderCell.vue
@@ -202,20 +202,20 @@ export default {
       return ''
     },
     childTable() {
-      if (this.relationMeta?.table_name) {
-        return this.relationMeta.table_name
+      if (this.relationMeta?.title) {
+        return this.relationMeta.title
       }
       return ''
     },
     parentTable() {
       if (this.rels.includes(this.type)) {
-        return this.meta.table_name
+        return this.meta.title
       }
       return ''
     },
     parentColumn() {
       if (this.rels.includes(this.type)) {
-        return this.column.column_name
+        return this.column.title
       }
       return ''
     },
@@ -230,11 +230,11 @@ export default {
       } else if (this.type === 'bt') {
         return `'${this.column.title}' belongs to '${this.childTable}'`
       } else if (this.type === 'lk') {
-        return `'${this.childColumn.column_name}' from '${this.childTable}' (${this.childColumn.uidt})`
+        return `'${this.childColumn.title}' from '${this.childTable}' (${this.childColumn.uidt})`
       } else if (this.type === 'formula') {
         return `Formula - ${this.column.colOptions.formula}`
       } else if (this.type === 'rl') {
-        return `'${this.childColumn.column_name}' of '${this.childTable}' (${this.childColumn.uidt})`
+        return `'${this.childColumn.title}' of '${this.childTable}' (${this.childColumn.uidt})`
       }
       return ''
     }


### PR DESCRIPTION
## Change Summary

Re #1880

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

![image](https://user-images.githubusercontent.com/59797957/165276122-82e117cf-21fb-4c0d-9afd-3019bad8b789.png)
