### PR TITLE
fix: Make rating readonly in lookup column

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/RatingCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/RatingCell.vue
@@ -5,7 +5,7 @@
       :length="ratingMeta.max"
       dense
       x-small
-      :disabled="readOnly"
+      :readonly="readOnly"
       clearable
     >
       <template #item="{isFilled, click}">


### PR DESCRIPTION
## Change Summary

Make rating read-only if referred in a lookup cell.

ref: #2045 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


![Screenshot 2022-06-13 at 2 04 42 PM](https://user-images.githubusercontent.com/61551451/173313665-c1329ee4-bd45-4424-9e35-5d738bf7bc99.png)