### PR TITLE
fix(gui-v2): use import data with the first key

### DIFF
--- a/packages/nc-gui-v2/components/template/Editor.vue
+++ b/packages/nc-gui-v2/components/template/Editor.vue
@@ -332,7 +332,8 @@ async function importTemplate() {
 
       const tableName = meta.value.title
 
-      const data = importData[tableName]
+      // only one file is allowed currently
+      const data = importData[Object.keys(importData)[0]]
 
       const projectName = project.value.title!
 


### PR DESCRIPTION
## Change Summary

- ref: #3392 

Sheet name can be different than `tableName`. As we only allow one file to be imported, we choose the first key. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
