### PR TITLE
feat: json inference and jsonb saving for postgresql

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
@@ -1740,7 +1740,7 @@ export class PgUi {
         return ['json', 'char', 'character', 'character varying', 'text'];
 
       case 'JSON':
-        return ['json', 'text'];
+        return ['json', 'jsonb', 'text'];
       case 'Checkbox':
         return [
           'bit',

--- a/packages/nocodb/src/lib/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
@@ -439,7 +439,7 @@ class ModelXcMetaPg extends BaseModelXcMeta {
       case 'set':
         return 'MultiSelect';
       case 'json':
-        return 'LongText';
+        return 'JSON';
       case 'blob':
         return 'LongText';
       case 'geometry':
@@ -512,9 +512,8 @@ class ModelXcMetaPg extends BaseModelXcMeta {
       case 'interval':
         return 'string';
       case 'json':
-        return 'json';
       case 'jsonb':
-        return 'string';
+        return 'json';
 
       case 'language_handler':
       case 'lsec':


### PR DESCRIPTION
## Change Summary

When using postgresql as source, json/jsonb types are inferred as LongText in nocodb schema. Meanwhile, json type in nocodb cannot be saved as jsonb type in postgresql.

This PR fixes the inference of json type and add jsonb as one of db types for json.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Creation of jsonb columns and the inference of JSON types are verified.

creation:

<img width="245" alt="image" src="https://user-images.githubusercontent.com/20841764/176008245-985e092c-3f8e-42cd-8d9d-d9331ebd1057.png">

inference:

<img width="366" alt="image" src="https://user-images.githubusercontent.com/20841764/176007937-0d1e3ead-51f2-48c0-9b8f-be2deaf63d46.png">

## Additional information / screenshots (optional)

Note: I'm not sure if there are any compatibility consideration to infer json as LongText, but we cannot edit LongText json in ui as they are displayed as "[object]" in the editor.
