### PR TITLE
 feat: server.enable('trust proxy');

### DIFF
--- a/packages/nocodb/docker/index.js
+++ b/packages/nocodb/docker/index.js
@@ -2,6 +2,7 @@ const Noco = require("../build/main/lib/Noco").default;
 const express = require('express');
 const cors = require('cors');
 const server = express();
+server.enable('trust proxy');
 server.use(cors());
 
 

--- a/packages/nocodb/src/__tests__/graphql.test.ts
+++ b/packages/nocodb/src/__tests__/graphql.test.ts
@@ -63,6 +63,8 @@ describe('{Auth, CRUD, HasMany, Belongs} Tests', () => {
     this.timeout(10000);
     (async () => {
       const server = express();
+      server.enable('trust proxy');
+
 
       server.use(await Noco.init({}));
       app = server;

--- a/packages/nocodb/src/__tests__/rest.test.ts
+++ b/packages/nocodb/src/__tests__/rest.test.ts
@@ -81,6 +81,7 @@ describe('{Auth, CRUD, HasMany, Belongs} Tests', () => {
 
     (async () => {
       const server = express();
+      server.enable('trust proxy');
 
       server.use(await Noco.init());
       app = server;

--- a/packages/nocodb/src/__tests__/restv2.test.ts
+++ b/packages/nocodb/src/__tests__/restv2.test.ts
@@ -95,6 +95,7 @@ describe('Noco v2 Tests', () => {
       } catch {}
 
       const server = express();
+      server.enable('trust proxy');
 
       server.use(await Noco.init());
       app = server;

--- a/packages/nocodb/src/lib/v1-legacy/nc.try.ts
+++ b/packages/nocodb/src/lib/v1-legacy/nc.try.ts
@@ -8,6 +8,7 @@ import Noco from '../Noco';
 export default async function (dbUrl): Promise<void> {
   const server = express();
   server.use(cors());
+  server.enable('trust proxy');
 
   server.set('view engine', 'ejs');
 

--- a/packages/nocodb/src/run/docker.ts
+++ b/packages/nocodb/src/run/docker.ts
@@ -5,6 +5,8 @@ import Noco from '../lib/Noco';
 process.env.NC_VERSION = '0009044';
 
 const server = express();
+server.enable('trust proxy');
+
 server.use(
   cors({
     exposedHeaders: 'xc-db-response',

--- a/packages/nocodb/src/run/dockerRunMysql.ts
+++ b/packages/nocodb/src/run/dockerRunMysql.ts
@@ -5,6 +5,8 @@ import Noco from '../lib/Noco';
 process.env.NC_VERSION = '0009044';
 
 const server = express();
+server.enable('trust proxy');
+
 server.use(
   cors({
     exposedHeaders: 'xc-db-response',

--- a/packages/nocodb/src/run/dockerRunPG.ts
+++ b/packages/nocodb/src/run/dockerRunPG.ts
@@ -5,6 +5,8 @@ import Noco from '../lib/Noco';
 process.env.NC_VERSION = '0009044';
 
 const server = express();
+server.enable('trust proxy');
+
 server.use(
   cors({
     exposedHeaders: 'xc-db-response',

--- a/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
+++ b/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
@@ -5,6 +5,8 @@ import Noco from '../lib/Noco';
 process.env.NC_VERSION = '0009044';
 
 const server = express();
+server.enable('trust proxy');
+
 server.use(
   cors({
     exposedHeaders: 'xc-db-response',

--- a/packages/nocodb/src/run/try.ts
+++ b/packages/nocodb/src/run/try.ts
@@ -11,6 +11,8 @@ process.env.NC_DB = url;
 
 (async () => {
   const server = express();
+  server.enable('trust proxy');
+
   server.use(cors());
   server.set('view engine', 'ejs');
   const app = new Noco();


### PR DESCRIPTION
## Change Summary

#2711

Unable to get the correct request, after using nginx forwarding agent。

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

After the test, code snippet and swagger API doc are found, and the URL is determined by req Ncsiteurl control. After nginx proxy forwarding, req Protocol can only get http.

`packages\nocodb\src\lib\Noco.ts`
```
 /******************* Middlewares : start *******************/
    this.router.use((req: any, _res, next) => {
      req.nc = this.requestContext;
      req.ncSiteUrl =
        this.config?.envs?.[this.env]?.publicUrl ||
        this.config?.publicUrl ||
        req.protocol + '://' + req.get('host');
      req.ncFullUrl = req.protocol + '://' + req.get('host') + req.originalUrl;
      next();
    });
```
###  add `server.enable('trust proxy');`
```
const server = express();
server.enable('trust proxy');
```
Anything for maintainers to be made aware of
