### PR TITLE
fix: sync duplicate column_name after sanitize

### DIFF
--- a/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
@@ -211,14 +211,15 @@ export default async (
     const col_alias = name.trim().replace(/\./g, '_');
 
     // check if already a column exists with same name?
-    const duplicateColumn = table.columns.find(x => x.title === col_alias);
-    if (duplicateColumn) {
-      if (enableErrorLogs) console.log(`## Duplicate ${col_alias}`);
+    const duplicateTitle = table.columns.find(x => x.title?.toLowerCase() === col_alias?.toLowerCase());
+    const duplicateColumn = table.columns.find(x => x.column_name?.toLowerCase() === col_name?.toLowerCase());
+    if (duplicateTitle) {
+      if (enableErrorLogs) console.log(`## Duplicate title ${col_alias}`);
     }
 
     return {
       // kludge: error observed in Nc with space around column-name
-      title: col_alias + (duplicateColumn ? '_2' : ''),
+      title: col_alias + (duplicateTitle ? '_2' : ''),
       column_name: col_name + (duplicateColumn ? '_2' : '')
     };
   }


### PR DESCRIPTION
## Change Summary

ID*, id? on remote was causing `Duplicate column name 'ID_'`
Added check for column name.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

