### PR TITLE
fix(gui-v2): fix empty meta & feed default values

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet-column/CurrencyOptions.vue
+++ b/packages/nc-gui-v2/components/smartsheet-column/CurrencyOptions.vue
@@ -57,6 +57,13 @@ const message = computed(() => {
 function filterOption(input: string, option: Option) {
   return option.value.toUpperCase().includes(input.toUpperCase())
 }
+
+// set default value
+formState.value.meta = {
+  currency_locale: 'en-US',
+  currency_code: 'USD',
+  ...formState.value.meta,
+}
 </script>
 
 <template>

--- a/packages/nc-gui-v2/components/smartsheet-column/DurationOptions.vue
+++ b/packages/nc-gui-v2/components/smartsheet-column/DurationOptions.vue
@@ -10,6 +10,12 @@ const durationOptionList =
     // h:mm:ss (e.g. 3:45, 1:23:40)
     title: `${o.title} ${o.example}`,
   })) || []
+
+// set default value
+formState.value.meta = {
+  duration: 0,
+  ...formState.value.meta,
+}
 </script>
 
 <template>

--- a/packages/nc-gui-v2/components/smartsheet-column/RatingOptions.vue
+++ b/packages/nc-gui-v2/components/smartsheet-column/RatingOptions.vue
@@ -32,6 +32,17 @@ const iconList = [
 const advanced = ref(true)
 
 const picked = ref(formState.value.meta.color || enumColor.light[0])
+
+// set default value
+formState.value.meta = {
+  icons: {
+    full: 'mdi-star',
+    empty: 'mdi-star-outline',
+  },
+  color: '#fcb401',
+  max: 5,
+  ...formState.value.meta,
+}
 </script>
 
 <template>

--- a/packages/nc-gui-v2/composables/useColumnCreateStore.ts
+++ b/packages/nc-gui-v2/composables/useColumnCreateStore.ts
@@ -33,6 +33,7 @@ const [useProvideColumnCreateStore, useColumnCreateStore] = createInjectionState
   const formState = ref<Partial<Record<string, any>>>({
     title: 'title',
     uidt: UITypes.SingleLineText,
+    meta: {},
     ...(column || {}),
   })
 
@@ -92,7 +93,7 @@ const [useProvideColumnCreateStore, useColumnCreateStore] = createInjectionState
     const colProp = sqlUi?.value.getDataTypeForUiType(formState?.value as any, idType as any)
     formState.value = {
       ...formState.value,
-      meta: null,
+      meta: {},
       rqd: false,
       pk: false,
       ai: false,


### PR DESCRIPTION
## Change Summary

- set meta as `{}` rather than `null`
- set default values for each column options

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
