### PR TITLE
fix(gui-v2): use promise reject when returning api error

### DIFF
--- a/packages/nc-gui-v2/composables/useApi/index.ts
+++ b/packages/nc-gui-v2/composables/useApi/index.ts
@@ -114,7 +114,7 @@ export function useApi<Data = any, RequestConfig = any>({
 
       onRequestFinish()
 
-      return requestError
+      return Promise.reject(requestError)
     },
   )
 
@@ -125,7 +125,7 @@ export function useApi<Data = any, RequestConfig = any>({
 
       onRequestFinish()
 
-      return apiResponse
+      return Promise.resolve(apiResponse)
     },
     (apiError) => {
       errorHook.trigger(apiError)
@@ -133,7 +133,7 @@ export function useApi<Data = any, RequestConfig = any>({
 
       onRequestFinish()
 
-      return apiError
+      return Promise.reject(apiError)
     },
   )
 

--- a/packages/nc-gui-v2/plugins/state.ts
+++ b/packages/nc-gui-v2/plugins/state.ts
@@ -3,7 +3,7 @@ import { defineNuxtPlugin } from '#app'
 import { useBreakpoints, useDark, useGlobal, watch } from '#imports'
 
 /**
- * Injects global state into nuxt app.
+ * Initialize global state and watches for changes
  *
  * @example
  * ```js


### PR DESCRIPTION
## Change Summary

* fix useApi not returning axios errors to the calling `catch` block

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
