### PR TITLE
fix passing nested query in nested getAst calls

### DIFF
--- a/packages/nocodb/src/lib/dataMapper/lib/sql/helpers/getAst.ts
+++ b/packages/nocodb/src/lib/dataMapper/lib/sql/helpers/getAst.ts
@@ -72,7 +72,7 @@ const getAst = async ({
 
       value = await getAst({
         model,
-        query: query?.nested,
+        query: query?.nested?.[col.title],
         extractOnlyPrimaries: nestedFields !== '*'
       });
     }


### PR DESCRIPTION
Passing nested query to nested getAst calls was wrong if `fields=*`

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Before this fix the multi-nested query was not working correctly. If you wanted to pass something to a double nested record it was not working if you specified `?fields=*` because it would pass along `query.nested` instead of `query.nested.NestedRecord`

f.e.: `?fields=*&nested[NestedRecord][fields]=*&nested[NestedRecord][nested][DoubleNestedRecord][fields]=*` was not working correctly

It was passed correctly here already:
https://github.com/nocodb/nocodb/blob/c06f43c1cda71a140c83bc7473035746ec6bc154/packages/nocodb/src/lib/dataMapper/lib/sql/helpers/getAst.ts#L60

 but not in the else block: