### PR TITLE
fix: issues related to formula

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -490,7 +490,7 @@ export default {
             case UITypes.PhoneNumber:
             case UITypes.Email:
             case UITypes.URL:
-              return 'string'
+              return formulaTypes.STRING
 
             // numeric
             case UITypes.Year:
@@ -499,14 +499,14 @@ export default {
             case UITypes.Rating:
             case UITypes.Count:
             case UITypes.AutoNumber:
-              return 'number'
+              return formulaTypes.NUMERIC
 
             // date
             case UITypes.Date:
             case UITypes.DateTime:
             case UITypes.CreateTime:
             case UITypes.LastModifiedTime:
-              return 'date'
+              return formulaTypes.DATE
 
             // not supported
             case UITypes.ForeignKey:
@@ -527,7 +527,7 @@ export default {
           }
         }
       } else if (parsedTree.type === jsep.BINARY_EXP || parsedTree.type === jsep.UNARY_EXP) {
-        return 'number'
+        return formulaTypes.NUMERIC
       } else if (parsedTree.type === jsep.LITERAL) {
         return typeof parsedTree.value
       } else {

--- a/packages/nocodb-sdk/src/lib/formulaHelpers.ts
+++ b/packages/nocodb-sdk/src/lib/formulaHelpers.ts
@@ -84,9 +84,6 @@ export function substituteColumnIdWithAliasInFormula(
           c.title === colNameOrId
       );
       pt.name = column?.title || ptRaw?.name || pt?.name;
-      if (pt.name[0] != '$' && pt.name[pt.name.length - 1] != '$') {
-        pt.name = '$' + pt.name + '$';
-      }
     } else if (pt.type === 'BinaryExpression') {
       substituteId(pt.left, ptRaw?.left);
       substituteId(pt.right, ptRaw?.right);

--- a/packages/nocodb/src/lib/dataMapper/lib/sql/formulav2/formulaQueryBuilderv2.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/formulav2/formulaQueryBuilderv2.ts
@@ -69,6 +69,7 @@ export default async function formulaQueryBuilderv2(
             model,
             { ...aliasToColumn, [col.id]: null }
           );
+          builder.sql = '(' + builder.sql + ')';
           aliasToColumn[col.id] = builder;
         }
         break;


### PR DESCRIPTION
## Change Summary

- fix incorrect data type - e.g. `ADD({numberic_formula}, 10)`.
- remove unexpected $pt.name$ - create a formula and edit it. `{$column_name$}` is shown rather than `{column_name}`.
- add ( ) to formula for precedence. ref to #2128 
  - formula1 = 1 + 1
  - formula2 = {formula1} * 5 = 1 + 1 * 5 (current behaviour) but expected to be (1 + 1) * 5

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
