### PR TITLE
enhancement: formula

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -568,14 +568,13 @@ export default {
       this.selected = 0
       this.suggestion = null
       const query = getWordUntilCaret(this.$refs.input.$el.querySelector('input'))
+      const parts = query.split(/\W+/)
+      this.wordToComplete = parts.pop()
+      this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
       // count number of opening curly brackets and closing curly brackets
       const cntCurlyBrackets = (this.$refs.input.$el.querySelector('input').value.match(/\{|}/g) || []).reduce((acc, cur) => (acc[cur] = (acc[cur] || 0) + 1, acc), {})
       if (Math.abs((cntCurlyBrackets['{'] || 0) - (cntCurlyBrackets['}'] || 0))) {
-        this.suggestion = this.suggestionsList.filter(v => v.type === 'column')
-      } else {
-        const parts = query.split(/\W+/)
-        this.wordToComplete = parts.pop()
-        this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
+        this.suggestion = this.suggestion.filter(v => v.type === 'column')
       }
       this.autocomplete = !!this.suggestion.length
     },

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -154,7 +154,6 @@ export default {
         })),
         ...this.meta.columns.filter(c => !this.column || this.column.id !== c.id).map(c => ({
           text: c.title,
-          uidt: c.uidt,
           type: 'column',
           icon: getUIDTIcon(c.uidt),
           c

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -545,13 +545,18 @@ export default {
         return 'N/A'
       }
     },
+    isCurlyBracketBalanced() {
+      // count number of opening curly brackets and closing curly brackets
+      const cntCurlyBrackets = (this.$refs.input.$el.querySelector('input').value.match(/\{|}/g) || []).reduce((acc, cur) => (acc[cur] = (acc[cur] || 0) + 1, acc), {})
+      return (cntCurlyBrackets['{'] || 0) === (cntCurlyBrackets['}'] || 0)
+    },
     appendText(it) {
       const text = it.text
       const len = this.wordToComplete.length
       if (it.type === 'function') {
         this.$set(this.formula, 'value', insertAtCursor(this.$refs.input.$el.querySelector('input'), text, len, 1))
       } else if (it.type === 'column') {
-        this.$set(this.formula, 'value', insertAtCursor(this.$refs.input.$el.querySelector('input'), '{' + text + '}', len))
+        this.$set(this.formula, 'value', insertAtCursor(this.$refs.input.$el.querySelector('input'), '{' + text + '}', len + (!this.isCurlyBracketBalanced())))
       } else {
         this.$set(this.formula, 'value', insertAtCursor(this.$refs.input.$el.querySelector('input'), text, len))
       }
@@ -571,9 +576,7 @@ export default {
       const parts = query.split(/\W+/)
       this.wordToComplete = parts.pop()
       this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
-      // count number of opening curly brackets and closing curly brackets
-      const cntCurlyBrackets = (this.$refs.input.$el.querySelector('input').value.match(/\{|}/g) || []).reduce((acc, cur) => (acc[cur] = (acc[cur] || 0) + 1, acc), {})
-      if (Math.abs((cntCurlyBrackets['{'] || 0) - (cntCurlyBrackets['}'] || 0))) {
+      if (this.isCurlyBracketBalanced()) {
         this.suggestion = this.suggestion.filter(v => v.type === 'column')
       }
       this.autocomplete = !!this.suggestion.length

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -568,9 +568,15 @@ export default {
       this.selected = 0
       this.suggestion = null
       const query = getWordUntilCaret(this.$refs.input.$el.querySelector('input'))
-      const parts = query.split(/\W+/)
-      this.wordToComplete = parts.pop()
-      this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
+      // count number of opening curly brackets and closing curly brackets
+      const cntCurlyBrackets = (this.$refs.input.$el.querySelector('input').value.match(/\{|}/g) || []).reduce((acc, cur) => (acc[cur] = (acc[cur] || 0) + 1, acc), {})
+      if (Math.abs((cntCurlyBrackets['{'] || 0) - (cntCurlyBrackets['}'] || 0))) {
+        this.suggestion = this.suggestionsList.filter(v => v.type === 'column')
+      } else {
+        const parts = query.split(/\W+/)
+        this.wordToComplete = parts.pop()
+        this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
+      }
       this.autocomplete = !!this.suggestion.length
     },
     selectText() {

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -43,6 +43,9 @@
                     <span
                       class="caption primary--text text--lighten-2 font-weight-bold"
                     >
+                      <v-icon color="primary lighten-2" small class="mr-1">
+                        mdi-function
+                      </v-icon>
                       {{ it.text }}
                     </span>
                   </v-list-item-content>
@@ -70,10 +73,12 @@
                 <span
                   class="caption text--darken-3 font-weight-bold"
                 >
+                  <v-icon color="grey darken-4" small class="mr-1">
+                    {{ it.icon }}
+                  </v-icon>
                   {{ it.text }}
                 </span>
               </v-list-item-content>
-
               <v-list-item-action>
                 <span class="caption">
                   Column
@@ -87,6 +92,9 @@
                 <span
                   class="caption indigo--text text--darken-3 font-weight-bold"
                 >
+                  <v-icon color="indigo darken-3" small class="mr-1">
+                    mdi-calculator-variant
+                  </v-icon>
                   {{ it.text }}
                 </span>
               </v-list-item-content>
@@ -109,6 +117,7 @@
 import debounce from 'debounce'
 import jsep from 'jsep'
 import { UITypes, jsepCurlyHook } from 'nocodb-sdk'
+import { getUIDTIcon } from '../../helpers/uiTypes'
 import formulaList, { formulas, formulaTypes } from '../../../../../helpers/formulaList'
 import { getWordUntilCaret, insertAtCursor } from '@/helpers'
 import NcAutocompleteTree from '@/helpers/NcAutocompleteTree'
@@ -145,7 +154,9 @@ export default {
         })),
         ...this.meta.columns.filter(c => !this.column || this.column.id !== c.id).map(c => ({
           text: c.title,
+          uidt: c.uidt,
           type: 'column',
+          icon: getUIDTIcon(c.uidt),
           c
         })),
         ...this.availableBinOps.map(op => ({

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/FormulaOptions.vue
@@ -576,7 +576,7 @@ export default {
       const parts = query.split(/\W+/)
       this.wordToComplete = parts.pop()
       this.suggestion = this.acTree.complete(this.wordToComplete)?.sort((x, y) => this.sortOrder[x.type] - this.sortOrder[y.type])
-      if (this.isCurlyBracketBalanced()) {
+      if (!this.isCurlyBracketBalanced()) {
         this.suggestion = this.suggestion.filter(v => v.type === 'column')
       }
       this.autocomplete = !!this.suggestion.length

--- a/packages/nc-gui/components/project/spreadsheet/helpers/uiTypes.js
+++ b/packages/nc-gui/components/project/spreadsheet/helpers/uiTypes.js
@@ -151,10 +151,20 @@ const uiTypes = [
 ]
 
 const getUIDTIcon = (uidt) => {
-  return ([...uiTypes, {
-    name: 'CreateTime',
-    icon: 'mdi-calendar-clock'
-  }].find(t => t.name === uidt) || {}).icon
+  return ([...uiTypes,
+    {
+      name: 'CreateTime',
+      icon: 'mdi-calendar-clock'
+    },
+    {
+      name: 'ID',
+      icon: 'mdi-identifier'
+    },
+    {
+      name: 'ForeignKey',
+      icon: 'mdi-link-variant'
+    }
+  ].find(t => t.name === uidt) || {}).icon
 }
 
 export {

--- a/packages/nocodb/src/lib/noco-models/Column.ts
+++ b/packages/nocodb/src/lib/noco-models/Column.ts
@@ -541,7 +541,7 @@ export default class Column<T = any> implements ColumnType {
             title: col?.title
           })
         )
-          await FormulaColumn.update(formula.id, formula, ncMeta);
+          await FormulaColumn.update(formulaCol.id, formula, ncMeta);
       }
     }
 

--- a/packages/nocodb/src/lib/noco/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/noco/meta/api/columnApis.ts
@@ -649,7 +649,7 @@ export async function columnUpdate(req: Request, res: Response<TableType>) {
                     formula,
                     [new_column]
                   );
-                  await FormulaColumn.update(f.id, {
+                  await FormulaColumn.update(c.id, {
                     formula_raw: new_formula_raw
                   });
                 }


### PR DESCRIPTION
## Change Summary

#### Handle NULL value when calling `CONCAT`

Previously any NULL value in formula with CONCAT would make the entire result empty. Now it's considered as an empty string instead. 

Example: F: `CONCAT({Title}, {Title1}, {Title2}, "B")`

![image](https://user-images.githubusercontent.com/35857179/170188444-ecf4077c-a704-41e6-8dd7-065c7ca3de17.png)

#### Include icons in formula suggestion list

![image](https://user-images.githubusercontent.com/35857179/170419828-30b9eac2-9b95-40a4-bcfc-d9c1cb6835c9.png) | ![image](https://user-images.githubusercontent.com/35857179/170419874-0f1308b9-f705-49b5-bd3e-bf982c6cab32.png)
|---|---|

#### Misc

- Show column options in suggestion list when users enter `{` as what's following must be a column.
- Fix the incorrect insertAtCursor position when calling appendText. Previously selecting `column1` after `{` would become `{{column1}` while `{column1}` is expected.
- Fix incorrect ID passing to `FormulaColumn.update`. Previously deleting a column that is referenced by a formula would throw an error and all data will be not shown when calling dataList as something wrong with the cache part as attribute `error` is not updated due to the wrong ID.  

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [x] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
