### PR TITLE
fix: exclude date1904 fix from csv quick import

### DIFF
--- a/packages/nc-gui/components/import/templateParsers/ExcelTemplateAdapter.js
+++ b/packages/nc-gui/components/import/templateParsers/ExcelTemplateAdapter.js
@@ -46,25 +46,27 @@ export default class ExcelTemplateAdapter extends TemplateGenerator {
       this.data[tn] = []
       const ws = this.wb.Sheets[sheet]
       const range = XLSX.utils.decode_range(ws['!ref'])
-      const originalRows = XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false, cellDates: true, defval: null })
+      const rows = XLSX.utils.sheet_to_json(ws, { header: 1, blankrows: false, cellDates: true, defval: null })
 
-      // fix precision bug & timezone offset issues introduced by xlsx
-      const basedate = new Date(1899, 11, 30, 0, 0, 0)
-      // number of milliseconds since base date
-      const dnthresh = basedate.getTime() + (new Date().getTimezoneOffset() - basedate.getTimezoneOffset()) * 60000
-      // number of milliseconds in a day
-      const day_ms = 24 * 60 * 60 * 1000
-      // handle date1904 property
-      const fixImportedDate = (date) => {
-        const parsed = XLSX.SSF.parse_date_code((date.getTime() - dnthresh) / day_ms, {
-          date1904: this.wb.Workbook.WBProps.date1904
-        })
-        return new Date(parsed.y, parsed.m, parsed.d, parsed.H, parsed.M, parsed.S)
+      if (this.name.slice(-3) !== 'csv') {
+        // fix precision bug & timezone offset issues introduced by xlsx
+        const basedate = new Date(1899, 11, 30, 0, 0, 0)
+        // number of milliseconds since base date
+        const dnthresh = basedate.getTime() + (new Date().getTimezoneOffset() - basedate.getTimezoneOffset()) * 60000
+        // number of milliseconds in a day
+        const day_ms = 24 * 60 * 60 * 1000
+        // handle date1904 property
+        const fixImportedDate = (date) => {
+          const parsed = XLSX.SSF.parse_date_code((date.getTime() - dnthresh) / day_ms, {
+            date1904: this.wb.Workbook.WBProps.date1904
+          })
+          return new Date(parsed.y, parsed.m, parsed.d, parsed.H, parsed.M, parsed.S)
+        }
+        // fix imported date
+        rows = rows.map(r => r.map((v) => {
+          return v instanceof Date ? fixImportedDate(v) : v
+        }))
       }
-      // fix imported date
-      const rows = originalRows.map(r => r.map((v) => {
-        return v instanceof Date ? fixImportedDate(v) : v
-      }))
 
       const columnNameRowExist = +rows[0].every(v => v === null || typeof v === 'string')
 


### PR DESCRIPTION
## Change Summary

date1904 fix was done previously for fixing precision bug & timezone offset issues introduced by xlsx, while CSV shouldn't be applicable.

ref: #2334 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Using reporter's CSV

![image](https://user-images.githubusercontent.com/35857179/173532831-6d81a5a3-9824-4c6a-a36b-5d7a01898bc9.png)
