### PR TITLE
Fix: Reload related table metadata after relation column delete

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/VirtualHeaderCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/VirtualHeaderCell.vue
@@ -252,6 +252,11 @@ export default {
     async deleteColumn() {
       try {
         await this.$api.dbTableColumn.delete(this.column.id)
+
+        if (this.column.uidt === UITypes.LinkToAnotherRecord && this.column.colOptions) {
+          this.$store.dispatch('meta/ActLoadMeta', { force: true, id: this.column.colOptions.fk_related_model_id }).then(() => {})
+        }
+
         this.$emit('saved')
         this.columnDeleteDialog = false
       } catch (e) {


### PR DESCRIPTION
## Change Summary

Reload metadata of related metadata on LinkToAnotherRecord column delete.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification


https://user-images.githubusercontent.com/61551451/173379978-91c40975-eafc-4aaf-85e8-f4ea0c50f0be.mov


