### PR TITLE
fix: single/multi select options at creation

### DIFF
--- a/packages/nocodb/src/lib/noco/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/columnApis.ts
@@ -493,7 +493,11 @@ export async function columnAdd(req: Request, res: Response<TableType>) {
         }> = (await sqlClient.columnList({ tn: table.table_name }))?.data?.list;
 
         const insertedColumnMeta =
-          columns.find(c => c.cn === colBody.column_name) || {};
+          columns.find(c => c.cn === colBody.column_name) || {} as any;
+
+        if (colBody.uidt === UITypes.SingleSelect || colBody.uidt === UITypes.MultiSelect) {
+          insertedColumnMeta.dtxp = colBody.dtxp;
+        }
 
         await Column.insert({
           ...colBody,


### PR DESCRIPTION
## Change Summary

Re #1955 
As options are handled from meta for databases beside MySQL the options should be appended to created column meta.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
