### PR TITLE
fix: info message error when using invite more option

### DIFF
--- a/packages/nc-gui-v2/components/tabs/auth/user-management/UsersModal.vue
+++ b/packages/nc-gui-v2/components/tabs/auth/user-management/UsersModal.vue
@@ -41,7 +41,7 @@ const validators = computed(() => {
     emails: [
       {
         validator: (rule: any, value: string, callback: (errMsg?: string) => void) => {
-          if (value.length === 0) {
+          if (!value || value.length === 0) {
             callback('Email is required')
             return
           }


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Use of invite-more button shows the default error; null check added

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)

https://user-images.githubusercontent.com/86527202/182288159-9a1411c7-efd2-49a3-b7a8-a2c756bc6c64.png