### PR TITLE
fix(gui-v2): easter icons appear when toggling toolbar icons twice

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet/sidebar/index.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/index.vue
@@ -133,7 +133,7 @@ function onCreate(view: GridType | FormType | KanbanType | GalleryType) {
           <template #title> {{ $t('objects.webhooks') }}</template>
 
           <div class="nc-sidebar-right-item hover:after:bg-gray-300">
-            <MdiHook />
+            <MdiHook @click.stop />
           </div>
         </a-tooltip>
 
@@ -143,7 +143,7 @@ function onCreate(view: GridType | FormType | KanbanType | GalleryType) {
           <template #title> Get API Snippet</template>
 
           <div class="nc-sidebar-right-item group hover:after:bg-yellow-500">
-            <MdiXml class="group-hover:(!text-white)" />
+            <MdiXml class="group-hover:(!text-white)" @click.stop />
           </div>
         </a-tooltip>
 


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Fix extension for https://github.com/nocodb/nocodb/commit/5ec7971c145a0a310e0ed3e8fc588d55c07096b2
`Webhook` & `API Snippet` multiple click was opening easter egg menu

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification
Locally verified
