### PR TITLE
fix: add btw and nbtw filters

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/conditionV2.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/conditionV2.ts
@@ -284,6 +284,12 @@ const parseConditionV2 = async (
           case 'notnull':
             qb = qb.whereNotNull(customWhereClause || field);
             break;
+          case 'btw':
+            qb = qb.whereBetween(field, val.split(','));
+            break;
+          case 'nbtw':
+            qb = qb.whereNotBetween(field, val.split(','));
+            break;
         }
       };
     }

--- a/packages/nocodb/src/lib/noco-models/Filter.ts
+++ b/packages/nocodb/src/lib/noco-models/Filter.ts
@@ -37,7 +37,9 @@ export default class Filter {
     | 'le'
     | 'in'
     | 'isnot'
-    | 'is';
+    | 'is'
+    | 'btw'
+    | 'nbtw';
   value?: string;
 
   logical_op?: string;


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

The comparison operators `btw` and `nbtw` were not working in List API anymore. This PR is to fix it.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
