### PR TITLE
fix: tab level state

### DIFF
--- a/packages/nc-gui/components/cell/MultiSelect.vue
+++ b/packages/nc-gui/components/cell/MultiSelect.vue
@@ -1,8 +1,7 @@
 <script lang="ts" setup>
 import tinycolor from 'tinycolor2'
 import type { Select as AntSelect } from 'ant-design-vue'
-import { SelectOptionType } from 'nocodb-sdk'
-import type { SelectOptionsType } from 'nocodb-sdk'
+import type { SelectOptionType, SelectOptionsType } from 'nocodb-sdk'
 import {
   ActiveCellInj,
   ColumnInj,

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -87,7 +87,7 @@ watch(
   () => activeView.value?.id,
   (n, o) => {
     if (!nested && n !== o && (hookId || !webHook)) loadFilters(hookId as string)
-  }
+  },
 )
 
 loadFilters(hookId as string)

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -86,10 +86,11 @@ const types = computed(() => {
 watch(
   () => activeView.value?.id,
   (n, o) => {
-    if (n !== o && (hookId || !webHook)) loadFilters(hookId as string)
-  },
-  { immediate: true },
+    if (!nested && n !== o && (hookId || !webHook)) loadFilters(hookId as string)
+  }
 )
+
+loadFilters(hookId as string)
 
 watch(
   () => nonDeletedFilters.value.length,

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -86,6 +86,7 @@ const types = computed(() => {
 watch(
   () => activeView.value?.id,
   (n, o) => {
+    // if nested no need to reload since it will get reloaded from parent
     if (!nested && n !== o && (hookId || !webHook)) loadFilters(hookId as string)
   },
 )
@@ -154,6 +155,7 @@ defineExpose({
             <div class="col-span-5">
               <LazySmartsheetToolbarColumnFilter
                 v-if="filter.id || filter.children"
+                :key="filter.id ?? i"
                 ref="localNestedFilters"
                 v-model="filter.children"
                 :parent-id="filter.id"

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilterMenu.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilterMenu.vue
@@ -29,7 +29,7 @@ const { $e } = useNuxtApp()
 const { nestedFilters } = useSmartsheetStoreOrThrow()
 
 // todo: avoid duplicate api call by keeping a filter store
-const { activeView, nonDeletedFilters, loadFilters } = useViewFilters(
+const { nonDeletedFilters, loadFilters } = useViewFilters(
   activeView!,
   undefined,
   computed(() => true),

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilterMenu.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilterMenu.vue
@@ -29,8 +29,8 @@ const { $e } = useNuxtApp()
 const { nestedFilters } = useSmartsheetStoreOrThrow()
 
 // todo: avoid duplicate api call by keeping a filter store
-const { nonDeletedFilters, loadFilters } = useViewFilters(
-  activeView,
+const { activeView, nonDeletedFilters, loadFilters } = useViewFilters(
+  activeView!,
   undefined,
   computed(() => true),
   () => false,

--- a/packages/nc-gui/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui/components/tabs/Smartsheet.vue
@@ -37,13 +37,34 @@ const meta = computed<TableType | undefined>(() => activeTab.value && metas.valu
 
 const reloadEventHook = createEventHook()
 
-const { isGallery, isGrid, isForm, isKanban, isLocked, nestedFilters } = useProvideSmartsheetStore(activeView, meta)
+const { isGallery, isGrid, isForm, isKanban, isLocked, nestedFilters, sorts } = useProvideSmartsheetStore(activeView, meta)
 
 const openNewRecordFormHook = createEventHook()
 
 const reloadViewMetaEventHook = createEventHook()
 
 useProvideKanbanViewStore(meta, activeView)
+
+
+/** keep view level state in tabMeta and restore on view change */
+watch(nestedFilters, (newFilters) => {
+  activeTab.value.state = activeTab.value.state || {}
+  activeTab.value.state[activeView.value.id] = activeTab.value.state[activeView.value.id] || {}
+  activeTab.value.state[activeView.value.id].filters = newFilters
+})
+
+watch(sorts, (newSorts) => {
+  activeTab.value.state = activeTab.value.state || {}
+  activeTab.value.state[activeView.value.id] = activeTab.value.state[activeView.value.id] || {}
+  activeTab.value.state[activeView.value.id].sorts = newSorts
+})
+
+watch(activeView, (newView: ViewType) => {
+  if (activeTab.value.state?.[newView.id!]?.filters)
+    nestedFilters.value = activeTab.value.state?.[newView.id!]?.filters || []
+  if (activeTab.value.state?.[newView.id!]?.sorts)
+    sorts.value = activeTab.value.state?.[newView.id!]?.sorts || []
+})
 
 // todo: move to store
 provide(MetaInj, meta)

--- a/packages/nc-gui/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui/components/tabs/Smartsheet.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import type { ColumnType, TableType, ViewType } from 'nocodb-sdk'
-import type { Ref } from 'vue'
-import { useUIPermission } from '#imports'
+import type { ColumnType, TableType } from 'nocodb-sdk'
 import SmartsheetGrid from '../smartsheet/Grid.vue'
 import {
   ActiveViewInj,
@@ -21,6 +19,8 @@ import {
   useMetas,
   useProvideKanbanViewStore,
   useProvideSmartsheetStore,
+  useUIPermission,
+  watch,
 } from '#imports'
 import type { TabItem } from '~/lib'
 
@@ -44,43 +44,10 @@ const { isGallery, isGrid, isForm, isKanban, isLocked, nestedFilters, sorts } = 
 
 const openNewRecordFormHook = createEventHook()
 
-const reloadViewMetaEventHook = createEventHook()
+const reloadEventHook = createEventHook<void | boolean>()
+const openNewRecordFormHook = createEventHook<void>()
 
-useProvideKanbanViewStore(meta, activeView)
-
-const { isUIAllowed } = useUIPermission()
-
-/** keep view level state in tabMeta and restore on view change */
-watch(nestedFilters, (newFilters) => {
-  activeTab.value.state = activeTab.value.state || new Map()
-  if (!activeTab.value.state.has(activeView.value.id)) {
-    activeTab.value.state.set(activeView.value.id, new Map())
-  }
-  activeTab.value.state.get(activeView.value.id)!.set('filters', newFilters)
-})
-
-watch(sorts, (newSorts) => {
-  activeTab.value.state = activeTab.value.state || new Map()
-  if (!activeTab.value.state.has(activeView.value.id)) {
-    activeTab.value.state.set(activeView.value.id, new Map())
-  }
-  activeTab.value.state.get(activeView.value.id)!.set('sorts', newSorts)
-})
-
-watch(activeView, (newView: ViewType) => {
-  if(!newView || !activeTab.value?.state?.get(newView.id as string)) return
-
-  if (
-    activeTab.value?.state?.get(newView.id as string)?.has('filters') &&
-    !isUIAllowed('filterSync') &&
-    !isUIAllowed('filterChildrenRead')
-  ) {
-    nestedFilters.value = activeTab.value?.state?.get(newView.id as string)?.get('filters') || []
-  }
-  if (activeTab.value?.state?.get(newView.id as string)?.has('sorts') && !isUIAllowed('sortSync')) {
-    nestedFilters.value = activeTab.value?.state?.get(newView.id as string)?.get('sorts') || []
-  }
-})
+const { isGallery, isGrid, isForm, isLocked } = useProvideSmartsheetStore(activeView, meta)
 
 // todo: move to store
 provide(MetaInj, meta)

--- a/packages/nc-gui/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui/components/tabs/Smartsheet.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ColumnType, TableType } from 'nocodb-sdk'
+import type { ColumnType, TableType, ViewType } from 'nocodb-sdk'
 import {
   ActiveViewInj,
   FieldsInj,
@@ -37,7 +37,7 @@ const meta = computed<TableType | undefined>(() => activeTab.value && metas.valu
 
 const reloadEventHook = createEventHook()
 
-const { isGallery, isGrid, isForm, isKanban, isLocked } = useProvideSmartsheetStore(activeView, meta)
+const { isGallery, isGrid, isForm, isKanban, isLocked, nestedFilters } = useProvideSmartsheetStore(activeView, meta)
 
 const openNewRecordFormHook = createEventHook()
 
@@ -55,6 +55,15 @@ provide(OpenNewRecordFormHookInj, openNewRecordFormHook)
 provide(FieldsInj, fields)
 provide(IsFormInj, isForm)
 provide(TabMetaInj, activeTab)
+
+watch(nestedFilters, (newFilters) => {
+  activeTab.value.state = activeTab.value.state || {}
+  activeTab.value.state[activeView.value.id] = newFilters
+})
+
+watch(activeView, (newView: ViewType) => {
+  nestedFilters.value = activeTab.value.state?.[newView.id!]
+})
 </script>
 
 <template>

--- a/packages/nc-gui/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui/components/tabs/Smartsheet.vue
@@ -38,7 +38,9 @@ const meta = computed<TableType | undefined>(() => activeTab.value && metas.valu
 const { isGallery, isGrid, isForm, isKanban, isLocked } = useProvideSmartsheetStore(activeView, meta)
 
 const reloadEventHook = createEventHook<void | boolean>()
+
 const reloadViewMetaEventHook = createEventHook<void | boolean>()
+
 const openNewRecordFormHook = createEventHook<void>()
 
 useProvideKanbanViewStore(meta, activeView)

--- a/packages/nc-gui/components/tabs/Smartsheet.vue
+++ b/packages/nc-gui/components/tabs/Smartsheet.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { ColumnType, TableType } from 'nocodb-sdk'
-import SmartsheetGrid from '../smartsheet/Grid.vue'
 import {
   ActiveViewInj,
   FieldsInj,
@@ -19,8 +18,6 @@ import {
   useMetas,
   useProvideKanbanViewStore,
   useProvideSmartsheetStore,
-  useUIPermission,
-  watch,
 } from '#imports'
 import type { TabItem } from '~/lib'
 
@@ -38,16 +35,13 @@ const fields = ref<ColumnType[]>([])
 
 const meta = computed<TableType | undefined>(() => activeTab.value && metas.value[activeTab.value.id!])
 
-const reloadEventHook = createEventHook()
-
-const { isGallery, isGrid, isForm, isKanban, isLocked, nestedFilters, sorts } = useProvideSmartsheetStore(activeView, meta)
-
-const openNewRecordFormHook = createEventHook()
+const { isGallery, isGrid, isForm, isKanban, isLocked } = useProvideSmartsheetStore(activeView, meta)
 
 const reloadEventHook = createEventHook<void | boolean>()
+const reloadViewMetaEventHook = createEventHook<void | boolean>()
 const openNewRecordFormHook = createEventHook<void>()
 
-const { isGallery, isGrid, isForm, isLocked } = useProvideSmartsheetStore(activeView, meta)
+useProvideKanbanViewStore(meta, activeView)
 
 // todo: move to store
 provide(MetaInj, meta)
@@ -59,15 +53,6 @@ provide(OpenNewRecordFormHookInj, openNewRecordFormHook)
 provide(FieldsInj, fields)
 provide(IsFormInj, isForm)
 provide(TabMetaInj, activeTab)
-
-watch(nestedFilters, (newFilters) => {
-  activeTab.value.state = activeTab.value.state || {}
-  activeTab.value.state[activeView.value.id] = newFilters
-})
-
-watch(activeView, (newView: ViewType) => {
-  nestedFilters.value = activeTab.value.state?.[newView.id!]
-})
 </script>
 
 <template>

--- a/packages/nc-gui/composables/useTabs.ts
+++ b/packages/nc-gui/composables/useTabs.ts
@@ -38,6 +38,7 @@ const [setup, use] = useInjectionState(() => {
         let index = tabs.value.findIndex((t) => t.id === tab.id)
 
         if (index === -1) {
+          tab.state = tab.state || new Map()
           tabs.value.push(tab)
           index = tabs.value.length - 1
         }

--- a/packages/nc-gui/composables/useTabs.ts
+++ b/packages/nc-gui/composables/useTabs.ts
@@ -38,7 +38,8 @@ const [setup, use] = useInjectionState(() => {
         let index = tabs.value.findIndex((t) => t.id === tab.id)
 
         if (index === -1) {
-          tab.state = tab.state || new Map()
+          tab.sortsState = tab.sortsState || new Map()
+          tab.filterState = tab.filterState || new Map()
           tabs.value.push(tab)
           index = tabs.value.length - 1
         }
@@ -71,6 +72,8 @@ const [setup, use] = useInjectionState(() => {
   const activeTab = computed(() => tabs.value?.[activeTabIndex.value])
 
   const addTab = (tabMeta: TabItem) => {
+    tabMeta.sortsState = tabMeta.sortsState || new Map()
+    tabMeta.filterState = tabMeta.filterState || new Map()
     const tabIndex = tabs.value.findIndex((tab) => tab.id === tabMeta.id)
     // if tab already found make it active
     if (tabIndex > -1) {

--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -25,6 +25,7 @@ export function useViewFilters(
   isNestedRoot?: boolean,
 ) {
   let currentFilters = $ref(_currentFilters)
+
   const reloadHook = inject(ReloadViewDataHookInj)
 
   const { nestedFilters } = useSmartsheetStoreOrThrow()
@@ -41,7 +42,7 @@ export function useViewFilters(
 
   const nestedMode = computed(() => isPublic.value || !isUIAllowed('filte rSync') || !isUIAllowed('filterChildrenRead'))
 
-  const tabMeta = inject(TabMetaInj, ref({ filterState: new Map() } as TabItem))
+  const tabMeta = inject(TabMetaInj, ref({ filterState: new Map(), sortsState: new Map() } as TabItem))
 
   const filters = computed<Filter[]>({
     get: () => {

--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -37,7 +37,7 @@ export function useViewFilters(
 
   const _filters = ref<Filter[]>([])
 
-  const nestedMode = computed(() => isPublic.value || !isUIAllowed('filterSync' || !isUIAllowed('filterChildrenRead')))
+  const nestedMode = computed(() => isPublic.value || !isUIAllowed('filterSync') || !isUIAllowed('filterChildrenRead'))
 
   const filters = computed<Filter[]>({
     get: () => (nestedMode.value ? currentFilters! : _filters.value),

--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -13,9 +13,8 @@ import {
   useUIPermission,
   watch,
 } from '#imports'
-import type { TabItem } from '~/composables/useTabs'
 import { TabMetaInj } from '~/context'
-import type { Filter } from '~/lib'
+import type { Filter, TabItem } from '~/lib'
 
 export function useViewFilters(
   view: Ref<ViewType | undefined>,
@@ -53,7 +52,7 @@ export function useViewFilters(
         currentFilters = value
         if (isNestedRoot) {
           nestedFilters.value = value
-          tabMeta.value.filterState!.set(view!.value.id!, nestedFilters.value)
+          tabMeta.value.filterState!.set(view.value!.id!, nestedFilters.value)
         }
         nestedFilters.value = [...nestedFilters.value]
         reloadHook?.trigger()
@@ -77,8 +76,8 @@ export function useViewFilters(
 
   const loadFilters = async (hookId?: string) => {
     if (nestedMode.value) {
-      if (isNestedRoot)
-        filters.value = tabMeta.value.filterState!.get(view.value.id!) || []
+      // ignore restoring if not root filter group
+      if (isNestedRoot) filters.value = tabMeta.value.filterState!.get(view.value!.id!) || []
       return
     }
 

--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -51,11 +51,11 @@ export function useViewFilters(
     set: (value: Filter[]) => {
       if (nestedMode.value) {
         currentFilters = value
-        if (isNestedRoot) nestedFilters.value = value
-
+        if (isNestedRoot) {
+          nestedFilters.value = value
+          tabMeta.value.filterState!.set(view!.value.id!, nestedFilters.value)
+        }
         nestedFilters.value = [...nestedFilters.value]
-
-        tabMeta.value.filterState!.set(view!.value.id!, nestedFilters.value)
         reloadHook?.trigger()
         return
       }
@@ -77,7 +77,8 @@ export function useViewFilters(
 
   const loadFilters = async (hookId?: string) => {
     if (nestedMode.value) {
-      filters.value = tabMeta.value.filterState!.get(view.value.id!) || []
+      if (isNestedRoot)
+        filters.value = tabMeta.value.filterState!.get(view.value.id!) || []
       return
     }
 

--- a/packages/nc-gui/composables/useViewFilters.ts
+++ b/packages/nc-gui/composables/useViewFilters.ts
@@ -22,9 +22,10 @@ export function useViewFilters(
   parentId?: string,
   autoApply?: ComputedRef<boolean>,
   reloadData?: () => void,
-  currentFilters?: Filter[],
+  _currentFilters?: Filter[],
   isNestedRoot?: boolean,
 ) {
+  let currentFilters = $ref(_currentFilters)
   const reloadHook = inject(ReloadViewDataHookInj)
 
   const { nestedFilters } = useSmartsheetStoreOrThrow()
@@ -44,7 +45,9 @@ export function useViewFilters(
   const tabMeta = inject(TabMetaInj, ref({ filterState: new Map() } as TabItem))
 
   const filters = computed<Filter[]>({
-    get: () => (nestedMode.value ? currentFilters! : _filters.value),
+    get: () => {
+      return nestedMode.value ? currentFilters! : _filters.value
+    },
     set: (value: Filter[]) => {
       if (nestedMode.value) {
         currentFilters = value

--- a/packages/nc-gui/composables/useViewSorts.ts
+++ b/packages/nc-gui/composables/useViewSorts.ts
@@ -13,7 +13,7 @@ import {
   useSmartsheetStoreOrThrow,
   useUIPermission,
 } from '#imports'
-import { TabItem } from '~/lib'
+import type { TabItem } from '~/lib'
 
 export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () => void) {
   const { sharedView } = useSharedView()
@@ -42,7 +42,7 @@ export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () =>
 
     try {
       if (!isUIAllowed('sortSync')) {
-        const sortsBackup = tabMeta.value.sortsState.get(view.value.id!)
+        const sortsBackup = tabMeta.value.sortsState!.get(view.value!.id!)
         if (sortsBackup) {
           sorts.value = sortsBackup
           return
@@ -61,7 +61,7 @@ export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () =>
       sorts.value[i] = sort
       sorts.value = [...sorts.value]
       reloadHook?.trigger()
-      tabMeta.value.sortsState.set(view.value.id!, sorts.value)
+      tabMeta.value.sortsState!.set(view.value!.id!, sorts.value)
       return
     }
 
@@ -91,7 +91,7 @@ export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () =>
 
     $e('a:sort:add', { length: sorts?.value?.length })
 
-    tabMeta.value.sortsState.set(view.value.id!, sorts.value)
+    tabMeta.value.sortsState!.set(view.value!.id!, sorts.value)
   }
 
   const deleteSort = async (sort: SortType, i: number) => {
@@ -102,7 +102,7 @@ export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () =>
       sorts.value.splice(i, 1)
       sorts.value = [...sorts.value]
 
-      tabMeta.value.sortsState.set(view.value.id!, sorts.value)
+      tabMeta.value.sortsState!.set(view.value!.id!, sorts.value)
 
       reloadHook?.trigger()
       $e('a:sort:delete')

--- a/packages/nc-gui/composables/useViewSorts.ts
+++ b/packages/nc-gui/composables/useViewSorts.ts
@@ -1,5 +1,4 @@
-import { ViewType } from 'nocodb-sdk'
-import type { GalleryType, GridType, KanbanType, SortType } from 'nocodb-sdk'
+import type { SortType, ViewType } from 'nocodb-sdk'
 import type { Ref } from 'vue'
 import {
   IsPublicInj,

--- a/packages/nc-gui/composables/useViewSorts.ts
+++ b/packages/nc-gui/composables/useViewSorts.ts
@@ -13,6 +13,7 @@ import {
   useSmartsheetStoreOrThrow,
   useUIPermission,
 } from '#imports'
+import { TabItem } from '~/lib'
 
 export function useViewSorts(view: Ref<ViewType | undefined>, reloadData?: () => void) {
   const { sharedView } = useSharedView()

--- a/packages/nc-gui/lib/types.ts
+++ b/packages/nc-gui/lib/types.ts
@@ -69,6 +69,8 @@ export interface TabItem {
   id?: string
   viewTitle?: string
   viewId?: string
+  sortsState?: Map<string, any>
+  filterState?: Map<string, any>
 }
 
 export interface SharedViewMeta extends Record<string, any> {


### PR DESCRIPTION
## Change Summary

Keep tab level state for views(for `viewer` and `commenter` role) in open tabs and on revisit restore the state.


re #3261 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
