### PR TITLE
fix: when_select_empty_importData_failed

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/MoreActions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/MoreActions.vue
@@ -311,6 +311,8 @@ export default {
                 }
               } else if (v.uidt === UITypes.Number) {
                 if (input == '') { input = null }
+              } else if (v.uidt === UITypes.SingleSelect || v.uidt === UITypes.MultiSelect) {
+                if (input == '') { input = null }
               }
               res[col.destCn] = input
             }


### PR DESCRIPTION
## Change Summary

when upload csv has SingleSelect or MultiSelect type，and value is empty，will be failed

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
