### PR TITLE
Removed `calendar` icon from `DatePicker`, `DateTimePicker` and `YearPicker`

### DIFF
--- a/packages/nc-gui-v2/components/cell/DatePicker.vue
+++ b/packages/nc-gui-v2/components/cell/DatePicker.vue
@@ -53,7 +53,7 @@ const localState = $computed({
     :input-read-only="true"
     :open="readOnlyMode ? false : undefined"
   >
-    <template v-if="readOnlyMode" #suffixIcon></template>
+    <template #suffixIcon></template>
   </a-date-picker>
 </template>
 

--- a/packages/nc-gui-v2/components/cell/DateTimePicker.vue
+++ b/packages/nc-gui-v2/components/cell/DateTimePicker.vue
@@ -50,12 +50,12 @@ const localState = $computed({
     :bordered="false"
     class="!w-full px-1"
     format="YYYY-MM-DD HH:mm"
-    :placeholder="isDateInvalid ? 'Invalid date' : !readOnlyMode ? 'Select date' : ''"
+    :placeholder="isDateInvalid ? 'Invalid date' : !readOnlyMode ? 'Select date and time' : ''"
     :allow-clear="!readOnlyMode"
     :input-read-only="true"
     :open="readOnlyMode ? false : undefined"
   >
-    <template v-if="readOnlyMode" #suffixIcon></template>
+    <template #suffixIcon></template>
   </a-date-picker>
 </template>
 

--- a/packages/nc-gui-v2/components/cell/YearPicker.vue
+++ b/packages/nc-gui-v2/components/cell/YearPicker.vue
@@ -52,7 +52,7 @@ const localState = $computed({
     :input-read-only="true"
     :open="readOnlyMode ? false : undefined"
   >
-    <template v-if="readOnlyMode" #suffixIcon></template>
+    <template #suffixIcon></template>
   </a-date-picker>
 </template>
 


### PR DESCRIPTION
Ref: [comment](https://github.com/nocodb/nocodb/pull/2899#issuecomment-1200174342)

Removed `calendar` icon from `DatePicker`, `DateTimePicker` and `YearPicker`


UI:

![image](https://user-images.githubusercontent.com/35809690/182105515-ed7567be-ce54-4616-b081-0ac49f4a3e73.png)
![image](https://user-images.githubusercontent.com/35809690/182105544-17e3a142-6c0d-43b6-a858-6dffba40a25f.png)

