### PR TITLE
fix nested field projection

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/helpers/getAst.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/helpers/getAst.ts
@@ -86,7 +86,7 @@ const getAst = async ({
             (!fields?.length || fields.includes(col.title)) &&
             value
           : fields?.length
-          ? fields.includes(col.title)
+          ? fields.includes(col.title) && value
           : value
     };
   }, Promise.resolve({}));


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

In the data list API Field projection is not working for nested columns if the 'fields' query parameter set

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

In the list API, if you provide `fields` and `nested[relatedTable][fields]` both, nested projection does not get applied.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
