### PR TITLE
fix: alter_hooklog_payload_types

### DIFF
--- a/packages/nocodb/src/lib/noco/common/XcMigrationSourcev2.ts
+++ b/packages/nocodb/src/lib/noco/common/XcMigrationSourcev2.ts
@@ -3,6 +3,7 @@ import * as nc_012_alter_column_data_types from '../migrationsv2/nc_012_alter_co
 import * as nc_013_sync_source from '../migrationsv2/nc_013_sync_source';
 import * as nc_014_alter_column_data_types from '../migrationsv2/nc_014_alter_column_data_types';
 import * as nc_015_add_meta_col_in_column_table from '../migrationsv2/nc_015_add_meta_col_in_column_table';
+import * as nc_016_alter_hooklog_payload_types from '../migrationsv2/nc_016_alter_hooklog_payload_types';
 
 // Create a custom migration source class
 export default class XcMigrationSourcev2 {
@@ -16,7 +17,8 @@ export default class XcMigrationSourcev2 {
       'nc_012_alter_column_data_types',
       'nc_013_sync_source',
       'nc_014_alter_column_data_types',
-      'nc_015_add_meta_col_in_column_table'
+      'nc_015_add_meta_col_in_column_table',
+      'nc_016_alter_hooklog_payload_types'
     ]);
   }
 
@@ -36,6 +38,8 @@ export default class XcMigrationSourcev2 {
         return nc_014_alter_column_data_types;
       case 'nc_015_add_meta_col_in_column_table':
         return nc_015_add_meta_col_in_column_table;
+      case 'nc_016_alter_hooklog_payload_types':
+        return nc_016_alter_hooklog_payload_types;
     }
   }
 }

--- a/packages/nocodb/src/lib/noco/migrationsv2/nc_016_alter_hooklog_payload_types.ts
+++ b/packages/nocodb/src/lib/noco/migrationsv2/nc_016_alter_hooklog_payload_types.ts
@@ -1,0 +1,42 @@
+import Knex from 'knex';
+import { MetaTable } from '../../utils/globals';
+
+const up = async (knex: Knex) => {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable(MetaTable.HOOK_LOGS, table => {
+      table.text('payload').alter();
+    });
+  }
+};
+
+const down = async knex => {
+  if (knex.client.config.client !== 'sqlite3') {
+    await knex.schema.alterTable(MetaTable.HOOK_LOGS, table => {
+      table.boolean('payload').alter();
+    });
+  }
+};
+
+export { up, down };
+
+/**
+ * @copyright Copyright (c) 2022, Xgene Cloud Ltd
+ *
+ * @author Wing-Kam Wong <wingkwong.code@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/packages/nocodb/src/lib/noco/migrationsv2/nc_016_alter_hooklog_payload_types.ts
+++ b/packages/nocodb/src/lib/noco/migrationsv2/nc_016_alter_hooklog_payload_types.ts
@@ -22,7 +22,7 @@ export { up, down };
 /**
  * @copyright Copyright (c) 2022, Xgene Cloud Ltd
  *
- * @author Wing-Kam Wong <wingkwong.code@gmail.com>
+ * @author willnewii <willnewii@163.com>
  *
  * @license GNU AGPL version 3 or any later version
  *


### PR DESCRIPTION
## Change Summary

nc_hook_logs_v2.payload type is boolean. but in webHookHelpers.ts ,payload type it should be text. will be can't save hook log.

https://github.com/nocodb/nocodb/blob/4d423a383077d2c25fd9903856ba857abcd50800/packages/nocodb/src/lib/noco/meta/helpers/webhookHelpers.ts#L250

https://github.com/nocodb/nocodb/blob/4d423a383077d2c25fd9903856ba857abcd50800/packages/nocodb/src/lib/noco/meta/helpers/webhookHelpers.ts#L277

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

