### PR TITLE
fix: pass correct project id to get model list

### DIFF
--- a/packages/nocodb/src/lib/noco/meta/api/swagger/helpers/getSwaggerColumnMetas.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/swagger/helpers/getSwaggerColumnMetas.ts
@@ -26,9 +26,11 @@ export default async (
             const colOpt = await c.getColOptions<LinkToAnotherRecordColumn>(
               ncMeta
             );
-            const relTable = await colOpt.getRelatedTable(ncMeta);
-            field.type = undefined;
-            field.$ref = `#/components/schemas/${relTable.title}Request`;
+            if (colOpt) {
+              const relTable = await colOpt.getRelatedTable(ncMeta);
+              field.type = undefined;
+              field.$ref = `#/components/schemas/${relTable.title}Request`;
+            }
           }
           break;
         case UITypes.Formula:

--- a/packages/nocodb/src/lib/noco/meta/api/swagger/swaggerApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/swagger/swaggerApis.ts
@@ -13,7 +13,7 @@ async function swaggerJson(req, res) {
   if (!project) NcError.notFound();
 
   const models = await Model.list({
-    project_id: req.params.project_id,
+    project_id: req.params.projectId,
     base_id: null
   });
 


### PR DESCRIPTION
Get models from current projects to populate swagger json which contains models and views from the current project.

re #1899