### PR TITLE
Fix: invalidate token if admin email or password changed

### DIFF
--- a/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
@@ -5,10 +5,11 @@ import { Tele } from 'nc-help';
 
 import bcrypt from 'bcryptjs';
 import Noco from '../../../Noco';
-import { MetaTable } from '../../../utils/globals';
+import { CacheScope, MetaTable } from '../../../utils/globals';
 import ProjectUser from '../../../models/ProjectUser';
 import { validatePassword } from 'nocodb-sdk';
 import boxen from 'boxen';
+import NocoCache from '../../../cache/NocoCache';
 
 const { isEmail } = require('validator');
 const rolesLevel = { owner: 0, creator: 1, editor: 2, commenter: 3, viewer: 4 };
@@ -160,6 +161,21 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
               null,
               MetaTable.USERS,
               existingUserWithNewEmail.id
+            );
+
+            // clear cache
+            await NocoCache.delAll(
+              CacheScope.USER,
+              `${existingUserWithNewEmail.email}___*`
+            );
+            await NocoCache.del(
+              `${CacheScope.USER}:${existingUserWithNewEmail.id}`
+            );
+            await NocoCache.del(
+              `${CacheScope.USER}:${existingUserWithNewEmail.email}`
+            );
+            await NocoCache.del(
+              `${CacheScope.USER}:${existingUserWithNewEmail.email}`
             );
 
             // Update email and password of super admin account

--- a/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
@@ -191,7 +191,7 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
         } else {
           const newPasswordHash = await promisify(bcrypt.hash)(
             process.env.NC_ADMIN_PASSWORD,
-            superUser.hash
+            superUser.salt
           );
 
           if (newPasswordHash !== superUser.password) {

--- a/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
@@ -103,7 +103,7 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
           // check user account already present with the new admin email
           const existingUserWithNewEmail = await User.getByEmail(email, ncMeta);
 
-          if (existingUserWithNewEmail) {
+          if (existingUserWithNewEmail?.id) {
             // get all project access belongs to the existing account
             // and migrate to the admin account
             const existingUserProjects = await ncMeta.metaList2(
@@ -155,7 +155,7 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
             }
 
             // delete existing user
-            ncMeta.metaDelete(
+            await ncMeta.metaDelete(
               null,
               null,
               MetaTable.USERS,

--- a/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
@@ -170,7 +170,8 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
                 email,
                 password,
                 email_verification_token,
-                token_version: null
+                token_version: null,
+                refresh_token: null
               },
               ncMeta
             );
@@ -183,7 +184,8 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
                 email,
                 password,
                 email_verification_token,
-                token_version: null
+                token_version: null,
+                refresh_token: null
               },
               ncMeta
             );
@@ -203,7 +205,8 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
                 salt,
                 password,
                 email_verification_token,
-                token_version: null
+                token_version: null,
+                refresh_token: null
               },
               ncMeta
             );

--- a/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initAdminFromEnv.ts
@@ -174,10 +174,7 @@ export default async function initAdminFromEnv(_ncMeta = Noco.ncMeta) {
             await NocoCache.del(
               `${CacheScope.USER}:${existingUserWithNewEmail.email}`
             );
-            await NocoCache.del(
-              `${CacheScope.USER}:${existingUserWithNewEmail.email}`
-            );
-
+            
             // Update email and password of super admin account
             await User.update(
               superUser.id,

--- a/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
@@ -103,8 +103,8 @@ export function initStrategies(router): void {
 
         if (cachedVal) {
           if (
-            cachedVal.token_version &&
-            jwtPayload.token_version &&
+            !cachedVal.token_version ||
+            !jwtPayload.token_version ||
             cachedVal.token_version !== jwtPayload.token_version
           ) {
             return done(new Error('Token Expired. Please login again.'));
@@ -115,8 +115,8 @@ export function initStrategies(router): void {
         User.getByEmail(jwtPayload?.email)
           .then(async user => {
             if (
-              user.token_version &&
-              jwtPayload.token_version &&
+              !user.token_version ||
+              !jwtPayload.token_version ||
               user.token_version !== jwtPayload.token_version
             ) {
               return done(new Error('Token Expired. Please login again.'));

--- a/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
@@ -179,15 +179,14 @@ async function successfulSignIn({
     await promisify((req as any).login.bind(req))(user);
     const refreshToken = randomTokenString();
 
-    let token_version = user.token_version;
-    if (!token_version) {
-      token_version = randomTokenString();
+    if (!user.token_version) {
+      user.token_version = randomTokenString();
     }
 
     await User.update(user.id, {
       refresh_token: refreshToken,
       email: user.email,
-      token_version
+      token_version: user.token_version
     });
     setTokenCookie(res, refreshToken);
 

--- a/packages/nocodb/src/lib/models/User.ts
+++ b/packages/nocodb/src/lib/models/User.ts
@@ -84,6 +84,9 @@ export default class User implements UserType {
 
     if (updateObj.email) {
       updateObj.email = updateObj.email.toLowerCase();
+    } else {
+      // set email prop to avoid generation of invalid cache key
+      updateObj.email = (await this.get(id, ncMeta))?.email?.toLowerCase();
     }
     // get existing cache
     const keys = [


### PR DESCRIPTION
## Change Summary

On admin environment variables update ( `NC_ADMIN_EMAIL` and `NC_ADMIN_PASSWORD` )

- Invalidate old token if admin email changed in env
- Invalidate token if password updated in env
- Avoid unnecessary updates if both email and passwords are the same


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


## Scenarios to be tested

| Project type | Test environment | Expected behavior | Status |
|------|-----|-----|---|
| Existing | Updated `NC_ADMIN_EMAIL` with a non-existing users email | Old super admin tokens should be invalid | __Verified__ (@mertmit) |
| Existing | Updated `NC_ADMIN_EMAIL` with an existing users email | Old tokens of both super and another user(deleted) should be invalid | __Not tested__ |
| Existing | Updated `NC_ADMIN_PASSWORD` | Old super admin tokens should be invalid  | __Verified__ (@mertmit) |
| Existing | Updated `NC_ADMIN_PASSWORD` and `NC_ADMIN_EMAIL` | Old super admin tokens should be invalid  | __Verified__ (@mertmit) |
| Existing | Updated nothing | Old super admin tokens should be valid  | __Verified__ (@mertmit) |


