### PR TITLE
enhancement: update underlying db name after table rename

### DIFF
--- a/packages/nc-gui/components/ProjectTreeView.vue
+++ b/packages/nc-gui/components/ProjectTreeView.vue
@@ -1432,7 +1432,7 @@ export default {
       try {
         await this.$api.dbTable.update(item.id, {
           projectId: this.projectId,
-          title,
+          table_name: title,
         });
       } catch (e) {
         this.$toast.error(await this._extractSdkResponseErrorMsg(e)).goAway(3000);

--- a/packages/nc-gui/components/ProjectTreeView.vue
+++ b/packages/nc-gui/components/ProjectTreeView.vue
@@ -1438,30 +1438,37 @@ export default {
         this.$toast.error(await this._extractSdkResponseErrorMsg(e)).goAway(3000);
         return;
       }
-      await this.removeTabsByName(item);
-      await this.loadTablesFromParentTreeNode({
-        _nodes: {
-          ...item._nodes,
-        },
-      });
-      this.$store.dispatch('tabs/ActAddTab', {
-        _nodes: {
-          env: this.menuItem._nodes.env,
-          dbAlias: this.menuItem._nodes.dbAlias,
-          table_name: this.menuItem._nodes.table_name,
-          title: title,
-          dbConnection: this.menuItem._nodes.dbConnection,
-          type: 'table',
-          dbKey: this.menuItem._nodes.dbKey,
-          key: this.menuItem._nodes.key,
-          tableDirKey: this.menuItem._nodes.tableDirKey,
-        },
-        name: title,
-      });
-      this.dialogRenameTable.dialogShow = false;
-      this.dialogRenameTable.defaultValue = null;
-      this.$toast.success('Table renamed successfully').goAway(3000);
-      this.$e('a:table:rename');
+      try {
+        await this.removeTabsByName(item);
+        await this.loadTablesFromParentTreeNode({
+          _nodes: {
+            ...item._nodes,
+          },
+        });
+        const projectPrefix = this.$store.getters['project/GtrProjectPrefix'] || '';
+        this.$store.dispatch('tabs/ActAddTab', {
+          _nodes: {
+            env: this.menuItem._nodes.env,
+            dbAlias: this.menuItem._nodes.dbAlias,
+            table_name: `${projectPrefix}${title}`,
+            title: title,
+            dbConnection: this.menuItem._nodes.dbConnection,
+            type: 'table',
+            dbKey: this.menuItem._nodes.dbKey,
+            key: this.menuItem._nodes.key,
+            tableDirKey: this.menuItem._nodes.tableDirKey,
+          },
+          name: title,
+        });
+        this.dialogRenameTable.dialogShow = false;
+        this.dialogRenameTable.defaultValue = null;
+        this.$toast.success('Table renamed successfully').goAway(3000);
+        this.$e('a:table:rename');
+      } catch (e) {
+        console.log(e);
+        this.$toast.error(e.message);
+        return;
+      }
     },
     mtdDialogRenameTableCancel() {
       this.dialogRenameTable.dialogShow = false;

--- a/packages/nc-gui/components/ProjectTreeView.vue
+++ b/packages/nc-gui/components/ProjectTreeView.vue
@@ -1777,7 +1777,9 @@ export default {
         tableNameLengthLimit = 128;
       }
       const projectPrefix = this.$store.getters['project/GtrProjectPrefix'] || '';
-      return (projectPrefix + v).length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`;
+      return (
+        (projectPrefix + v).length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`
+      );
     },
   },
   async created() {

--- a/packages/nc-gui/components/ProjectTreeView.vue
+++ b/packages/nc-gui/components/ProjectTreeView.vue
@@ -572,7 +572,7 @@
 
     <textDlgSubmitCancel
       v-if="dialogRenameTable.dialogShow"
-      :rules="[validateTableName, validateUniqueAlias]"
+      :rules="[validateTableName, validateUniqueAlias, validateLength]"
       :dialog-show="dialogRenameTable.dialogShow"
       :heading="dialogRenameTable.heading"
       :cookie="dialogRenameTable.cookie"
@@ -1431,6 +1431,7 @@ export default {
       let item = cookie;
       try {
         await this.$api.dbTable.update(item.id, {
+          projectId: this.projectId,
           title,
         });
       } catch (e) {
@@ -1764,6 +1765,19 @@ export default {
     },
     validateTableName(v) {
       return validateTableName(v, this.$store.getters['project/GtrProjectIsGraphql']);
+    },
+    validateLength(v) {
+      let tableNameLengthLimit = 255;
+      const sqlClientType = this.$store.getters['project/GtrClientType'];
+      if (sqlClientType === 'mysql2' || sqlClientType === 'mysql') {
+        tableNameLengthLimit = 64;
+      } else if (sqlClientType === 'pg') {
+        tableNameLengthLimit = 63;
+      } else if (sqlClientType === 'mssql') {
+        tableNameLengthLimit = 128;
+      }
+      const projectPrefix = this.$store.getters['project/GtrProjectPrefix'] || '';
+      return (projectPrefix + v).length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`;
     },
   },
   async created() {

--- a/packages/nc-gui/components/utils/DlgTableCreate.vue
+++ b/packages/nc-gui/components/utils/DlgTableCreate.vue
@@ -241,7 +241,10 @@ export default {
       } else if (sqlClientType === 'mssql') {
         tableNameLengthLimit = 128;
       }
-      return v.length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`;
+      const projectPrefix = this.$store.getters['project/GtrProjectPrefix'] || '';
+      return (
+        (projectPrefix + v).length <= tableNameLengthLimit || `Table name exceeds ${tableNameLengthLimit} characters`
+      );
     },
     onCreateBtnClick() {
       this.$emit('create', {

--- a/packages/nocodb/src/lib/meta/api/tableApis.ts
+++ b/packages/nocodb/src/lib/meta/api/tableApis.ts
@@ -2,6 +2,7 @@ import { Request, Response, Router } from 'express';
 import Model from '../../models/Model';
 import { PagedResponseImpl } from '../helpers/PagedResponse';
 import { Tele } from 'nc-help';
+import DOMPurify from 'isomorphic-dompurify';
 import {
   AuditOperationSubTypes,
   AuditOperationTypes,
@@ -102,6 +103,8 @@ export async function tableCreate(req: Request<any, any, TableReqType>, res) {
       req.body.table_name = `${project.prefix}_${req.body.table_name}`;
     }
   }
+
+  req.body.table_name = DOMPurify.sanitize(req.body.table_name);
 
   // validate table name
   if (/^\s+|\s+$/.test(req.body.table_name)) {
@@ -217,19 +220,86 @@ export async function tableCreate(req: Request<any, any, TableReqType>, res) {
 
 export async function tableUpdate(req: Request<any, any>, res) {
   const model = await Model.get(req.params.tableId);
+  const project = await Project.getWithInfo(req.body.projectId);
+  const base = project.bases[0];
+
+  if (!req.body.table_name) {
+    NcError.badRequest(
+      'Missing table name `table_name` property in request body'
+    );
+  }
+
+  if (project.prefix) {
+    if (!req.body.table_name.startsWith(project.prefix)) {
+      req.body.table_name = `${project.prefix}${req.body.table_name}`;
+    }
+  }
+
+  req.body.table_name = DOMPurify.sanitize(req.body.table_name);
+
+  // validate table name
+  if (/^\s+|\s+$/.test(req.body.table_name)) {
+    NcError.badRequest(
+      'Leading or trailing whitespace not allowed in table names'
+    );
+  }
 
   if (
-    !(await Model.checkAliasAvailable({
-      title: req.body.title,
-      project_id: model.project_id,
-      base_id: model.base_id,
-      exclude_id: req.params.tableId,
+    !(await Model.checkTitleAvailable({
+      table_name: req.body.table_name,
+      project_id: project.id,
+      base_id: base.id,
     }))
   ) {
     NcError.badRequest('Duplicate table name');
   }
 
-  await Model.updateAlias(req.params.tableId, req.body.title);
+  if (!req.body.title) {
+    req.body.title = getTableNameAlias(
+      req.body.table_name,
+      project.prefix,
+      base
+    );
+  }
+
+  if (
+    !(await Model.checkAliasAvailable({
+      title: req.body.title,
+      project_id: project.id,
+      base_id: base.id,
+    }))
+  ) {
+    NcError.badRequest('Duplicate table alias');
+  }
+
+  const sqlMgr = await ProjectMgrv2.getSqlMgr(project);
+  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+
+  let tableNameLengthLimit = 255;
+  const sqlClientType = sqlClient.clientType;
+  if (sqlClientType === 'mysql2' || sqlClientType === 'mysql') {
+    tableNameLengthLimit = 64;
+  } else if (sqlClientType === 'pg') {
+    tableNameLengthLimit = 63;
+  } else if (sqlClientType === 'mssql') {
+    tableNameLengthLimit = 128;
+  }
+
+  if (req.body.table_name.length > tableNameLengthLimit) {
+    NcError.badRequest(`Table name exceeds ${tableNameLengthLimit} characters`);
+  }
+
+  await Model.updateAliasAndTableName(
+    req.params.tableId,
+    req.body.title,
+    req.body.table_name
+  );
+
+  await sqlMgr.sqlOpPlus(base, 'tableRename', {
+    ...req.body,
+    tn: req.body.table_name,
+    tn_old: model.table_name,
+  });
 
   Tele.emit('evt', { evt_type: 'table:updated' });
 

--- a/packages/nocodb/src/lib/models/Model.ts
+++ b/packages/nocodb/src/lib/models/Model.ts
@@ -412,14 +412,25 @@ export default class Model implements TableType {
     return insertObj;
   }
 
-  static async updateAlias(tableId, title: string, ncMeta = Noco.ncMeta) {
-    if (!title) NcError.badRequest("Missing 'title' property in body");
+  static async updateAliasAndTableName(
+    tableId,
+    title: string,
+    table_name: string,
+    ncMeta = Noco.ncMeta
+  ) {
+    if (!title) {
+      NcError.badRequest("Missing 'title' property in body");
+    }
+    if (!table_name) {
+      NcError.badRequest("Missing 'table_name' property in body");
+    }
     // get existing cache
     const key = `${CacheScope.MODEL}:${tableId}`;
     const o = await NocoCache.get(key, CacheGetType.TYPE_OBJECT);
     // update alias
     if (o) {
       o.title = title;
+      o.table_name = table_name;
       // set cache
       await NocoCache.set(key, o);
     }
@@ -430,6 +441,7 @@ export default class Model implements TableType {
       MetaTable.MODELS,
       {
         title,
+        table_name,
       },
       tableId
     );

--- a/scripts/cypress/integration/common/1a_table_operations.js
+++ b/scripts/cypress/integration/common/1a_table_operations.js
@@ -11,9 +11,9 @@ export const genTest = (apiType, dbType) => {
             cy.get(".mdi-close").click({ multiple: true });
         });
 
-        after(() => {
-            cy.get(".mdi-close").click({ multiple: true, force: true });
-        });
+        // after(() => {
+        //     cy.get(".mdi-close").click({ multiple: true, force: true });
+        // });
 
         const name = "tablex";
 
@@ -78,6 +78,7 @@ export const genTest = (apiType, dbType) => {
             
             // revert re-name operation to not impact rest of test suite
             cy.renameTable("CityX", "City");
+            cy.closeTableTab("City");
 
             // 4. verify linked contents in other table
             // 4a. Address table, has many field

--- a/scripts/cypress/integration/common/1a_table_operations.js
+++ b/scripts/cypress/integration/common/1a_table_operations.js
@@ -75,6 +75,9 @@ export const genTest = (apiType, dbType) => {
                 .should("exist");
 
             cy.closeTableTab("CityX");
+            
+            // revert re-name operation to not impact rest of test suite
+            cy.renameTable("CityX", "City");
 
             // 4. verify linked contents in other table
             // 4a. Address table, has many field
@@ -97,9 +100,6 @@ export const genTest = (apiType, dbType) => {
                 .contains("Kabul")
                 .should("exist");
             cy.closeTableTab("Country");
-
-            // revert re-name operation to not impact rest of test suite
-            cy.renameTable("CityX", "City");
         });
     });
 };


### PR DESCRIPTION
## Change Summary

- fix / add table create / rename table name length validation logic
- DOMPurify table name for tableCreate & tableUpdate
- update title, table_name & underlying db table name when renaming the table in NocoDB UI (ref: #2668)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Create TableA

![image](https://user-images.githubusercontent.com/35857179/178903423-18869ab0-f5ca-4907-abc2-a5ac4ace4501.png)

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/35857179/178903519-778cdc85-5e50-4a6a-8c76-8ebfc10bbcf4.png">

Rename it to TableB

![image](https://user-images.githubusercontent.com/35857179/178903568-644430b9-4892-4790-a1e2-b97c1fc31576.png)

table_name, title and underlying DB table name are changed.

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/35857179/178903616-821f3131-bdf0-4488-8ad4-5cbae4f8cb68.png">

![image](https://user-images.githubusercontent.com/35857179/178903688-3da4db54-2ba7-4c3a-a67a-cba09f1e5b6e.png)
