### PR TITLE
fix: expired jwt token still usable

### DIFF
--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -187,7 +187,7 @@ export default class Noco {
     }
 
     await Noco._ncMeta.metaInit();
-    await this.readOrGenJwtSecret();
+    await this.initJwt();
     await initAdminFromEnv();
 
     await NcUpgrader.upgrade({ ncMeta: Noco._ncMeta });
@@ -489,20 +489,28 @@ export default class Noco {
     }
   }
 
-  private async readOrGenJwtSecret(): Promise<any> {
-    if (this.config?.auth?.jwt && !this.config.auth.jwt.secret) {
-      let secret = (
-        await Noco._ncMeta.metaGet('', '', 'nc_store', {
-          key: 'nc_auth_jwt_secret'
-        })
-      )?.value;
-      if (!secret) {
-        await Noco._ncMeta.metaInsert('', '', 'nc_store', {
-          key: 'nc_auth_jwt_secret',
-          value: secret = uuidv4()
-        });
+  private async initJwt(): Promise<any> {
+    if (this.config?.auth?.jwt) {
+      if (!this.config.auth.jwt.secret) {
+        let secret = (
+          await Noco._ncMeta.metaGet('', '', 'nc_store', {
+            key: 'nc_auth_jwt_secret'
+          })
+        )?.value;
+        if (!secret) {
+          await Noco._ncMeta.metaInsert('', '', 'nc_store', {
+            key: 'nc_auth_jwt_secret',
+            value: secret = uuidv4()
+          });
+        }
+        this.config.auth.jwt.secret = secret;
       }
-      this.config.auth.jwt.secret = secret;
+
+      this.config.auth.jwt.options = this.config.auth.jwt.options || {};
+      if (!this.config.auth.jwt.options?.expiresIn) {
+        this.config.auth.jwt.options.expiresIn =
+          process.env.NC_JWT_EXPIRES_IN ?? '10h';
+      }
     }
     let serverId = (
       await Noco._ncMeta.metaGet('', '', 'nc_store', {

--- a/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
@@ -2,18 +2,17 @@ import User from '../../../models/User';
 import ProjectUser from '../../../models/ProjectUser';
 import { promisify } from 'util';
 import { Strategy as CustomStrategy } from 'passport-custom';
-
-import { Strategy } from 'passport-jwt';
 import passport from 'passport';
-import { ExtractJwt } from 'passport-jwt';
+import passportJWT from 'passport-jwt';
 import { Strategy as AuthTokenStrategy } from 'passport-auth-token';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { randomTokenString } from '../../helpers/stringHelpers';
 
 const PassportLocalStrategy = require('passport-local').Strategy;
+const ExtractJwt = passportJWT.ExtractJwt;
+const JwtStrategy = passportJWT.Strategy;
 
 const jwtOptions = {
-  expiresIn: process.env.NC_JWT_EXPIRES_IN ?? '10h',
   jwtFromRequest: ExtractJwt.fromHeader('xc-auth')
 };
 
@@ -84,7 +83,7 @@ export function initStrategies(router): void {
   });
 
   passport.use(
-    new Strategy(
+    new JwtStrategy(
       {
         secretOrKey: Noco.getConfig().auth.jwt.secret,
         ...jwtOptions,


### PR DESCRIPTION
## Change Summary

- Use JwtStrategy to check `expiresIn` (ref: #2422)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Setting `NC_JWT_EXPIRES_IN=60000` for testing, i.e 60 seconds. (By default, it's `10h`.)

1. Frontend - no action for 60 seconds - then refresh the page

![image](https://user-images.githubusercontent.com/35857179/174423709-37ebf70f-f82d-4d50-8465-fc6e7460047e.png)

2. API - run curl command retrieved from Get API Snippet -  no action for 60 seconds - run it again

<img width="320" alt="image" src="https://user-images.githubusercontent.com/35857179/174423735-82d16222-b043-4f02-a5d3-43979548e174.png">

