### PR TITLE
add support to not in filters

### DIFF
--- a/packages/noco-docs/content/en/developer-resources/rest-apis.md
+++ b/packages/noco-docs/content/en/developer-resources/rest-apis.md
@@ -193,7 +193,8 @@ Currently, the default value for {orgs} is <b>noco</b>. Users will be able to ch
 | Operation | Meaning | Example |
 |---|---|---|
 | eq | equal | (colName,eq,colValue) |
-| not | not equal | (colName,not,colValue) |
+| neq | not equal | (colName,neq,colValue) |
+| not | not equal (alias of neq) | (colName,not,colValue) |
 | gt | greater than | (colName,gt,colValue) |
 | ge | greater or equal | (colName,ge,colValue) |
 | lt | less than | (colName,lt,colValue) |

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
@@ -216,6 +216,7 @@ const parseConditionV2 = async (
             qb = qb.where(field, val);
             break;
           case 'neq':
+          case 'not':
             qb = qb.whereNot(field, val);
             break;
           case 'like':

--- a/packages/nocodb/src/lib/models/Filter.ts
+++ b/packages/nocodb/src/lib/models/Filter.ts
@@ -23,6 +23,7 @@ export default class Filter {
   comparison_op?:
     | 'eq'
     | 'neq'
+    | 'not'
     | 'like'
     | 'nlike'
     | 'empty'


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

In version 0.90.0 and after `not` was removed from the filters, however, it was still there in the docs. This PR fixes the docs as well as adds support for `not`.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
