### PR TITLE
Improved email and password validation of signup page

### DIFF
--- a/packages/nc-gui-v2/pages/signup/[[token]].vue
+++ b/packages/nc-gui-v2/pages/signup/[[token]].vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { validatePassword } from 'nocodb-sdk'
 import {
   definePageMeta,
   extractSdkResponseErrorMsg,
@@ -43,7 +44,7 @@ const formRules = {
     {
       validator: (_: unknown, v: string) => {
         return new Promise((resolve, reject) => {
-          if (isEmail(v)) return resolve(true)
+          if (!v?.length || isEmail(v)) return resolve(true)
           reject(new Error(t('msg.error.signUpRules.emailInvalid')))
         })
       },
@@ -51,9 +52,15 @@ const formRules = {
     },
   ],
   password: [
-    // Password is required
-    { required: true, message: t('msg.error.signUpRules.passwdRequired') },
-    { min: 8, message: t('msg.error.signUpRules.passwdLength') },
+    {
+      validator: (_: unknown, v: string) => {
+        return new Promise((resolve, reject) => {
+          const { error, valid } = validatePassword(v)
+          if (valid) return resolve(true)
+          reject(new Error(error))
+        })
+      },
+    },
   ],
 }
 


### PR DESCRIPTION
Ref: #3220

- Added more reactive password hint.
- Email validation doesn't show email is required and invalid in the case of empty email field.

UI:
<img width="605" alt="image" src="https://user-images.githubusercontent.com/35809690/185305403-f46afa93-9809-4886-bed4-6934a2cd7974.png">
<img width="572" alt="image" src="https://user-images.githubusercontent.com/35809690/185305421-edaef516-0774-4de4-97ad-03ba91b5e937.png">
