### PR TITLE
fix: cypress quick test enable in CICD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -623,7 +623,7 @@ jobs:
           with:
             start: |
               docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d
-              npm run start:api:cache:pg  
+              npm run watch:run:cypress:pg:cyquick  
               npm run start:web
             spec: "./scripts/cypress/integration/common/9a_QuickTest.js"
             wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -577,7 +577,6 @@ jobs:
           uses: cypress-io/github-action@v2
           with:
             start: |
-              npm run build:common
               npm run start:api:cache
               npm run start:web
               docker-compose -f ./scripts/docker-compose-cypress.yml up -d
@@ -622,7 +621,6 @@ jobs:
           uses: cypress-io/github-action@v2
           with:
             start: |
-              npm run build:common
               npm run start:api:cache:pg  
               npm run start:web
               docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -547,6 +547,96 @@ jobs:
                   name: cypress-xcdb-restMisc-run-cache-snapshots
                   path: scripts/cypress/screenshots
                   retention-days: 2
+    cy-quick-sqlite:
+      runs-on: ubuntu-20.04
+      steps:
+        - name: Setup Node
+          uses: actions/setup-node@v1
+          with:
+            node-version: 16.15.0
+        - name: Checkout
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Cache node modules
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-node-modules
+
+          with:
+            # npm cache files are stored in `~/.npm` on Linux/macOS
+            path: ~/.npm
+            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+            restore-keys: |
+              ${{ runner.os }}-build-${{ env.cache-name }}-
+              ${{ runner.os }}-build-
+              ${{ runner.os }}-
+        - name: Set env
+          run: echo "NODE_ENV=test" >> $GITHUB_ENV
+        - name: Cypress run
+          uses: cypress-io/github-action@v2
+          with:
+            start: |
+              npm run build:common
+              npm run start:api:cache
+              npm run start:web
+              docker-compose -f ./scripts/docker-compose-cypress.yml up -d
+            spec: "./scripts/cypress/integration/common/9a_QuickTest.js"
+            wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"
+            wait-on-timeout: 1200
+            config-file: scripts/cypress/cypress.json
+        - name: Upload screenshots
+          if: always()
+          uses: actions/upload-artifact@v2
+          with:
+            name: cy-quick-sqlite-snapshots
+            path: scripts/cypress/screenshots
+            retention-days: 2
+    cy-quick-pg:
+      runs-on: ubuntu-20.04
+      steps:
+        - name: Setup Node
+          uses: actions/setup-node@v1
+          with:
+            node-version: 16.15.0
+        - name: Checkout
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - name: Cache node modules
+          uses: actions/cache@v2
+          env:
+            cache-name: cache-node-modules
+
+          with:
+            # npm cache files are stored in `~/.npm` on Linux/macOS
+            path: ~/.npm
+            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+            restore-keys: |
+              ${{ runner.os }}-build-${{ env.cache-name }}-
+              ${{ runner.os }}-build-
+              ${{ runner.os }}-
+        - name: Set env
+          run: echo "NODE_ENV=test" >> $GITHUB_ENV
+        - name: Cypress run
+          uses: cypress-io/github-action@v2
+          with:
+            start: |
+              npm run build:common
+              npm run start:api:cache:pg  
+              npm run start:web
+              docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d
+            spec: "./scripts/cypress/integration/common/9a_QuickTest.js"
+            wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"
+            wait-on-timeout: 1200
+            config-file: scripts/cypress/cypress.json
+                           - name: Upload screenshots
+                           if: always()
+                           uses: actions/upload-artifact@v2
+                           with:
+                             name: cy-quick-pg-snapshots
+                             path: scripts/cypress/screenshots
+                             retention-days: 2
 #    docker:
 #        runs-on: ubuntu-latest
 #        steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -577,6 +577,7 @@ jobs:
           uses: cypress-io/github-action@v2
           with:
             start: |
+              cp ./scripts/cypress/fixtures/quickTest/noco_0_91_7.db ./packages/nocodb/noco.db
               npm run start:api:cache
               npm run start:web
               docker-compose -f ./scripts/docker-compose-cypress.yml up -d
@@ -621,9 +622,9 @@ jobs:
           uses: cypress-io/github-action@v2
           with:
             start: |
+              docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d
               npm run start:api:cache:pg  
               npm run start:web
-              docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d
             spec: "./scripts/cypress/integration/common/9a_QuickTest.js"
             wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"
             wait-on-timeout: 1200

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -628,13 +628,13 @@ jobs:
             wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"
             wait-on-timeout: 1200
             config-file: scripts/cypress/cypress.json
-                           - name: Upload screenshots
-                           if: always()
-                           uses: actions/upload-artifact@v2
-                           with:
-                             name: cy-quick-pg-snapshots
-                             path: scripts/cypress/screenshots
-                             retention-days: 2
+        - name: Upload screenshots
+          if: always()
+          uses: actions/upload-artifact@v2
+          with:
+            name: cy-quick-pg-snapshots
+            path: scripts/cypress/screenshots
+            retention-days: 2
 #    docker:
 #        runs-on: ubuntu-latest
 #        steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -623,7 +623,7 @@ jobs:
           with:
             start: |
               docker-compose -f ./scripts/cypress/docker-compose-pg-cy-quick.yml up -d
