### PR TITLE
fix: allow to edit the length of a nvarchar (mssql). #1930

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
@@ -337,7 +337,7 @@ export class MssqlUi {
         return '';
 
       case 'nvarchar':
-        return '';
+        return 255;
 
       case 'real':
         return '';
@@ -391,6 +391,9 @@ export class MssqlUi {
 
   static getDefaultLengthIsDisabled(type) {
     switch (type) {
+      case 'nvarchar':
+        return false;
+
       case 'bigint':
       case 'binary':
       case 'bit':


### PR DESCRIPTION
## Change Summary

Allow to set the length of nvarchar. (I tested with 'MAX' it works too). It allows to change the type from SingleLineText to MultiLineText in the UI for the mssql databases.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification


## Additional information / screenshots (optional)

Anything for maintainers to be made aware of

closes #1930 
