### PR TITLE
Fix: Include `token_version` value in jwt payload

### DIFF
--- a/packages/nocodb/src/lib/meta/api/sync/importApis.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/importApis.ts
@@ -7,7 +7,7 @@ import NocoJobs from '../../../jobs/NocoJobs';
 import job, { AirtableSyncConfig } from './helpers/job';
 import SyncSource from '../../../models/SyncSource';
 import Noco from '../../../Noco';
-import * as jwt from 'jsonwebtoken';
+import { genJwt } from '../userApi/helpers';
 const AIRTABLE_IMPORT_JOB = 'AIRTABLE_IMPORT_JOB';
 const AIRTABLE_PROGRESS_JOB = 'AIRTABLE_PROGRESS_JOB';
 
@@ -76,18 +76,7 @@ export default (router: Router, clients: { [id: string]: Socket }) => {
       const syncSource = await SyncSource.get(req.params.syncId);
 
       const user = await syncSource.getUser();
-      const token = jwt.sign(
-        {
-          email: user.email,
-          firstname: user.firstname,
-          lastname: user.lastname,
-          id: user.id,
-          roles: user.roles
-        },
-
-        Noco.getConfig().auth.jwt.secret,
-        Noco.getConfig().auth.jwt.options
-      );
+      const token = genJwt(user, Noco.getConfig());
 
       // Treat default baseUrl as siteUrl from req object
       let baseURL = (req as any).ncSiteUrl;

--- a/packages/nocodb/src/lib/meta/api/userApi/helpers.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/helpers.ts
@@ -1,0 +1,18 @@
+import * as jwt from 'jsonwebtoken';
+import User from '../../../models/User';
+import { NcConfig } from '../../../../interface/config';
+
+export function genJwt(user: User, config: NcConfig) {
+  return jwt.sign(
+    {
+      email: user.email,
+      firstname: user.firstname,
+      lastname: user.lastname,
+      id: user.id,
+      roles: user.roles,
+      token_version: user.token_version
+    },
+    config.auth.jwt.secret,
+    config.auth.jwt.options
+  );
+}

--- a/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
@@ -10,7 +10,6 @@ import User from '../../../models/User';
 import { Tele } from 'nc-help';
 
 const { v4: uuidv4 } = require('uuid');
-import * as jwt from 'jsonwebtoken';
 import Audit from '../../../models/Audit';
 import crypto from 'crypto';
 import NcPluginMgrv2 from '../../helpers/NcPluginMgrv2';
@@ -20,6 +19,7 @@ import extractProjectIdAndAuthenticate from '../../helpers/extractProjectIdAndAu
 import ncMetaAclMw from '../../helpers/ncMetaAclMw';
 import { MetaTable } from '../../../utils/globals';
 import Noco from '../../../Noco';
+import { genJwt } from './helpers';
 
 export async function signup(req: Request, res: Response<TableType>) {
   const {
@@ -147,18 +147,7 @@ export async function signup(req: Request, res: Response<TableType>) {
   });
 
   res.json({
-    token: jwt.sign(
-      {
-        email: user.email,
-        firstname: user.firstname,
-        lastname: user.lastname,
-        id: user.id,
-        roles: user.roles,
-        token_version: user.token_version
-      },
-      Noco.getConfig().auth.jwt.secret,
-      Noco.getConfig().auth.jwt.options
-    )
+    token: genJwt(user, Noco.getConfig())
   } as any);
 }
 
@@ -205,19 +194,7 @@ async function successfulSignIn({
     });
 
     res.json({
-      token: jwt.sign(
-        {
-          email: user.email,
-          firstname: user.firstname,
-          lastname: user.lastname,
-          id: user.id,
-          roles: user.roles,
-          token_version
-        },
-
-        Noco.getConfig().auth.jwt.secret,
-        Noco.getConfig().auth.jwt.options
-      )
+      token: genJwt(user, Noco.getConfig())
     } as any);
   } catch (e) {
     console.log(e);
@@ -477,17 +454,7 @@ async function refreshToken(req, res): Promise<any> {
     setTokenCookie(res, refreshToken);
 
     res.json({
-      token: jwt.sign(
-        {
-          email: user.email,
-          firstname: user.firstname,
-          lastname: user.lastname,
-          id: user.id,
-          roles: user.roles
-        },
-        Noco.getConfig().auth.jwt.secret,
-        Noco.getConfig().auth.jwt.options
-      )
+      token: genJwt(user, Noco.getConfig())
     } as any);
   } catch (e) {
     return res.status(400).json({ msg: e.message });


### PR DESCRIPTION


## Change Summary

- Include `token_version` value in jwt payload
- Use a generic function to populate jwt token to avoid repetition

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


re #2361

