### PR TITLE
refactor(gui-v2): cleanup template editor component

### DIFF
--- a/packages/nc-gui-v2/components/template/utils.ts
+++ b/packages/nc-gui-v2/components/template/utils.ts
@@ -1,0 +1,25 @@
+import type { ColumnGroupType } from 'ant-design-vue/es/table'
+
+export const tableColumns: (Omit<ColumnGroupType<any>, 'children'> & { dataIndex?: string; name: string })[] = [
+  {
+    name: 'Column Name',
+    dataIndex: 'column_name',
+    key: 'column_name',
+    width: 250,
+  },
+  {
+    name: 'Column Type',
+    dataIndex: 'column_type',
+    key: 'uidt',
+    width: 250,
+  },
+  {
+    name: 'Select Option',
+    key: 'dtxp',
+  },
+  {
+    name: 'Action',
+    key: 'action',
+    align: 'right',
+  },
+]


### PR DESCRIPTION
# What's changed?

* fix types
* change arrow fns to regular functions to avoid ordering issues
* move templateColumns to utils file
* 
## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
