### PR TITLE
fix: monaco editor dialog closes on click

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/mixins/cell.js
+++ b/packages/nc-gui/components/project/spreadsheet/mixins/cell.js
@@ -45,7 +45,7 @@ export default {
       return this.abstractType === 'datetime' || this.uiDatatype === 'DateTime'
     },
     isJSON() {
-      return this.abstractType === 'json' || this.uiDatatype === 'JSON'
+      return this.uiDatatype === 'JSON'
     },
     isEnum() {
       return this.uiDatatype === 'SingleSelect'

--- a/packages/nc-gui/components/project/spreadsheet/views/xcGridView.vue
+++ b/packages/nc-gui/components/project/spreadsheet/views/xcGridView.vue
@@ -729,9 +729,12 @@ export default {
     },
     onClickOutside() {
       if (
-        this.meta.columns &&
+        (this.meta.columns &&
         this.meta.columns[this.selected.col] &&
-        this.meta.columns[this.selected.col].virtual
+        this.meta.columns[this.selected.col].virtual) ||
+        (this.availableColumns &&
+        this.availableColumns[this.editEnabled.col] &&
+        this.availableColumns[this.editEnabled.col].uidt === "JSON")
       ) {
         return;
       }


### PR DESCRIPTION
## Change Summary

Re #1932
Disables on outside click listener for monaco editor.
This way:
- the dialog doesn't close when you click inside
- keeps data when you minimize the dialog
- also makes it harder to accidentally close monaco editor while minimized (closed with proper buttons or selecting another cell)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
