### PR TITLE
fix: Including all fields of nested record

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/helpers/getAst.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/helpers/getAst.ts
@@ -17,6 +17,8 @@ const getAst = async ({
   view?: View;
 }) => {
   if (!model.columns?.length) await model.getColumns();
+
+  // extract only pk and pv
   if (extractOnlyPrimaries) {
     return {
       ...(model.primaryKeys
@@ -71,7 +73,7 @@ const getAst = async ({
       value = await getAst({
         model,
         query: query?.nested,
-        extractOnlyPrimaries: true
+        extractOnlyPrimaries: nestedFields !== '*'
       });
     }
 


### PR DESCRIPTION
### Summary

If the nested `fields` value is specified as `*` extract all fields of the record(including nested).


 ### Sample response
![Screenshot 2022-05-06 at 11 34 44 AM](https://user-images.githubusercontent.com/61551451/167075976-8d9715a2-bc9c-4df5-9541-e69ff22abf13.png)

#### Paramter passed

```nested[CityList][fields]=*```