### PR TITLE
fix: avoid complete page reload on clicking view name in right navbar

### DIFF
--- a/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
+++ b/packages/nc-gui-v2/components/smartsheet/sidebar/MenuTop.vue
@@ -146,7 +146,11 @@ function changeView(view: { id: string; alias?: string; title?: string; type: Vi
   router.push({ params: { viewTitle: view.title || '' } })
   if (view.type === 1 && selected.value[0] === view.id) {
     // reload the page if the same form view is clicked
-    router.go(0)
+    // router.go(0)
+    // fix me: router.go(0) reloads entire page. need to reload only the form view
+    router.replace({ query: { reload: 'true' } }).then(() => {
+      router.replace({ query: {} })
+    })
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Kludge: trigger route update twice. But avoids a complete reload of page from the beginning.

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification
verified locally