### PR TITLE
fix(gui-v2): incorrect sheet names in excel import

### DIFF
--- a/packages/nc-gui-v2/components/template/Editor.vue
+++ b/packages/nc-gui-v2/components/template/Editor.vue
@@ -92,7 +92,7 @@ const data = reactive<{ title: string | null; name: string; tables: (TableType &
 
 const validators = computed(() =>
   data.tables.reduce<Record<string, [typeof fieldRequiredValidator]>>((acc, table, tableIdx) => {
-    acc[`tables.${tableIdx}.table_name`] = [fieldRequiredValidator]
+    acc[`tables.${tableIdx}.ref_table_name`] = [fieldRequiredValidator]
     hasSelectColumn.value[tableIdx] = false
 
     table.columns?.forEach((column, columnIdx) => {
@@ -425,8 +425,8 @@ async function importTemplate() {
           }
         }
         const tableMeta = await $api.dbTable.create(project?.value?.id as string, {
-          table_name: table.table_name,
-          // leave title empty to get a generated one based on table_name
+          table_name: table.ref_table_name,
+          // leave title empty to get a generated one based on ref_table_name
           title: '',
           columns: table.columns,
         })
@@ -581,9 +581,9 @@ onMounted(() => {
         >
           <a-collapse-panel v-for="(table, tableIdx) of data.tables" :key="tableIdx">
             <template #header>
-              <a-form-item v-if="editableTn[tableIdx]" v-bind="validateInfos[`tables.${tableIdx}.table_name`]" no-style>
+              <a-form-item v-if="editableTn[tableIdx]" v-bind="validateInfos[`tables.${tableIdx}.ref_table_name`]" no-style>
                 <a-input
-                  v-model:value="table.table_name"
+                  v-model:value="table.ref_table_name"
                   class="max-w-xs"
                   size="large"
                   hide-details
@@ -595,7 +595,7 @@ onMounted(() => {
 
               <span v-else class="font-weight-bold text-lg flex items-center gap-2" @click="setEditableTn(tableIdx, true)">
                 <mdi-table class="text-primary" />
-                {{ table.table_name }}
+                {{ table.ref_table_name }}
               </span>
             </template>
 


### PR DESCRIPTION
## Change Summary

- ref: #3316 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Using [simple.xlsx](https://github.com/nocodb/nocodb/files/9414143/simple.xlsx)

![image](https://user-images.githubusercontent.com/35857179/186373793-5400e553-65c8-44d0-9afa-662457b155af.png)

