### PR TITLE
feat(gui-v2): get project roles

### DIFF
--- a/packages/nc-gui-v2/composables/useProject.ts
+++ b/packages/nc-gui-v2/composables/useProject.ts
@@ -1,28 +1,38 @@
 import { SqlUiFactory } from 'nocodb-sdk'
 import type { ProjectType, TableType } from 'nocodb-sdk'
-import { useNuxtApp } from '#app'
+import { useNuxtApp, useState } from '#app'
+import { USER_PROJECT_ROLES } from '~/lib/constants'
 
 export default () => {
+  const projectRoles = useState<Record<string, boolean>>(USER_PROJECT_ROLES, () => ({}))
+
   const { $api } = useNuxtApp()
 
   const project = useState<ProjectType>('project')
   const tables = useState<TableType[]>('tables')
 
+  const loadProjectRoles = async () => {
+    projectRoles.value = {}
+
+    if (project.value.id) {
+      const user = await $api.auth.me({ project_id: project.value.id })
+      projectRoles.value = user.roles
+    }
+  }
   const loadTables = async () => {
     if (project.value.id) {
       const tablesResponse = await $api.dbTable.list(project.value.id)
-
       if (tablesResponse.list) tables.value = tablesResponse.list
     }
   }
 
   const loadProject = async (projectId: string) => {
     project.value = await $api.project.read(projectId)
+    await loadProjectRoles()
   }
 
   const isMysql = computed(() => ['mysql', 'mysql2'].includes(project.value?.bases?.[0]?.type || ''))
   const isPg = computed(() => project.value?.bases?.[0]?.type === 'pg')
-
   const sqlUi = computed(() => SqlUiFactory.create({ client: project.value?.bases?.[0]?.type || '' }))
 
   return { project, tables, loadProject, loadTables, isMysql, isPg, sqlUi }

--- a/packages/nc-gui-v2/lib/constants.ts
+++ b/packages/nc-gui-v2/lib/constants.ts
@@ -1,1 +1,2 @@
 export const NOCO = 'noco'
+export const USER_PROJECT_ROLES = 'user_project_roles'


### PR DESCRIPTION
## Change Summary

Load project specific user roles and use it with UI permission composable.

Usage

```js
const { isUIAllowed } = useUIPermission()


if(isUIAllowed('permissionName')){
   // logic here
}
```

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
