### PR TITLE
fix: large characters in table create

### DIFF
--- a/packages/nc-gui/components/utils/DlgTableCreate.vue
+++ b/packages/nc-gui/components/utils/DlgTableCreate.vue
@@ -23,7 +23,7 @@
             persistent-hint
             dense
             hide-details1
-            :rules="[validateTableName, validateDuplicateAlias]"
+            :rules="[validateTableName, validateDuplicateAlias, validateLength]"
             :hint="$t('msg.info.enterTableName')"
             class="mt-4 caption nc-table-name"
           />
@@ -230,6 +230,18 @@ export default {
       return (
         (this.tables || []).every(t => t.table_name.toLowerCase() !== (v || '').toLowerCase()) || 'Duplicate table name'
       );
+    },
+    validateLength(v) {
+      let tableNameLengthLimit = 255;
+      const sqlClientType = this.$store.getters['project/GtrClientType'];
+      if (sqlClientType === 'mysql2' || sqlClientType === 'mysql') {
+        tableNameLengthLimit = 64;
+      } else if (sqlClientType === 'pg') {
+        tableNameLengthLimit = 63;
+      } else if (sqlClientType === 'mssql') {
+        tableNameLengthLimit = 128;
+      }
+      return v.length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`;
     },
     onCreateBtnClick() {
       this.$emit('create', {

--- a/packages/nocodb/src/lib/meta/api/tableApis.ts
+++ b/packages/nocodb/src/lib/meta/api/tableApis.ts
@@ -141,6 +141,20 @@ export async function tableCreate(req: Request<any, any, TableReqType>, res) {
   const sqlMgr = await ProjectMgrv2.getSqlMgr(project);
   const sqlClient = NcConnectionMgrv2.getSqlClient(base);
 
+  let tableNameLengthLimit = 255;
+  const sqlClientType = sqlClient.clientType;
+  if (sqlClientType === 'mysql2' || sqlClientType === 'mysql') {
+    tableNameLengthLimit = 64;
+  } else if (sqlClientType === 'pg') {
+    tableNameLengthLimit = 63;
+  } else if (sqlClientType === 'mssql') {
+    tableNameLengthLimit = 128;
+  }
+
+  if (req.body.table_name.length > tableNameLengthLimit) {
+    NcError.badRequest(`Table name exceeds ${tableNameLengthLimit} characters`);
+  }
+
   req.body.columns = req.body.columns?.map((c) => ({
     ...getColumnPropsFromUIDT(c as any, base),
     cn: c.column_name,


### PR DESCRIPTION
## Change Summary

- limit the table length in frontend and backend
   - mysql: 64
   - pg: 63
   - mssql: 128
   - sqlite: 255

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Payload: https://drive.google.com/file/d/13IK67Sx93nvnb_3gLUBDLgoEC7XTQiso/view?usp=sharing

![image](https://user-images.githubusercontent.com/35857179/178406563-64a05e33-469a-42df-8f6c-4968ed28053c.png)
