### PR TITLE
fix: Support Airtable import even mapped to a different port

### DIFF
--- a/packages/noco-docs/content/en/getting-started/installation.md
+++ b/packages/noco-docs/content/en/getting-started/installation.md
@@ -207,6 +207,7 @@ By default, SQLite is used for storing meta data. However, you can specify your 
 | NC_DISABLE_ERR_REPORT              | No        | Disable error reporting                                                                                                 |                                                                                                |   |
 | NC_REDIS_URL                       | No        | Custom Redis URL. Example: `redis://:authpassword@127.0.0.1:6380/4`                                                     | Meta data will be stored in memory                                                             |   |
 | NC_DISABLE_CACHE                   | No        | To be used only while debugging. On setting this to `true` - meta data be fetched from db instead of redis/cache.           | `false`                                                                                    |   |
+| NC_BASEURL_INTERNAL                | No        | Used as base url for internal(server) API calls                                                                         | Default value in docker will be `http://localhost:$PORT` and in all other case it's populated from request object |   |
 
 ### AWS ECS (Fargate)
 

--- a/packages/nocodb/src/lib/noco/meta/api/sync/importApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/sync/importApis.ts
@@ -67,12 +67,23 @@ export default (router: Router, clients: { [id: string]: Socket }) => {
         Noco.getConfig().auth.jwt.options
       );
 
+      // Treat default baseUrl as siteUrl from req object
+      let baseURL = (req as any).ncSiteUrl;
+
+      // if environment value avail use it
+      // or if it's docker construct using `PORT`
+      if (process.env.NC_BASEURL_INTERNAL) {
+        baseURL = process.env.NC_BASEURL_INTERNAL;
+      } else if (process.env.NC_DOCKER) {
+        baseURL = `http://localhost:${process.env.PORT || 8080}`;
+      }
+
       NocoJobs.jobsMgr.add<AirtableSyncConfig>(AIRTABLE_IMPORT_JOB, {
         id: req.query.id,
         ...(syncSource?.details || {}),
         projectId: syncSource.project_id,
         authToken: token,
-        baseURL: (req as any).ncSiteUrl
+        baseURL
       });
       res.json({});
     })


### PR DESCRIPTION
## Change Summary

In the existing release it Airtable import will fail in docker if mapped to a port other than `8080`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

<img width="705" alt="Screenshot 2022-05-24 at 11 11 12 AM" src="https://user-images.githubusercontent.com/61551451/169957489-e4d09daf-0702-475b-9475-5cd2244ebaae.png">


re #2127

