### PR TITLE
fix(gui-v2): reload the page if the same form view is clicked

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
@@ -137,6 +137,10 @@ onMounted(() => menuRef && initSortable(menuRef.$el))
 /** Navigate to view by changing url param */
 function changeView(view: { id: string; alias?: string; title?: string; type: ViewTypes }) {
   router.push({ params: { viewTitle: view.title || '' } })
+  if (view.type === 1 && selected.value[0] === view.id) {
+    // reload the page if the same form view is clicked
+    router.go(0)
+  }
 }
 
 /** Rename a view */


### PR DESCRIPTION
## Change Summary

- ref: #3161 

>  After submit form, click on form view name in right nav bar should re-open view 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
