### PR TITLE
fix: webhook-related issues

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/moreActions.vue
@@ -104,7 +104,7 @@
       :parsed-csv="parsedCsv"
       @import="importData"
     />
-    <webhook-modal v-model="webhookModal" :meta="meta" />
+    <webhook-modal v-if="webhookModal" v-model="webhookModal" :meta="meta" />
   </div>
 </template>
 

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/BaseModelSqlv2.ts
@@ -1260,12 +1260,13 @@ class BaseModelSqlv2 {
 
   async delByPk(id, trx?, cookie?) {
     try {
+      // retrieve data for handling paramas in hook
+      const data = await this.readByPk(id);
       await this.beforeDelete(id, trx, cookie);
-
       const response = await this.dbDriver(this.tnPath)
         .del()
         .where(await this._wherePk(id));
-      await this.afterDelete(response, trx, cookie);
+      await this.afterDelete(data, trx, cookie);
       return response;
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
## Change Summary

- pass the correct `data` to `after.delete` webhook. ref: #2024 
- show the webhook listing page instead of empty detail page after reopening webhook from MoreAction

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/168000991-dd2ec3cf-2413-4dbc-92e2-425d4251270a.png)

![image](https://user-images.githubusercontent.com/35857179/168000759-61d5904c-4d25-466a-aa98-8b514cd9c429.png)