### PR TITLE
chore(nc-gui): remove conflicting lint rules

### DIFF
--- a/packages/nc-gui/.eslintrc.json
+++ b/packages/nc-gui/.eslintrc.json
@@ -9,7 +9,8 @@
   ],
   "extends": [
     "@nuxtjs",
-    "plugin:@intlify/vue-i18n/recommended"
+    "plugin:@intlify/vue-i18n/recommended",
+    "prettier"
   ],
   "rules": {
     "no-console": "off",

--- a/packages/nc-gui/components/project/spreadsheet/components/ExpandedForm.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/ExpandedForm.vue
@@ -678,7 +678,6 @@ h5 {
   padding: 8px;
   border-radius: 8px;
 }
-
 </style>
 <!--
 /**

--- a/packages/nc-gui/components/project/spreadsheet/components/MoreActions.vue
+++ b/packages/nc-gui/components/project/spreadsheet/components/MoreActions.vue
@@ -257,7 +257,7 @@ export default {
 
       try {
         while (!isNaN(offset) && offset > -1) {
-          const res = await this.getExportData({ offset, exportType: ExportTypes.CSV, responseType: 'blob' })
+          const res = await this.getExportData({ offset, exportType: ExportTypes.CSV, responseType: 'blob' });
           const { data } = res;
 
           offset = +res.headers['nc-export-offset'];

--- a/packages/nc-gui/components/utils/Language.vue
+++ b/packages/nc-gui/components/utils/Language.vue
@@ -2,9 +2,7 @@
   <div>
     <v-menu top offset-y>
       <template #activator="{ on }">
-        <v-icon size="20" class="ml-2 nc-menu-translate" v-on="on">
-          mdi-translate
-        </v-icon>
+        <v-icon size="20" class="ml-2 nc-menu-translate" v-on="on"> mdi-translate </v-icon>
       </template>
       <v-list dense class="nc-language-list">
         <v-list-item-group v-model="language">
@@ -71,78 +69,78 @@ export default {
       vi: 'Tiếng Việt',
       zh_CN: '大陆简体',
       zh_HK: '香港繁體',
-      zh_TW: '臺灣正體'
-    }
+      zh_TW: '臺灣正體',
+    },
   }),
   computed: {
     languages() {
-      return ((this.$i18n && this.$i18n.availableLocales) || ['en']).sort()
+      return ((this.$i18n && this.$i18n.availableLocales) || ['en']).sort();
     },
     language: {
       get() {
-        return this.$store.state.settings.language
+        return this.$store.state.settings.language;
       },
       set(val) {
-        this.$store.commit('settings/MutLanguage', val)
-        this.applyDirection()
-      }
-    }
+        this.$store.commit('settings/MutLanguage', val);
+        this.applyDirection();
+      },
+    },
   },
   mounted() {
-    this.applyDirection()
+    this.applyDirection();
   },
   methods: {
     applyDirection() {
-      const targetDirection = this.isRtlLang() ? 'rtl' : 'ltr'
-      const oppositeDirection = targetDirection == 'ltr' ? 'rtl' : 'ltr'
-      document.body.classList.remove(oppositeDirection)
-      document.body.classList.add(targetDirection)
-      document.body.style.direction = targetDirection
+      const targetDirection = this.isRtlLang() ? 'rtl' : 'ltr';
+      const oppositeDirection = targetDirection == 'ltr' ? 'rtl' : 'ltr';
+      document.body.classList.remove(oppositeDirection);
+      document.body.classList.add(targetDirection);
+      document.body.style.direction = targetDirection;
     },
     isRtlLang() {
-      return ['fa', 'ar'].includes(this.language)
+      return ['fa', 'ar'].includes(this.language);
     },
     changeLan(lan) {
-      this.language = lan
-      const count = 200
+      this.language = lan;
+      const count = 200;
       const defaults = {
-        origin: { y: 0.7 }
-      }
+        origin: { y: 0.7 },
+      };
 
       function fire(particleRatio, opts) {
         window.confetti(
           Object.assign({}, defaults, opts, {
-            particleCount: Math.floor(count * particleRatio)
+            particleCount: Math.floor(count * particleRatio),
           })
-        )
+        );
       }
 
       fire(0.25, {
         spread: 26,
-        startVelocity: 55
-      })
+        startVelocity: 55,
+      });
       fire(0.2, {
-        spread: 60
-      })
+        spread: 60,
+      });
       fire(0.35, {
         spread: 100,
         decay: 0.91,
-        scalar: 0.8
-      })
+        scalar: 0.8,
+      });
       fire(0.1, {
         spread: 120,
         startVelocity: 25,
         decay: 0.92,
-        scalar: 1.2
-      })
+        scalar: 1.2,
+      });
       fire(0.1, {
         spread: 120,
-        startVelocity: 45
-      })
-      this.$e('c:navbar:lang', { lang: lan })
-    }
-  }
-}
+        startVelocity: 45,
+      });
+      this.$e('c:navbar:lang', { lang: lan });
+    },
+  },
+};
 </script>
 
 <style scoped lang="scss">

--- a/packages/nc-gui/package-lock.json
+++ b/packages/nc-gui/package-lock.json
@@ -69,6 +69,7 @@
         "babel-eslint": "^10.1.0",
         "cross-env": "^7.0.3",
         "eslint": "^7.31.0",
+        "eslint-config-prettier": "^8.5.0",
         "monaco-editor-webpack-plugin": "^1.9.1",
         "sass": "~1.32.12",
         "vue-eslint-parser": "^7.9.0"
@@ -6693,6 +6694,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -23273,6 +23286,13 @@
           }
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "16.0.3",

--- a/packages/nc-gui/package.json
+++ b/packages/nc-gui/package.json
@@ -73,6 +73,7 @@
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.3",
     "eslint": "^7.31.0",
+    "eslint-config-prettier": "^8.5.0",
     "monaco-editor-webpack-plugin": "^1.9.1",
     "sass": "~1.32.12",
     "vue-eslint-parser": "^7.9.0"


### PR DESCRIPTION
## Change Summary

While nc-gui still exists and has recently added prettier config, I hope it is a good idea to avoid conflicts with eslint rules. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
