### PR TITLE
fix: pg database type money

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/cell/CurrencyCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/cell/CurrencyCell.vue
@@ -13,8 +13,11 @@ export default {
   computed: {
     currency() {
       try {
-        return new Intl.NumberFormat(this.currencyMeta.currency_locale || 'en-US',
-          { style: 'currency', currency: this.currencyMeta.currency_code || 'USD' }).format(this.value)
+        return isNaN(this.value)
+          ? this.value
+          : new Intl.NumberFormat(this.currencyMeta.currency_locale || 'en-US',
+            { style: 'currency', currency: this.currencyMeta.currency_code || 'USD' })
+            .format(this.value)
       } catch (e) {
         return this.value
       }

--- a/packages/nc-gui/components/project/spreadsheet/components/editColumn/CurrencyOptions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editColumn/CurrencyOptions.vue
@@ -1,32 +1,39 @@
 <template>
-  <v-row class="currency-wrapper">
-    <v-col cols="6">
-      <!--label="Format Locale"-->
-      <v-autocomplete
-        v-model="colMeta.currency_locale"
-        dense
-        class="caption"
-        label="Currency Locale"
-        :rules="[isValidCurrencyLocale]"
-        :items="currencyLocaleList"
-        outlined
-        hide-details
-      />
-    </v-col>
-    <v-col cols="6">
-      <!--label="Currency Code"-->
-      <v-autocomplete
-        v-model="colMeta.currency_code"
-        dense
-        class="caption"
-        label="Currency Code"
-        :rules="[isValidCurrencyCode]"
-        :items="currencyList"
-        outlined
-        hide-details
-      />
-    </v-col>
-  </v-row>
+  <v-tooltip top :disabled="!(isMoney && isPG)">
+    <template #activator="{ on, attrs }">
+      <v-row class="currency-wrapper" v-bind="attrs" v-on="on">
+        <v-col cols="6">
+          <!--label="Format Locale"-->
+          <v-autocomplete
+            v-model="colMeta.currency_locale"
+            dense
+            class="caption"
+            label="Currency Locale"
+            :rules="[isValidCurrencyLocale]"
+            :items="currencyLocaleList"
+            outlined
+            hide-details
+            :disabled="isMoney && isPG"
+          />
+        </v-col>
+        <v-col cols="6">
+          <!--label="Currency Code"-->
+          <v-autocomplete
+            v-model="colMeta.currency_code"
+            dense
+            class="caption"
+            label="Currency Code"
+            :rules="[isValidCurrencyCode]"
+            :items="currencyList"
+            outlined
+            hide-details
+            :disabled="isMoney && isPG"
+          />
+        </v-col>
+      </v-row>
+    </template>
+    <span>{{ message }}</span>
+  </v-tooltip>
 </template>
 
 <script>
@@ -49,6 +56,20 @@ export default {
       return validateCurrencyCode(value) || 'Invalid Currency Code'
     }
   }),
+  computed: {
+    isMoney() {
+      return this.column.dt === 'money'
+    },
+    isPG() {
+      return ['pg'].includes(this.$store.getters['project/GtrClientType'])
+    },
+    message() {
+      if (this.isMoney && this.isPG) {
+        return "PostgreSQL 'money' type has own currency settings"
+      }
+      return ''
+    }
+  },
   watch: {
     value() {
       this.colMeta = this.value || {}


### PR DESCRIPTION
## Change Summary

Disabled currency options for columns using 'money' db type on PostgreSQL (it has own currency code/locale implementation but their community also suggest not using it https://wiki.postgresql.org/wiki/Don't_Do_This#Don.27t_use_money)
Re https://github.com/nocodb/nocodb/issues/2255

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

![image](https://user-images.githubusercontent.com/59797957/171990505-5281b212-b995-46f9-88ff-31cb41d3b62e.png)
![image](https://user-images.githubusercontent.com/59797957/171990525-0013a8e1-9953-4dd9-ae8e-2741b7e32b92.png)

