### PR TITLE
fix: use default view if no view is specified

### DIFF
--- a/packages/nocodb/src/lib/meta/api/dataApis/dataAliasExportApis.ts
+++ b/packages/nocodb/src/lib/meta/api/dataApis/dataAliasExportApis.ts
@@ -5,18 +5,22 @@ import {
   getViewAndModelFromRequestByAliasOrId
 } from './helpers';
 import apiMetrics from '../../helpers/apiMetrics';
+import View from '../../../models/View';
 
 async function csvDataExport(req: Request, res: Response) {
-  const { view } = await getViewAndModelFromRequestByAliasOrId(req);
-
-  const { offset, elapsed, data } = await extractCsvData(view, req);
+  const { model, view } = await getViewAndModelFromRequestByAliasOrId(req);
+  let targetView = view;
+  if (!targetView) {
+    targetView = await View.getDefaultView(model.id);
+  }
+  const { offset, elapsed, data } = await extractCsvData(targetView, req);
 
   res.set({
     'Access-Control-Expose-Headers': 'nc-export-offset',
     'nc-export-offset': offset,
     'nc-export-elapsed-time': elapsed,
     'Content-Disposition': `attachment; filename="${encodeURI(
-      view.title
+      targetView.title
     )}-export.csv"`
   });
   res.send(data);


### PR DESCRIPTION
## Change Summary

- No view will be given for existing export csv api. This PR is to feed the default view for export. ?
  (ref: #2395)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/174721374-6945857e-9772-4c63-9d50-45960947efff.png)

