### PR TITLE
docs: make field `columns` required for creating a table via the REST API

### DIFF
--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -6234,7 +6234,8 @@
         },
         "required": [
           "table_name",
-          "title"
+          "title",
+          "columns"
         ]
       },
       "TableList": {


### PR DESCRIPTION
## Change Summary

![image](https://user-images.githubusercontent.com/24459435/182122526-e8315b04-6132-4587-ae4d-c7cf75c0a6f8.png)

https://all-apis.nocodb.com/#tag/DB-table/operation/db-table-create

The API docs are saying that the field `columns` is not required. However, from understanding #2809 a table needs minimum 1 column. There is the `columns` field required. Technically, the `columns` shouldn't be an empty but I don't know to add a note for this.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
