### PR TITLE
fix: windows executables

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -108,7 +108,7 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./scripts/pkg-executable/dist/Noco-win-arm64.exe
-          asset_name: Noco-win-arm64
+          asset_name: Noco-win-arm64.exe
           asset_content_type: application/octet-stream
 
       - name: Upload win-x64 build to asset
@@ -118,7 +118,7 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./scripts/pkg-executable/dist/Noco-win-x64.exe
-          asset_name: Noco-win-x64
+          asset_name: Noco-win-x64.exe
           asset_content_type: application/octet-stream
 
       - name: Upload linux-arm64 build to asset

--- a/.github/workflows/release-pr-v2.yml
+++ b/.github/workflows/release-pr-v2.yml
@@ -119,7 +119,7 @@ jobs:
   #           #### Windows
 
   #           ```bash
-  #           iwp http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
+  #           iwr http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
   #           .\Noco-win-arm64.exe
   #           ```
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -119,7 +119,7 @@ jobs:
             #### Windows
 
             ```bash
-            iwp http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
+            iwr http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
             .\Noco-win-arm64.exe
             ```
 

--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ curl http://get.nocodb.com/linux-arm64 -o nocodb -L && chmod +x nocodb && ./noco
 
 ##### Windows (x64)
 ```bash
-iwp http://get.nocodb.com/win-x64 
+iwr http://get.nocodb.com/win-x64.exe
 .\Noco-win-x64.exe
 ```
 
 ##### Windows (arm64)
 ```bash
-iwp http://get.nocodb.com/win-arm64 
+iwr http://get.nocodb.com/win-arm64.exe
 .\Noco-win-arm64.exe
 ```
 

--- a/packages/noco-docs/content/en/getting-started/installation.md
+++ b/packages/noco-docs/content/en/getting-started/installation.md
@@ -103,13 +103,13 @@ curl http://get.nocodb.com/linux-arm64 -o nocodb -L \
 ##### Windows (x64)
 
 ```bash
-iwp http://get.nocodb.com/win-x64
+iwr http://get.nocodb.com/win-x64.exe
 .\Noco-win-x64.exe
 ```
 ##### Windows (arm64)
 
 ```bash
-iwp http://get.nocodb.com/win-arm64
+iwr http://get.nocodb.com/win-arm64.exe
 .\Noco-win-arm64.exe
 ```
 


### PR DESCRIPTION
## Change Summary

ref: #3378 

- add missing extension for windows executables
- use `iwr` (Invoke-WebRequest) instead of `iwp`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
