### PR TITLE
fix(gui-v2): permission type not allowing wildcard

### DIFF
--- a/packages/nc-gui-v2/composables/useUIPermission/index.ts
+++ b/packages/nc-gui-v2/composables/useUIPermission/index.ts
@@ -33,9 +33,9 @@ export function useUIPermission() {
     // }
 
     return Object.entries<boolean>(roles).some(([role, hasRole]) => {
-      const rolePermission = rolePermissions[role as keyof typeof rolePermissions] as Permission
+      const rolePermission = rolePermissions[role as keyof typeof rolePermissions] as '*' | Record<Permission, true>
 
-      return hasRole && (rolePermission === '*' || (typeof rolePermission === 'object' && rolePermission[permission]))
+      return hasRole && (rolePermission === '*' || rolePermission[permission])
     })
   }
 

--- a/packages/nc-gui-v2/composables/useUIPermission/index.ts
+++ b/packages/nc-gui-v2/composables/useUIPermission/index.ts
@@ -35,11 +35,7 @@ export function useUIPermission() {
     return Object.entries<boolean>(roles).some(([role, hasRole]) => {
       const rolePermission = rolePermissions[role as keyof typeof rolePermissions] as Permission
 
-      return (
-        hasRole &&
-        (rolePermission === '*' ||
-          (typeof rolePermission === 'object' && rolePermission[permission as keyof typeof rolePermission]))
-      )
+      return hasRole && (rolePermission === '*' || (typeof rolePermission === 'object' && rolePermission[permission]))
     })
   }
 

--- a/packages/nc-gui-v2/composables/useUIPermission/index.ts
+++ b/packages/nc-gui-v2/composables/useUIPermission/index.ts
@@ -1,4 +1,4 @@
-import type { RolePermissions } from './rolePermissions'
+import type { Permission } from './rolePermissions'
 import rolePermissions from './rolePermissions'
 import { useState } from '#app'
 import { USER_PROJECT_ROLES } from '~/lib/constants'
@@ -7,7 +7,7 @@ export function useUIPermission() {
   const { $state } = useNuxtApp()
   const projectRoles = useState<Record<string, boolean>>(USER_PROJECT_ROLES, () => ({}))
 
-  const isUIAllowed = (permission: RolePermissions, _skipPreviewAs = false) => {
+  const isUIAllowed = (permission: Permission, _skipPreviewAs = false) => {
     const user = $state.user
     let userRoles = user?.value?.roles || {}
 
@@ -32,14 +32,13 @@ export function useUIPermission() {
     //   };
     // }
 
-    return Object.entries(roles).some(([role, hasRole]) => {
-      const rolePermission = rolePermissions[role as keyof typeof rolePermissions]
+    return Object.entries<boolean>(roles).some(([role, hasRole]) => {
+      const rolePermission = rolePermissions[role as keyof typeof rolePermissions] as Permission
 
       return (
         hasRole &&
-        (rolePermission === '*' || typeof rolePermission === 'object'
-          ? rolePermission[permission as keyof typeof rolePermission] === true
-          : false)
+        (rolePermission === '*' ||
+          (typeof rolePermission === 'object' && rolePermission[permission as keyof typeof rolePermission]))
       )
     })
   }

--- a/packages/nc-gui-v2/composables/useUIPermission/rolePermissions.ts
+++ b/packages/nc-gui-v2/composables/useUIPermission/rolePermissions.ts
@@ -40,9 +40,10 @@ export default rolePermissions
 
 type GetKeys<T> = T extends Record<string, any> ? keyof T : never
 
-export type RolePermissions<T extends typeof rolePermissions = typeof rolePermissions, K extends keyof T = keyof T> =
-  | T[K] extends string
+export type Permission<T extends typeof rolePermissions = typeof rolePermissions, K extends keyof T = keyof T> = K extends
+  | 'creator'
+  | 'owner'
   ? T[K]
-  : never & T[K] extends Record<string, any>
+  : never | T[K] extends Record<string, any>
   ? GetKeys<T[K]>
   : never


### PR DESCRIPTION
# What's changed?

* rename `RolePermissions` to `Permission`
* allow wildcard permission for creator and owner roles

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
