### PR TITLE
refactor: remove user context information from webhook panel

### DIFF
--- a/packages/nc-gui-v2/components/webhook/Editor.vue
+++ b/packages/nc-gui-v2/components/webhook/Editor.vue
@@ -576,14 +576,11 @@ onMounted(() => {
       <a-row>
         <a-col :span="24">
           <div class="text-gray-600">
-            <em>Available context variables are <strong>data and user</strong></em>
+            <em>Use context variable <strong>data</strong> to refer the record under consideration</em>
 
             <a-tooltip bottom>
               <template #title>
-                <span>
-                  <strong>data</strong> : Row data <br />
-                  <strong>user</strong> : User information<br />
-                </span>
+                <span> <strong>data</strong> : Row data <br /> </span>
               </template>
               <MdiInformationIcon class="ml-2" />
             </a-tooltip>

--- a/packages/nc-gui-v2/components/webhook/Test.vue
+++ b/packages/nc-gui-v2/components/webhook/Test.vue
@@ -18,7 +18,6 @@ const meta = inject(MetaInj)
 
 const sampleData = ref({
   data: {},
-  user: {},
 })
 const activeKey = ref(0)
 
@@ -32,7 +31,6 @@ watch(
 async function loadSampleData() {
   sampleData.value = {
     data: await $api.dbTableWebhook.samplePayloadGet(meta?.value?.id as string, hook?.operation),
-    user: $state.user.value as Record<string, any>,
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
- Sending `user` context is not supported. Remove associated information from the webhook panel

## Change type
- [ ] refactor: (refactoring production code, eg. renaming a variable)

## Test/ Verification
locally verified