-              npm run watch:run:cypress:pg:cyquick  
+              npm run start:api:cache:pg:cyquick  
               npm run start:web
             spec: "./scripts/cypress/integration/common/9a_QuickTest.js"
             wait-on: "http://localhost:8080, http://localhost:3000/_nuxt/runtime.js"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "start:xcdb-api": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk;npm install; NC_DISABLE_CACHE=true NC_DISABLE_TELE=true NC_INFLECTION=camelize DATABASE_URL=sqlite:../../../scripts/cypress/fixtures/sqlite-sakila/sakila.db npm run watch:run:cypress",
     "start:api:cache": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk;npm install; NC_DISABLE_TELE=true npm run watch:run:cypress",
     "start:api:cache:pg": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk; npm install; NC_DISABLE_TELE=true npm run watch:run:cypress:pg",
+    "start:api:cache:pg:cyquick": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk; npm install; NC_DISABLE_TELE=true npm run watch:run:cypress:pg:cyquick",
     "start:xcdb-api:cache": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk; npm install; NC_DISABLE_TELE=true NC_INFLECTION=camelize DATABASE_URL=sqlite:../../../scripts/cypress/fixtures/sqlite-sakila/sakila.db npm run watch:run:cypress",
     "start:web": "npm run build:common ; cd ./packages/nc-gui; npm install ../nocodb-sdk; npm install; npm run dev",
     "cypress:run": "cypress run --config-file ./scripts/cypress/cypress.json",

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -71,6 +71,7 @@
     "watch:run": "cross-env NC_DISABLE_TELE1=true EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/docker --log-error --project tsconfig.json\"",
     "watch:run:cypress": "cross-env EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/docker --log-error --project tsconfig.json\"",
     "watch:run:cypress:pg": "cross-env EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/dockerRunPG --log-error --project tsconfig.json\"",
+    "watch:run:cypress:pg:cyquick": "cross-env EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/dockerRunPG_CyQuick.ts --log-error --project tsconfig.json\"",
     "watch:run:mysql": "cross-env  NC_DISABLE_TELE=true EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/dockerRunMysql --log-error --project tsconfig.json\"",
     "watch:run:pg": "cross-env  NC_DISABLE_TELE=true EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/dockerRunPG --log-error --project tsconfig.json\"",
     "run": "ts-node src/run/docker",

--- a/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
+++ b/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
@@ -1,0 +1,49 @@
+import cors from 'cors';
+import express from 'express';
+
+import Noco from '../lib/Noco';
+process.env.NC_VERSION = '0009044';
+
+const server = express();
+server.use(
+  cors({
+    exposedHeaders: 'xc-db-response',
+  })
+);
+
+server.set('view engine', 'ejs');
+process.env[
+  `NC_DB`
+] = `pg://localhost:5432?u=postgres&p=password&d=meta_v2_2022_06_13`;
+
+process.env[`DEBUG`] = 'xc*';
+
+(async () => {
+  const httpServer = server.listen(process.env.PORT || 8080, () => {
+    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  });
+  server.use(await Noco.init({}, httpServer, server));
+})().catch((e) => console.log(e));
+
+/**
+ * @copyright Copyright (c) 2021, Xgene Cloud Ltd
+ *
+ * @author Naveen MR <oof1lab@gmail.com>
+ * @author Pranav C Balan <pranavxc@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/scripts/cypress/integration/common/9a_QuickTest.js
+++ b/scripts/cypress/integration/common/9a_QuickTest.js
@@ -17,11 +17,11 @@ let records = {
     Number: "1",
     Value: "$1.00",
     Percent: "0.01",
-    Duration: "00:01",
 };
 
 // links/ computed fields
 let records2 = {
+    Duration: "00:01",
     Done: true,
     Date: "2022-05-31",
     Rating: "1",
@@ -88,6 +88,11 @@ export const genTest = (apiType, dbType) => {
                 .should(records2.Done ? "exist" : "not.exist");
 
             // date
+
+            // duration
+            mainPage.getCell("Duration", 1).find('input').then(($e) => {
+                expect($e[0].value).to.equal(records2.Duration)
+            })
 
             // rating
             mainPage

--- a/scripts/cypress/integration/common/9a_QuickTest.js
+++ b/scripts/cypress/integration/common/9a_QuickTest.js
@@ -17,7 +17,7 @@ let records = {
     Number: "1",
     Value: "$1.00",
     Percent: "0.01",
-    Duration: "60",
+    Duration: "00:01",
 };
 
 // links/ computed fields

--- a/scripts/cypress/integration/common/9a_QuickTest.js
+++ b/scripts/cypress/integration/common/9a_QuickTest.js
@@ -66,7 +66,7 @@ export const genTest = (apiType, dbType) => {
     if (!isTestSuiteActive(apiType, dbType)) return;
     describe(`Webhook`, () => {
         before(() => {
-            cy.task("copyFile")
+            // cy.task("copyFile")
             loginPage.signIn(roles.owner.credentials);
             projectsPage.openProject("sample");
         });


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
CI-CD quick tests were disabled during recent commits overlap. Re-enabling.

## Change type
- [x] test: (adding missing tests, refactoring tests; no production code change)

## Test/ Verification
CI/CD
