### PR TITLE
fix: ignore timezone mysql and rely on project info for checking data…

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/DateTimePickerCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/DateTimePickerCell.vue
@@ -32,17 +32,19 @@ export default {
     value: [String, Date, Number], ignoreFocus: Boolean
   },
   computed: {
+    isMysql() {
+      return ['mysql', 'mysql2'].indexOf(this.$store.getters['project/GtrClientType'])
+    },
     localState: {
       get() {
         if (!this.value) {
           return this.value
         }
-
         return (/^\d+$/.test(this.value) ? dayjs(+this.value) : dayjs(this.value))
           .format('YYYY-MM-DD HH:mm')
       },
       set(value) {
-        if (this.$parent.sqlUi.name === 'MysqlUi') {
+        if (this.isMysql) {
           this.$emit('input', value && dayjs(value).format('YYYY-MM-DD HH:mm:ss'))
         } else {
           this.$emit('input', value && dayjs(value).format('YYYY-MM-DD HH:mm:ssZ'))

--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/TimePickerCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/TimePickerCell.vue
@@ -44,7 +44,6 @@ export default {
         return dateTime.format('HH:mm:ss')
       },
       set(val) {
-        console.log('=========', this.$parent)
         const dateTime = dayjs(`1999-01-01 ${val}:00`)
         if (dateTime.isValid()) {
           if (this.isMysql) {

--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/TimePickerCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/TimePickerCell.vue
@@ -15,6 +15,7 @@
 
 <script>
 import dayjs from 'dayjs'
+import { MysqlUi } from 'nocodb-sdk'
 
 export default {
   name: 'TimePickerCell',
@@ -22,6 +23,9 @@ export default {
     value: [String, Date]
   },
   computed: {
+    isMysql() {
+      return ['mysql', 'mysql2'].indexOf(this.$store.getters['project/GtrClientType'])
+    },
     localState: {
       get() {
         if (!this.value) {
@@ -40,8 +44,15 @@ export default {
         return dateTime.format('HH:mm:ss')
       },
       set(val) {
+        console.log('=========', this.$parent)
         const dateTime = dayjs(`1999-01-01 ${val}:00`)
-        if (dateTime.isValid()) { this.$emit('input', dateTime.format('YYYY-MM-DD HH:mm:ssZ')) }
+        if (dateTime.isValid()) {
+          if (this.isMysql) {
+            this.$emit('input', dateTime.format('YYYY-MM-DD HH:mm:ss'))
+          } else {
+            this.$emit('input', dateTime.format('YYYY-MM-DD HH:mm:ssZ'))
+          }
+        }
       }
 
     },

--- a/packages/nc-gui/store/project.js
+++ b/packages/nc-gui/store/project.js
@@ -200,6 +200,9 @@ export const getters = {
   GtrProjectPrefix(state) {
     return state.project && state.project.prefix
   },
+  GtrClientType(state) {
+    return state.project && state.project.bases && state.project.bases[0]&& state.project.bases[0].type
+  },
 
   GtrApiEnvironment(state) {
     const projJson = state.unserializedList && state.unserializedList[0] ? state.unserializedList[0].projectJson : null


### PR DESCRIPTION
## Change Summary

- Ignore timezone from DateTime string for Mysql & MariaDB
- Rely on project info for checking data source client type in UI

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


re #1048