### PR TITLE
fix(gui-v2): fix project schema for pg and mssql

### DIFF
--- a/packages/nc-gui-v2/pages/project/index/create-external.vue
+++ b/packages/nc-gui-v2/pages/project/index/create-external.vue
@@ -59,7 +59,7 @@ const validators = computed(() => {
           'dataSource.connection.database': [fieldRequiredValidator],
           ...([ClientType.PG, ClientType.MSSQL].includes(formState.dataSource.client)
             ? {
-                'dataSource.connection.searchPath.0': [fieldRequiredValidator],
+                'dataSource.searchPath.0': [fieldRequiredValidator],
               }
             : {}),
         }),
@@ -288,11 +288,11 @@ onMounted(() => {
         </a-form-item>
         <!-- Schema name -->
         <a-form-item
-          v-if="[ClientType.MSSQL, ClientType.PG].includes(formState.dataSource.client)"
+          v-if="[ClientType.MSSQL, ClientType.PG].includes(formState.dataSource.client) && formState.dataSource.searchPath"
           :label="$t('labels.schemaName')"
-          v-bind="validateInfos['dataSource.connection.searchPath.0']"
+          v-bind="validateInfos['dataSource.searchPath.0']"
         >
-          <a-input v-model:value="formState.dataSource.connection.searchPath[0]" size="small" />
+          <a-input v-model:value="formState.dataSource.searchPath[0]" size="small" />
         </a-form-item>
 
         <a-collapse ghost expand-icon-position="right" class="mt-6">

--- a/packages/nc-gui-v2/utils/projectCreateUtils.ts
+++ b/packages/nc-gui-v2/utils/projectCreateUtils.ts
@@ -12,7 +12,6 @@ export interface ProjectCreateForm {
           password: string
           port: number | string
           ssl?: Record<string, string>
-          searchPath?: string[]
         }
       | {
           client?: ClientType.SQLITE
@@ -22,6 +21,7 @@ export interface ProjectCreateForm {
           }
           useNullAsDefault?: boolean
         }
+    searchPath?: string[]
   }
   inflection: {
     inflectionColumn?: string
@@ -73,7 +73,6 @@ const sampleConnectionData: Record<ClientType | string, ProjectCreateForm['dataS
     user: 'postgres',
     password: 'password',
     database: '_test',
-    searchPath: ['public'],
     ssl: {
       ca: '',
       key: '',
@@ -110,7 +109,6 @@ const sampleConnectionData: Record<ClientType | string, ProjectCreateForm['dataS
     user: 'sa',
     password: 'Password123.',
     database: '_test',
-    searchPath: ['dbo'],
     ssl: {
       ca: '',
       key: '',
@@ -203,6 +201,11 @@ export const getDefaultConnectionConfig = (client: ClientType): ProjectCreateFor
   return {
     client,
     connection: sampleConnectionData[client],
+    searchPath: [ClientType.PG, ClientType.MSSQL].includes(client)
+      ? client === ClientType.PG
+        ? ['public']
+        : ['dbo']
+      : undefined,
   }
 }
 


### PR DESCRIPTION
External PostgreSQL & MsSQL connection on v2 always results with 'public' schema as we normally store searchPath in dataSource object rather than dataSource.connection

## Change Summary

Fixed property path for both clients.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
