### PR TITLE
fix(gui-v2): cell follow ups

### DIFF
--- a/packages/nc-gui-v2/components/cell/Email.vue
+++ b/packages/nc-gui-v2/components/cell/Email.vue
@@ -2,40 +2,36 @@
 import { computed } from '#imports'
 import { isEmail } from '~/utils'
 
-const { modelValue: value } = defineProps<Props>()
-
-const emit = defineEmits(['update:modelValue'])
-
-const editEnabled = inject<boolean>('editEnabled')
-
 interface Props {
   modelValue: string
 }
 
-const root = ref<HTMLInputElement>()
-const localState = computed({
-  get: () => value,
-  set: (val) => emit('update:modelValue', val),
-})
-
-const validEmail = computed(() => isEmail(value))
-</script>
-
-<script lang="ts">
-export default {
-  name: 'EmailCell',
+interface Emits {
+  (event: 'update:modelValue', model: string): void
 }
+
+const props = defineProps<Props>()
+
+const emits = defineEmits<Emits>()
+
+const root = ref<HTMLInputElement>()
+
+const editEnabled = inject<boolean>('editEnabled')
+
+const vModel = useVModel(props, 'modelValue', emits)
+
+const validEmail = computed(() => isEmail(vModel.value))
 </script>
 
 <template>
-  <input v-if="editEnabled" ref="root" v-model="localState" />
+  <input v-if="editEnabled" ref="root" v-model="vModel" class="outline-none" />
   <a
     v-else-if="validEmail"
     class="caption py-2 text-primary underline hover:opacity-75"
-    :href="`mailto:${value}`"
+    :href="`mailto:${vModel}`"
     target="_blank"
   >
-    {{ value }}
+    {{ vModel }}
   </a>
-  <span v-else>{{ value }}</span>
+  <span v-else>{{ vModel }}</span>
 </template>

--- a/packages/nc-gui-v2/components/cell/Email.vue
+++ b/packages/nc-gui-v2/components/cell/Email.vue
@@ -25,12 +25,7 @@ const validEmail = computed(() => isEmail(vModel.value))
 
 <template>
   <input v-if="editEnabled" ref="root" v-model="vModel" class="outline-none prose-sm" />
-  <a
-    v-else-if="validEmail"
-    class="prose-sm underline hover:opacity-75"
-    :href="`mailto:${vModel}`"
-    target="_blank"
-  >
+  <a v-else-if="validEmail" class="prose-sm underline hover:opacity-75" :href="`mailto:${vModel}`" target="_blank">
     {{ vModel }}
   </a>
   <span v-else>{{ vModel }}</span>

--- a/packages/nc-gui-v2/components/cell/Email.vue
+++ b/packages/nc-gui-v2/components/cell/Email.vue
@@ -24,10 +24,10 @@ const validEmail = computed(() => isEmail(vModel.value))
 </script>
 
 <template>
-  <input v-if="editEnabled" ref="root" v-model="vModel" class="outline-none" />
+  <input v-if="editEnabled" ref="root" v-model="vModel" class="outline-none prose-sm" />
   <a
     v-else-if="validEmail"
-    class="caption py-2 text-primary underline hover:opacity-75"
+    class="prose-sm underline hover:opacity-75"
     :href="`mailto:${vModel}`"
     target="_blank"
   >

--- a/packages/nc-gui-v2/components/cell/Url.vue
+++ b/packages/nc-gui-v2/components/cell/Url.vue
@@ -34,7 +34,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <input class="outline-none" v-if="editEnabled" ref="root" v-model="vModel" />
+  <input v-if="editEnabled" ref="root" v-model="vModel" class="outline-none" />
   <nuxt-link v-else-if="isValid" class="py-2 underline hover:opacity-75" :to="value" target="_blank">{{ value }}</nuxt-link>
   <span v-else>{{ value }}</span>
 </template>

--- a/packages/nc-gui-v2/components/cell/Url.vue
+++ b/packages/nc-gui-v2/components/cell/Url.vue
@@ -8,11 +8,14 @@ interface Props {
 }
 
 const { modelValue: value } = defineProps<Props>()
+
 const emit = defineEmits(['update:modelValue'])
+
 const column = inject(ColumnInj)
+
 const editEnabled = inject<boolean>('editEnabled')
 
-const localState = computed({
+const vModel = computed({
   get: () => value,
   set: (val) => {
     if (!(column && column.meta && column.meta.validate) || isValidURL(val)) {
@@ -24,19 +27,16 @@ const localState = computed({
 const isValid = computed(() => value && isValidURL(value))
 
 const root = ref<HTMLInputElement>()
+
 onMounted(() => {
   root.value?.focus()
 })
 </script>
 
 <template>
-  <span v-if="editEnabled">
-    <input ref="root" v-model="localState" />
-  </span>
-  <span v-else>
-    <a v-if="isValid" class="caption py-2 text-primary underline hover:opacity-75" :href="value" target="_blank">{{ value }}</a>
-    <span v-else>{{ value }}</span>
-  </span>
+  <input class="outline-none" v-if="editEnabled" ref="root" v-model="vModel" />
+  <nuxt-link v-else-if="isValid" class="py-2 underline hover:opacity-75" :to="value" target="_blank">{{ value }}</nuxt-link>
+  <span v-else>{{ value }}</span>
 </template>
 
 <style scoped></style>

--- a/packages/nc-gui-v2/components/virtual-cell/Formula.vue
+++ b/packages/nc-gui-v2/components/virtual-cell/Formula.vue
@@ -35,7 +35,7 @@ const urls = computed(() => replaceUrlsWithLink(result.value))
     <div class="pa-2" @dblclick="showEditFormulaWarningMessage">
       <div v-if="urls" v-html="urls" />
       <div v-else>{{ result }}</div>
-      <div v-if="showEditFormulaWarning" class="text-left mt-2 text-[#e65100]">
+      <div v-if="showEditFormulaWarning" class="text-left text-wrap mt-2 text-[#e65100]">
         <!-- TODO: i18n -->
         Warning: Formula fields should be configured in the field menu dropdown.
       </div>


### PR DESCRIPTION
## Change Summary

ref: #2927

common - font size are not uniform

- Will revise in spreadsheet PR

display text was highlighted in blue in v1 for currency cell. is it by design to mark everything uniform in v2?

- Checked with Mert a month ago. It's not expected to show in Blue. In v2, they will display normally.

URL  - validation failure case, no pop-up error displayed

- in v1, i don't see a pop-up error

Email - validation failure case, no pop-up error displayed

- in v1, I don't see pop-up error. Current logic s that if it s not a valid email, it renders as a text instead of link with mailto

On editing a cell part of the formula, the cell value in the formula column didn't update. ignore if this will be picked up during spreadsheet activity

- I don't see there is an option to change the formula now. Will come back when it's ready.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)