### PR TITLE
Fix: Save datetime on  'click:outside' event

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/components/editableCell/DateTimePickerCell.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/editableCell/DateTimePickerCell.vue
@@ -65,6 +65,13 @@ export default {
     }
   },
   mounted() {
+    // listen dialog click:outside event and save on close
+    if (this.$refs.picker && this.$refs.picker.$children && this.$refs.picker.$children[0]) {
+      this.$refs.picker.$children[0].$on('click:outside', () => {
+        this.$refs.picker.okHandler()
+      })
+    }
+
     if (!this.ignoreFocus) {
       this.$refs.picker.display = true
     }


### PR DESCRIPTION
## Change Summary

Save/Update datetime picker value even if user clicked outside.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


re #2354 