### PR TITLE
fix: delete project:<uuid> in cache for disable shared base

### DIFF
--- a/packages/nocodb/src/lib/models/Project.ts
+++ b/packages/nocodb/src/lib/models/Project.ts
@@ -237,12 +237,17 @@ export default class Project implements ProjectType {
     let o = await NocoCache.get(key, CacheGetType.TYPE_OBJECT);
     if (o) {
       // update data
+      // new uuid is generated
       if (o.uuid && updateObj.uuid && o.uuid !== updateObj.uuid) {
         await NocoCache.del(`${CacheScope.PROJECT}:${o.uuid}`);
         await NocoCache.set(
           `${CacheScope.PROJECT}:${updateObj.uuid}`,
           projectId
         );
+      }
+      // disable shared base
+      if (o.uuid && updateObj.uuid === null) {
+        await NocoCache.del(`${CacheScope.PROJECT}:${o.uuid}`);
       }
       if (o.title && updateObj.title && o.title !== updateObj.title) {
         await NocoCache.del(`${CacheScope.PROJECT}:${o.title}`);


### PR DESCRIPTION
## Change Summary

disable shared base -> leftover cache makes the old link still accessible.

ref: #2358

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)