### PR TITLE
fix: missing logic in userInvite

### DIFF
--- a/packages/nocodb/src/lib/meta/api/projectUserApis.ts
+++ b/packages/nocodb/src/lib/meta/api/projectUserApis.ts
@@ -58,7 +58,7 @@ async function userInvite(req, res, next): Promise<any> {
       const projectUser = await ProjectUser.get(req.params.projectId, user.id);
       if (projectUser) {
         NcError.badRequest(
-          `${user.email} has been added to this project already`
+          `${user.email} with role ${projectUser.roles} already exists in this project`
         );
       }
 


### PR DESCRIPTION
## Change Summary

Invite and Edit user under User Management would trigger the same function `saveUser`. For the latter one, it would trigger `projectUserUpdate` while the other one would triggers `projectUserAdd`, which later calls `userInvite`. However, Add User To Project would also trigger the same as Invite. In current `userInvite` function, if the user exists, it would be updated and the cache will be changed also. And this logic should be only for the existing users who are not in the project.

Check if the target user is in the current project or not. If so, throw an error.

ref: #2301 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

User Exists + Already in the project

![image](https://user-images.githubusercontent.com/35857179/172833452-252e8d35-09fb-4ea6-aeb7-05a51fdf5ca3.png)

User Exists + Not in the project

![image](https://user-images.githubusercontent.com/35857179/172833496-7250f168-b939-49f7-aef0-675c111f97d3.png)

User Not Exists

![image](https://user-images.githubusercontent.com/35857179/172833778-a55d183e-2520-4e5e-9f2f-a6f02b564b08.png)
