### PR TITLE
Fix/invalid reset url bug

### DIFF
--- a/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
@@ -328,10 +328,9 @@ async function passwordForgot(req: Request<any, any>, res): Promise<any> {
           subject: 'Password Reset Link',
           text: `Visit following link to update your password : ${
             (req as any).ncSiteUrl
-          }/api/v1/auth/password/reset/${token}.`,
+          }/auth/password/reset/${token}.`,
           html: ejs.render(template, {
-            resetLink:
-              (req as any).ncSiteUrl + `/api/v1/auth/password/reset/${token}`,
+            resetLink: (req as any).ncSiteUrl + `/auth/password/reset/${token}`,
           }),
         })
       );
@@ -577,9 +576,7 @@ const mapRoutes = (router) => {
     '/api/v1/auth/token/refresh',
     ncMetaAclMw(refreshToken, 'refreshToken')
   );
-  router.get(
-    '/api/v1/auth/password/reset/:tokenId',
-    catchError(renderPasswordReset)
-  );
+  // respond with password reset page
+  router.get('/auth/password/reset/:tokenId', catchError(renderPasswordReset));
 };
 export { mapRoutes as userApis };

--- a/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
@@ -365,7 +365,7 @@ async function tokenValidate(req, res): Promise<any> {
   if (!user || !user.email) {
     NcError.badRequest('Invalid reset url');
   }
-  if (user.reset_password_expires < new Date()) {
+  if (new Date(user.reset_password_expires) < new Date()) {
     NcError.badRequest('Password reset url expired');
   }
   res.json(true);


### PR DESCRIPTION
## Change Summary

- Fixed date comparison code to avoid unexpected behavior
- Remove `api/v1` from the password reset page link

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Confirmed by discord user - @alex.pro