### PR TITLE
Fix: Exclude sensitive data related to server from SMTP test api

### DIFF
--- a/packages/nocodb/src/lib/plugins/smtp/SMTP.ts
+++ b/packages/nocodb/src/lib/plugins/smtp/SMTP.ts
@@ -47,7 +47,10 @@ export default class SMTP implements IEmailAdapter {
       } as any);
       return true;
     } catch (e) {
-      throw e;
+      console.log('SMTP test error :: ', e);
+      throw new Error(
+        'SMTP test failed, please check server log for more details.'
+      );
     }
   }
 }


### PR DESCRIPTION
## Change Summary

Exclude sensitive data related to the server from the SMTP test API by avoiding sending the error messages.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

![Screenshot 2022-06-13 at 3 58 19 PM](https://user-images.githubusercontent.com/61551451/173334557-00e48ae5-5fbd-4bd5-bc9d-cbf8062a606d.png)




