### PR TITLE
fix: SingeSelect/MultiSelect webhook trigger

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/EditableCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/EditableCell.vue
@@ -86,6 +86,7 @@
       :is-form="isForm"
       :column="column"
       v-on="parentListeners"
+      @input="$emit('save')"
     />
 
     <json-editable-cell
@@ -197,9 +198,9 @@ export default {
         if (val !== this.value) {
           this.changed = true
           this.$emit('input', val)
-          if (this.isAttachment || this.isEnum || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime || this.isDate) {
+          if (this.isAttachment || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime || this.isDate) {
             this.syncData()
-          } else if (!this.isCurrency) {
+          } else if (!this.isCurrency && !this.isEnum) {
             this.syncDataDebounce(this)
           }
         }
@@ -228,7 +229,7 @@ export default {
     // this.$refs.input.focus();
   },
   beforeDestroy() {
-    if (this.changed && !(this.isAttachment || this.isEnum || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime)) {
+    if (this.changed && !(this.isAttachment || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime)) {
       this.changed = false
       this.$emit('change')
     }

--- a/packages/nc-gui/components/project/spreadsheet/components/EditableCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/EditableCell.vue
@@ -102,6 +102,7 @@
       v-model="localState"
       :column="column"
       v-on="parentListeners"
+      @input="$emit('save')"
     />
     <set-list-cell
       v-else-if="isSet"
@@ -198,9 +199,9 @@ export default {
         if (val !== this.value) {
           this.changed = true
           this.$emit('input', val)
-          if (this.isAttachment || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime || this.isDate) {
+          if (this.isAttachment || this.isBoolean || this.isRating || this.isTime || this.isDateTime || this.isDate) {
             this.syncData()
-          } else if (!this.isCurrency && !this.isEnum) {
+          } else if (!this.isCurrency && !this.isEnum && !this.isSet) {
             this.syncDataDebounce(this)
           }
         }
@@ -229,7 +230,7 @@ export default {
     // this.$refs.input.focus();
   },
   beforeDestroy() {
-    if (this.changed && !(this.isAttachment || this.isBoolean || this.isRating || this.isSet || this.isTime || this.isDateTime)) {
+    if (this.changed && !(this.isAttachment || this.isBoolean || this.isRating || this.isTime || this.isDateTime)) {
       this.changed = false
       this.$emit('change')
     }

--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/EnumListEditableCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/EnumListEditableCell.vue
@@ -54,7 +54,6 @@ export default {
       },
       set(val) {
         this.$emit('input', val)
-        this.$emit('update')
       }
     },
     enumValues() {

--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/SetListEditableCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/SetListEditableCell.vue
@@ -57,7 +57,6 @@ export default {
       },
       set(val) {
         this.$emit('input', val.filter(v => this.setValues.includes(v)).join(','))
-        this.$emit('update')
       }
     },
     setValues() {


### PR DESCRIPTION
## Change Summary

SingleSelect record change fires without `ignoreWebhook` query.
Extended fix for MultiSelect
Re #2277 

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

