### PR TITLE
vue3: Forced meta loading when tab changes

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet/Grid.vue
+++ b/packages/nc-gui-v2/components/smartsheet/Grid.vue
@@ -79,6 +79,7 @@ const expandedFormRowState = ref<Record<string, any>>()
 const visibleColLength = $computed(() => fields.value?.length)
 
 const {
+  loading,
   loadData,
   paginationData,
   formattedData: data,
@@ -311,7 +312,10 @@ const onNavigate = (dir: NavigateDir) => {
 
 <template>
   <div class="flex flex-col h-full min-h-0 w-full">
-    <div class="nc-grid-wrapper min-h-0 flex-1 scrollbar-thin-dull">
+    <div v-if="loading" class="flex items-center justify-center h-full w-full">
+      <a-spin size="large" />
+    </div>
+    <div v-else class="nc-grid-wrapper min-h-0 flex-1 scrollbar-thin-dull">
       <a-dropdown v-model:visible="contextMenu" :trigger="['contextmenu']">
         <table
           ref="smartTable"

--- a/packages/nc-gui-v2/components/smartsheet/Grid.vue
+++ b/packages/nc-gui-v2/components/smartsheet/Grid.vue
@@ -79,7 +79,7 @@ const expandedFormRowState = ref<Record<string, any>>()
 const visibleColLength = $computed(() => fields.value?.length)
 
 const {
-  loading,
+  isLoading,
   loadData,
   paginationData,
   formattedData: data,
@@ -312,7 +312,7 @@ const onNavigate = (dir: NavigateDir) => {
 
 <template>
   <div class="flex flex-col h-full min-h-0 w-full">
-    <div v-if="loading" class="flex items-center justify-center h-full w-full">
+    <div v-if="isLoading" class="flex items-center justify-center h-full w-full">
       <a-spin size="large" />
     </div>
     <div v-else class="nc-grid-wrapper min-h-0 flex-1 scrollbar-thin-dull">

--- a/packages/nc-gui-v2/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui-v2/components/tabs/Smartsheet.vue
@@ -10,7 +10,6 @@ import {
   MetaInj,
   OpenNewRecordFormHookInj,
   ReloadViewDataHookInj,
-  TabMetaInj,
   computed,
   inject,
   provide,
@@ -18,12 +17,11 @@ import {
   useMetas,
   useProvideSmartsheetStore,
   watch,
-  watchEffect,
 } from '#imports'
 
 import type { TabItem } from '~/composables'
 
-const { getMeta, metas } = useMetas()
+const { metas } = useMetas()
 
 const activeView = ref()
 
@@ -35,12 +33,7 @@ const tabMeta = inject(
   TabMetaInj,
   computed(() => ({} as TabItem)),
 )
-
 const meta = computed<TableType>(() => metas.value?.[tabMeta?.value?.id as string])
-
-watchEffect(async () => {
-  await getMeta(tabMeta?.value?.id as string)
-})
 
 const reloadEventHook = createEventHook<void>()
 const openNewRecordFormHook = createEventHook<void>()
@@ -52,7 +45,6 @@ provideSidebar({ storageKey: 'nc-right-sidebar' })
 
 // todo: move to store
 provide(MetaInj, meta)
-provide(TabMetaInj, tabMeta)
 provide(ActiveViewInj, activeView)
 provide(IsLockedInj, isLocked)
 provide(ReloadViewDataHookInj, reloadEventHook)
@@ -61,10 +53,6 @@ provide(FieldsInj, fields)
 provide(IsFormInj, isForm)
 
 const treeViewIsLockedInj = inject('TreeViewIsLockedInj', ref(false))
-
-watch(tabMeta, async (newTabMeta, oldTabMeta) => {
-  if (newTabMeta !== oldTabMeta && newTabMeta?.id) await getMeta(newTabMeta.id)
-})
 
 watch(isLocked, (nextValue) => (treeViewIsLockedInj.value = nextValue), { immediate: true })
 </script>

--- a/packages/nc-gui-v2/composables/useViewData.ts
+++ b/packages/nc-gui-v2/composables/useViewData.ts
@@ -10,6 +10,7 @@ import {
   getHTMLEncodedText,
   useProject,
   useUIPermission,
+  useApi
 } from '#imports'
 
 const formatData = (list: Record<string, any>[]) =>
@@ -38,8 +39,7 @@ export function useViewData(
     throw new Error('Table meta is not available')
   }
 
-  const loading = ref(false)
-  const error = ref<any>()
+  const { api, isLoading, error } = useApi()
   const _paginationData = ref<PaginatedType>({ page: 1, pageSize: 25 })
   const aggCommentCount = ref<{ row_id: string; count: number }[]>([])
   const galleryData = ref<GalleryType>()
@@ -115,27 +115,19 @@ export function useViewData(
   }
 
   const loadData = async (params: Parameters<Api<any>['dbViewRow']['list']>[4] = {}) => {
-    try {
-      if ((!project?.value?.id || !meta?.value?.id || !viewMeta?.value?.id) && !isPublic.value) return
-      loading.value = true
-      error.value = null
-      const response = !isPublic.value
-        ? await $api.dbViewRow.list('noco', project.value.id!, meta.value.id!, viewMeta!.value.id, {
-            ...params,
-            ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
-            ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
-            where: where?.value,
-          })
-        : await fetchSharedViewData()
-      formattedData.value = formatData(response.list)
-      paginationData.value = response.pageInfo
+    if ((!project?.value?.id || !meta?.value?.id || !viewMeta?.value?.id) && !isPublic.value) return
+    const response = !isPublic.value
+      ? await api.dbViewRow.list('noco', project.value.id!, meta.value.id!, viewMeta!.value.id, {
+        ...params,
+        ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
+        ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
+        where: where?.value,
+      })
+      : await fetchSharedViewData()
+    formattedData.value = formatData(response.list)
+    paginationData.value = response.pageInfo
 
-      await loadAggCommentsCount()
-    } catch (e: any) {
-      error.value = e
-    } finally {
-      loading.value = false
-    }
+    await loadAggCommentsCount()
   }
 
   const loadGalleryData = async () => {
@@ -201,7 +193,8 @@ export function useViewData(
           value: getHTMLEncodedText(toUpdate.row[property]),
           prev_value: getHTMLEncodedText(toUpdate.oldRow[property]),
         })
-        .then(() => {})
+        .then(() => {
+        })
 
       /** update row data(to sync formula and other related columns) */
       Object.assign(toUpdate.row, updatedRowData)
@@ -243,7 +236,7 @@ export function useViewData(
 
   const deleteRowById = async (id: string) => {
     if (!id) {
-      throw new Error("Delete not allowed for table which doesn't have primary Key")
+      throw new Error('Delete not allowed for table which doesn\'t have primary Key')
     }
 
     const res: any = await $api.dbViewRow.delete(
@@ -361,7 +354,7 @@ export function useViewData(
 
   return {
     error,
-    loading,
+    isLoading,
     loadData,
     paginationData,
     queryParams,

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
@@ -7,10 +7,19 @@ import MdiView from '~icons/mdi/eye-circle-outline'
 import MdiAccountGroup from '~icons/mdi/account-group'
 
 const { tabs, activeTabIndex, activeTab, closeTab } = useTabs()
+const { getMeta } = useMetas()
 
 const { isLoading } = useGlobal()
 
 provide(TabMetaInj, activeTab)
+
+watch(
+  () => activeTab?.value?.id,
+  async () => {
+    await getMeta(activeTab?.value?.id as string, true)
+  },
+  { immediate: true },
+)
 
 const icon = (tab: TabItem) => {
   switch (tab.type) {

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
@@ -12,7 +12,6 @@ const { isLoading } = useGlobal()
 
 provide(TabMetaInj, activeTab)
 
-
 const icon = (tab: TabItem) => {
   switch (tab.type) {
     case TabType.TABLE:

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index.vue
@@ -7,19 +7,11 @@ import MdiView from '~icons/mdi/eye-circle-outline'
 import MdiAccountGroup from '~icons/mdi/account-group'
 
 const { tabs, activeTabIndex, activeTab, closeTab } = useTabs()
-const { getMeta } = useMetas()
 
 const { isLoading } = useGlobal()
 
 provide(TabMetaInj, activeTab)
 
-watch(
-  () => activeTab?.value?.id,
-  async () => {
-    await getMeta(activeTab?.value?.id as string, true)
-  },
-  { immediate: true },
-)
 
 const icon = (tab: TabItem) => {
   switch (tab.type) {
@@ -101,6 +93,7 @@ function onEdit(targetKey: number, action: 'add' | 'remove' | string) {
     .ant-tabs-nav-add {
       @apply !hidden;
     }
+
     .ant-tabs-nav-more {
       @apply text-white;
     }

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index/[type]/[title]/[[viewTitle]].vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index/[type]/[title]/[[viewTitle]].vue
@@ -1,7 +1,8 @@
-<script>
-export default {
-  name: 'Index',
-}
+<script setup lang="ts">
+const { getMeta } = useMetas()
+const route = useRoute()
+
+await getMeta(route.params.title as string, true)
 </script>
 
 <template>

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index/[type]/[title]/[[viewTitle]].vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index/index/[type]/[title]/[[viewTitle]].vue
@@ -1,12 +1,18 @@
 <script setup lang="ts">
 const { getMeta } = useMetas()
 const route = useRoute()
+const loading = ref(true)
 
-await getMeta(route.params.title as string, true)
+getMeta(route.params.title as string, true).finally(() => {
+  loading.value = false
+})
 </script>
 
 <template>
-  <TabsSmartsheet />
+  <div v-if="loading" class="flex items-center justify-center h-full w-full">
+    <a-spin size="large" />
+  </div>
+  <TabsSmartsheet v-else />
 </template>
 
 <style scoped></style>


### PR DESCRIPTION
Ref: https://github.com/nocodb/nocodb/issues/3089 

re #3340

Known issue:
- On tab change api is called twice and state related to tab is changed multiple times.

<img width="1029" alt="image" src="https://user-images.githubusercontent.com/35809690/186633357-def51eab-0f4a-4ad0-aca8-7334be39d230.png">

Here we are logging on changes on activeTab state in page(`index.vue`) and changes on the `tabs.value?.[activeTabIndex.value]` (activeTab is just a computed of this) (`useTabs.ts`)