### PR TITLE
feat(gui-v2): add `useInjectionState` composable

### DIFF
--- a/packages/nc-gui-v2/composables/index.ts
+++ b/packages/nc-gui-v2/composables/index.ts
@@ -1,5 +1,6 @@
 export * from './useApi'
 export * from './useGlobal'
+export * from './useInjectionState'
 export * from './useUIPermission'
 export * from './useAttachment'
 export * from './useBelongsTo'

--- a/packages/nc-gui-v2/composables/useInjectionState/index.ts
+++ b/packages/nc-gui-v2/composables/useInjectionState/index.ts
@@ -1,0 +1,19 @@
+import type { InjectionKey } from 'vue'
+
+export function useInjectionState<Arguments extends any[], Return>(
+  composable: (...args: Arguments) => Return,
+): readonly [useProvidingState: (...args: Arguments) => void, useInjectedState: () => Return | undefined] {
+  const key: string | InjectionKey<Return> = Symbol('InjectionState')
+
+  const useProvidingState = (...args: Arguments) => {
+    const providedState = composable(...args)
+
+    provide(key, providedState)
+
+    return providedState
+  }
+
+  const useInjectedState = () => inject(key)
+
+  return [useProvidingState, useInjectedState]
+}


### PR DESCRIPTION
# What's changed?

* extends on VueUses' `createInjectionState`
* immediately returns injection state on provide

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
