### PR TITLE
fix(gui-v2): abort renaming view on failed validation

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet-header/Cell.vue
+++ b/packages/nc-gui-v2/components/smartsheet-header/Cell.vue
@@ -5,7 +5,7 @@ import { inject, toRef } from 'vue'
 import { ColumnInj, IsFormInj, MetaInj } from '~/context'
 import { useProvideColumnCreateStore } from '#imports'
 
-const props = defineProps<{ column: ColumnType & { meta: any }; required: boolean; hideMenu?: boolean }>()
+const props = defineProps<{ column: ColumnType & { meta: any }; required?: boolean; hideMenu?: boolean }>()
 
 const hideMenu = toRef(props, 'hideMenu')
 

--- a/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
@@ -61,12 +61,12 @@ function markItem(id: string) {
 }
 
 /** validate view title */
-function validate(value?: string) {
-  if (!value || value.trim().length < 0) {
+function validate(view: Record<string, any>) {
+  if (!view.title || view.title.trim().length < 0) {
     return 'View name is required'
   }
 
-  if (views.value.every((v1) => v1.title !== value)) {
+  if (views.value.some((v) => v.title === view.title && v.id !== view.id)) {
     return 'View name should be unique'
   }
 
@@ -141,17 +141,6 @@ function changeView(view: { id: string; alias?: string; title?: string; type: Vi
 
 /** Rename a view */
 async function onRename(view: ViewType) {
-  const valid = validate(view.title)
-
-  if (valid !== true) {
-    notification.error({
-      message: valid,
-      duration: 2,
-    })
-
-    return
-  }
-
   try {
     await api.dbView.update(view.id!, {
       title: view.title,
@@ -195,6 +184,7 @@ function onDeleted() {
       :id="view.id"
       :key="view.id"
       :view="view"
+      :on-validate="validate"
       class="transition-all ease-in duration-300"
       :class="[
         isMarked === view.id ? 'bg-gray-200' : '',

--- a/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
@@ -148,12 +148,14 @@ async function onRename(view: ViewType) {
       message: valid,
       duration: 2,
     })
+
+    return
   }
 
   try {
     await api.dbView.update(view.id!, {
       title: view.title,
-      order: view.order,
+      order: String(view.order),
     })
 
     notification.success({

--- a/packages/nc-gui-v2/components/smartsheet/sidebar/RenameableMenuItem.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/RenameableMenuItem.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import type { ViewTypes } from 'nocodb-sdk'
+import { notification } from 'ant-design-vue'
 import { viewIcons } from '~/utils'
-import { useDebounceFn, useNuxtApp, useVModel } from '#imports'
+import { onKeyStroke, useDebounceFn, useNuxtApp, useVModel } from '#imports'
 
 interface Props {
   view: Record<string, any>
+  onValidate: (view: Record<string, any>) => boolean | string
 }
 
 interface Emits {
@@ -98,6 +100,18 @@ async function onDelete() {
 /** Rename a view */
 async function onRename() {
   if (!isEditing) return
+
+  const isValid = props.onValidate(vModel.value)
+
+  if (isValid !== true) {
+    notification.error({
+      message: isValid,
+      duration: 2,
+    })
+
+    onCancel()
+    return
+  }
 
   if (vModel.value.title === '' || vModel.value.title === originalTitle) {
     onCancel()

--- a/packages/nc-gui-v2/components/smartsheet/sidebar/RenameableMenuItem.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/RenameableMenuItem.vue
@@ -8,11 +8,11 @@ interface Props {
 }
 
 interface Emits {
-  (event: 'openModal', data: { type: ViewTypes; title?: string }): void
   (event: 'update:view', data: Record<string, any>): void
   (event: 'changeView', view: Record<string, any>): void
   (event: 'rename', view: Record<string, any>): void
   (event: 'delete', view: Record<string, any>): void
+  (event: 'openModal', data: { type: ViewTypes; title?: string; copyViewId?: string }): void
 }
 
 const props = defineProps<Props>()


### PR DESCRIPTION
## Change Summary

* abort renaming view on failed validation

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
