### PR TITLE
docs: Repair broken link

### DIFF
--- a/packages/noco-docs/content/en/index.md
+++ b/packages/noco-docs/content/en/index.md
@@ -91,7 +91,7 @@ Please refer to [Development Setup](https://github.com/nocodb/nocodb#development
 
 ### Committing Changes
 
-We encourage all contributors to commit messages following [Commit Message Convention](./COMMIT_CONVENTION.md).
+We encourage all contributors to commit messages following [Commit Message Convention](https://github.com/nocodb/nocodb/blob/master/.github/COMMIT_CONVENTION.md).
 
 ### Applying License
 


### PR DESCRIPTION
## Change Summary

Repair broken link on 'Commit Message Convention' in[docs > introduction](https://docs.nocodb.com).

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

The link not works instead of going to error page.

## Additional information / screenshots (optional)

None
