### PR TITLE
refactor(gui-v2): remove vuetify from language switcher

### DIFF
--- a/packages/nc-gui-v2/components/general/Language.vue
+++ b/packages/nc-gui-v2/components/general/Language.vue
@@ -41,7 +41,7 @@ onMounted(() => {
     <MaterialSymbolsTranslate v-bind="$attrs" class="md:text-xl cursor-pointer nc-menu-translate" />
 
     <template #overlay>
-      <a-menu class="scrollbar min-w-50 max-h-90vh overflow-auto !py-0 dark:(!bg-gray-800 !text-white)">
+      <a-menu class="scrollbar-thin-dull min-w-50 max-h-90vh overflow-auto !py-0 dark:(!bg-gray-800 !text-white)">
         <a-menu-item
           v-for="lang of languages"
           :key="lang"
@@ -71,9 +71,3 @@ onMounted(() => {
     </template>
   </a-dropdown>
 </template>
-
-<style scoped>
-.scrollbar {
-  @apply scrollbar scrollbar-thin scrollbar-thumb-rounded scrollbar-thumb-primary scrollbar-track-white dark:(!scrollbar-track-gray-900);
-}
-</style>

--- a/packages/nc-gui-v2/nuxt.config.ts
+++ b/packages/nc-gui-v2/nuxt.config.ts
@@ -106,4 +106,9 @@ export default defineNuxtConfig({
   image: {
     dir: 'assets/',
   },
+
+  autoImports: {
+    dirs: ['./context', './utils', './lib'],
+    imports: [{ name: 'useI18n', from: 'vue-i18n' }],
+  },
 })


### PR DESCRIPTION
## Change Summary

* use ant-design-vue instead

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
