### PR TITLE
fix: delete rows containing m2m / hm data

### DIFF
--- a/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
@@ -1124,27 +1124,8 @@ export default {
               .map(c => rowObj[c.title])
               .join('___');
 
-          if (!id) {
-            return this.$toast.info("Delete not allowed for table which doesn't have primary Key").goAway(3000);
-          }
-
-          const res = await this.$api.dbViewRow.delete(
-            'noco',
-            this.projectName,
-            this.meta.id,
-            this.selectedView.id,
-            id
-          );
-
-          if (res?.message) {
-            this.$toast
-              .info(
-                `<div style="padding:10px 4px">Unable to delete tables because of the following.
-                <br><br>${res.message.join('<br>')}<br><br>
-                Clear the data first & try again</div>
-            `
-              )
-              .goAway(5000);
+          const successfulDeletion = await this.deleteRowById(id);
+          if (!successfulDeletion) {
             return;
           }
         }
@@ -1157,7 +1138,6 @@ export default {
     },
     async deleteSelectedRows() {
       let row = this.rowLength;
-      // let success = 0
       while (row--) {
         try {
           const { row: rowObj, rowMeta } = this.data[row];
@@ -1170,10 +1150,10 @@ export default {
               .map(c => rowObj[c.title])
               .join('___');
 
-            if (!id) {
-              return this.$toast.info("Delete not allowed for table which doesn't have primary Key").goAway(3000);
+            const successfulDeletion = await this.deleteRowById(id);
+            if (!successfulDeletion) {
+              continue;
             }
-            await this.$api.dbViewRow.delete('noco', this.projectName, this.meta.id, this.selectedView.id, id);
           }
           this.data.splice(row, 1);
         } catch (e) {
@@ -1181,6 +1161,32 @@ export default {
         }
       }
       this.syncCount();
+    },
+
+    async deleteRowById(id) {
+      try {
+        if (!id) {
+          this.$toast.info("Delete not allowed for table which doesn't have primary Key").goAway(3000);
+          return false;
+        }
+
+        const res = await this.$api.dbViewRow.delete('noco', this.projectName, this.meta.id, this.selectedView.id, id);
+
+        if (res?.message) {
+          this.$toast
+            .info(
+              `<div style="padding:10px 4px">Unable to delete row with ID ${id} because of the following:
+                <br><br>${res.message.join('<br>')}<br><br>
+                Clear the data first & try again</div>`
+            )
+            .goAway(5000);
+          return false;
+        }
+      } catch (e) {
+        this.$toast.error(`Failed to delete row : ${e.message}`).goAway(3000);
+        return false;
+      }
+      return true;
     },
 
     async clearCellValue() {

--- a/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
+++ b/packages/nc-gui/components/project/spreadsheet/RowsXcDataTable.vue
@@ -1127,7 +1127,26 @@ export default {
           if (!id) {
             return this.$toast.info("Delete not allowed for table which doesn't have primary Key").goAway(3000);
           }
-          await this.$api.dbViewRow.delete('noco', this.projectName, this.meta.id, this.selectedView.id, id);
+
+          const res = await this.$api.dbViewRow.delete(
+            'noco',
+            this.projectName,
+            this.meta.id,
+            this.selectedView.id,
+            id
+          );
+
+          if (res?.message) {
+            this.$toast
+              .info(
+                `<div style="padding:10px 4px">Unable to delete tables because of the following.
+                <br><br>${res.message.join('<br>')}<br><br>
+                Clear the data first & try again</div>
+            `
+              )
+              .goAway(5000);
+            return;
+          }
         }
         this.data.splice(this.rowContextMenu.index, 1);
         this.syncCount();

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -1385,6 +1385,7 @@ class BaseModelSqlv2 {
       (c) => c.uidt === UITypes.LinkToAnotherRecord
     );
     const res = [];
+    let i = 0;
     for (const column of LTARColumns) {
       const colOptions =
         (await column.getColOptions()) as LinkToAnotherRecordColumn;
@@ -1394,10 +1395,18 @@ class BaseModelSqlv2 {
       await childModel.getColumns();
       const parentModel = await parentColumn.getModel();
       await parentModel.getColumns();
-      let i = 0;
       if (colOptions.type === RelationTypes.HAS_MANY) {
-        // TODO:
-        continue;
+        const selectHmCount = await this.dbDriver(childModel.table_name)
+          .count(childColumn.column_name, { as: 'cnt' })
+          .where(childColumn.column_name, rowId);
+        const cnt = (await selectHmCount)[0].cnt;
+        if (cnt) {
+          res.push(
+            `${i++ + 1}. ${model.title}.${
+              column.title
+            } is a LinkToAnotherRecord of ${childModel.title}`
+          );
+        }
       } else if (colOptions.type === RelationTypes.BELONGS_TO) {
         // TODO:
         continue;

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -1407,9 +1407,6 @@ class BaseModelSqlv2 {
             } is a LinkToAnotherRecord of ${childModel.title}`
           );
         }
-      } else if (colOptions.type === RelationTypes.BELONGS_TO) {
-        // TODO:
-        continue;
       } else if (colOptions.type === RelationTypes.MANY_TO_MANY) {
         const mmModel = await colOptions.getMMModel();
         const mmChildColumn = await colOptions.getMMChildColumn();

--- a/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
+++ b/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
@@ -76,11 +76,10 @@ async function dataUpdate(req: Request, res: Response) {
 async function dataDelete(req: Request, res: Response) {
   const { model, view } = await getViewAndModelFromRequestByAliasOrId(req);
   const base = await Base.get(model.base_id);
-  const dbDriver = NcConnectionMgrv2.get(base);
   const baseModel = await Model.getBaseModelSQL({
     id: model.id,
     viewId: view?.id,
-    dbDriver: dbDriver,
+    dbDriver: NcConnectionMgrv2.get(base),
   });
   const message = await baseModel.hasLTARData(req.params.rowId, model);
   if (message.length) {

--- a/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
+++ b/packages/nocodb/src/lib/meta/api/dataApis/dataAliasApis.ts
@@ -76,12 +76,17 @@ async function dataUpdate(req: Request, res: Response) {
 async function dataDelete(req: Request, res: Response) {
   const { model, view } = await getViewAndModelFromRequestByAliasOrId(req);
   const base = await Base.get(model.base_id);
+  const dbDriver = NcConnectionMgrv2.get(base);
   const baseModel = await Model.getBaseModelSQL({
     id: model.id,
     viewId: view?.id,
-    dbDriver: NcConnectionMgrv2.get(base),
+    dbDriver: dbDriver,
   });
-
+  const message = await baseModel.hasLTARData(req.params.rowId, model);
+  if (message.length) {
+    res.json({ message });
+    return;
+  }
   res.json(await baseModel.delByPk(req.params.rowId, null, req));
 }
 async function getDataList(model, view: View, req) {


### PR DESCRIPTION
## Change Summary

ref: #2557 

- In SQLite, we're using virtual key - so whether there is m2m / hm deletion - the deletion is considered valid. However, others would throw `Cannot delete or update a parent row: a foreign key constraint fails`
- This PR is to change the to-be-deleted row contains any m2m / hm data. If so, toast a message to indicate users to remove the data first just like table deletion logic.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Base Table

![image](https://user-images.githubusercontent.com/35857179/177916163-673812b0-5189-4d4f-a47f-cde0d47255ef.png)

Delete Row with ID = 2 

![image](https://user-images.githubusercontent.com/35857179/177916207-3a29f700-3cc7-4fb4-acc3-bed3abd4584b.png)

Delete Row with ID = 3 

![image](https://user-images.githubusercontent.com/35857179/177916229-8d34b406-7f15-4c35-aae2-c3f54ba43feb.png)

Delete Row with ID = 4

![image](https://user-images.githubusercontent.com/35857179/177916253-1f737a22-7e98-4d52-b359-0455f6c2dcdc.png)

Add one more record and select all to delete

![image](https://user-images.githubusercontent.com/35857179/177916338-43d860b8-d3c0-494e-9a37-c94f4db19089.png)

Only row with ID = 4 is deleted

![image](https://user-images.githubusercontent.com/35857179/177916366-0f8543ae-ef84-492b-933f-517a7f3d9ac1.png)
