### PR TITLE
fix: Nested lookup

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSqlv2.ts
@@ -523,6 +523,7 @@ class BaseModelSqlv2 {
       model: childTable
     });
     const rtn = childTable.table_name;
+    const rtnId = childTable.id;
 
     const qb = this.dbDriver(rtn).join(vtn, `${vtn}.${vrcn}`, `${rtn}.${rcn}`);
 
@@ -551,7 +552,10 @@ class BaseModelSqlv2 {
 
     const children = await finalQb;
     const proto = await (
-      await Model.getBaseModelSQL({ table_name: rtn, dbDriver: this.dbDriver })
+      await Model.getBaseModelSQL({
+        id: rtnId,
+        dbDriver: this.dbDriver
+      })
     ).getProto();
     const gs = _.groupBy(
       children.map(c => {
@@ -582,6 +586,7 @@ class BaseModelSqlv2 {
       model: childTable
     });
     const rtn = childTable.table_name;
+    const rtnId = childTable.id;
 
     const qb = this.dbDriver(rtn)
       .join(vtn, `${vtn}.${vrcn}`, `${rtn}.${rcn}`)
@@ -600,7 +605,7 @@ class BaseModelSqlv2 {
 
     const children = await qb;
     const proto = await (
-      await Model.getBaseModelSQL({ table_name: rtn, dbDriver: this.dbDriver })
+      await Model.getBaseModelSQL({ id: rtnId, dbDriver: this.dbDriver })
     ).getProto();
 
     return children.map(c => {

--- a/packages/nocodb/src/lib/noco-models/Model.ts
+++ b/packages/nocodb/src/lib/noco-models/Model.ts
@@ -317,37 +317,13 @@ export default class Model implements TableType {
   public static async getBaseModelSQL(
     args: {
       id?: string;
-      table_name?: string;
       viewId?: string;
       dbDriver: XKnex;
       model?: Model;
     },
     ncMeta = Noco.ncMeta
   ): Promise<BaseModelSqlv2> {
-    const model =
-      args?.model ||
-      (await this.getByIdOrName(
-        {
-          id: args.id,
-          table_name: args.table_name
-        },
-        ncMeta
-      ));
-
-    // if (
-    //   this.baseModels?.[model.base_id]?.[model.db_alias]?.[args.table_name || args.id]
-    // ) {
-    //   return this.baseModels[model.base_id][model.db_alias][args.table_name || args.id];
-    // }
-    // this.baseModels[model.base_id] = this.baseModels[model.base_id] || {};
-    // this.baseModels[model.base_id][model.db_alias] =
-    //   this.baseModels[model.base_id][model.db_alias] || {};
-    // return (this.baseModels[model.base_id][model.db_alias][
-    //   args.table_name || args.id
-    // ] = new BaseModelSqlv2({
-    //   dbDriver: args.dbDriver,
-    //   model
-    // }));
+    const model = args?.model || (await this.get(args.id, ncMeta));
 
     return new BaseModelSqlv2({
       dbDriver: args.dbDriver,


### PR DESCRIPTION
Extract the model by `id` instead of `table_name` to avoid extracting the wrong model from the meta table.

re #1946



Verified by creating nested lookup `a => b => a`

<img width="979" alt="Screenshot 2022-05-02 at 11 18 14 PM" src="https://user-images.githubusercontent.com/61551451/166298911-33ed64e1-e22e-443c-9aaa-a0c8a0169f8c.png">
<img width="838" alt="Screenshot 2022-05-02 at 11 18 23 PM" src="https://user-images.githubusercontent.com/61551451/166298927-e92d954c-dc43-442b-8c7d-401334d05288.png">

