### PR TITLE
Integrate Uffizzi PR Environments

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+x-uffizzi:
+  ingress:
+    service: nocodb
+    port: 8080
+
+services:
+  root_db:
+    image: postgres
+    restart: always
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_DB: root_db
+  nocodb:
+    image: nocodb/nocodb:latest
+    ports:
+      - "8080:8080"
+    restart: always
+    volumes:
+      - nc_data:/usr/app/data
+    environment:
+      NC_DB: "pg://localhost:5432?u=postgres&p=password&d=root_db"
+volumes:
+  db_data: {}
+  nc_data: {}

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,173 @@
+
+name: Build Images and Deploy Preview Environment
+
+on:
+  pull_request:
+    types: [opened,reopened,synchronize,closed]
+
+jobs:
+  set-tag:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false && github.base_ref == 'develop' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: set-tag
+        id: tag-step
+        run: |
+          # Get current date
+          CURRENT_DATE=$(date +"%Y%m%d")
+          CURRENT_TIME=$(date +"%H%M")
+          # Get current PR number
+          PR_NUMBER=${{github.event.number}}
+          # Get current version
+          CURRENT_VERSION=$(basename $(curl -fs -o/dev/null -w %{redirect_url} https://github.com/nocodb/nocodb/releases/latest))
+          # Construct tag name
+          TAG_NAME=pr-${PR_NUMBER}-${CURRENT_DATE}-${CURRENT_TIME}
+          echo "TARGET_TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+      - name: verify-tag
+        run: |
+          echo ${{ steps.tag-step.outputs.TARGET_TAG }}
+          echo ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+    outputs:
+      target_tag: ${{ steps.tag-step.outputs.TARGET_TAG }}
+      current_version: ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+  
+  build-nocodb:
+    name: Build and Push `nocodb`
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.action != 'closed' }}
+    env:
+      working-directory: ./packages/nocodb
+      targetEnv: DEV
+      tag: pr-${{ github.event.number }}
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.15.0
+
+      - name: upgrade packages for pr build
+        if: ${{ env.targetEnv == 'DEV' }}
+        run: |
+          export NODE_OPTIONS="--max_old_space_size=16384"
+          targetEnv=${{ env.targetEnv }} targetVersion=${{ needs.set-tag.outputs.target_tag }} node scripts/bumpNocodbSdkVersion.js
+          cd packages/nocodb-sdk
+          npm install && npm run build
+          cd ../..
+          targetEnv=${{ env.targetEnv }} targetVersion=${{ needs.set-tag.outputs.target_tag }} node scripts/upgradeNocodbSdk.js && 
+          targetEnv=${{ env.targetEnv }} targetVersion=${{ needs.set-tag.outputs.target_tag }} node scripts/bumpNcGuiVersion.js &&
+          cd packages/nc-gui
+          npm install
+          targetEnv=${{ env.targetEnv }} targetVersion=${{ needs.set-tag.outputs.target_tag }} npm run build:copy
+          cd ../..
+          targetEnv=${{ env.targetEnv }} targetVersion=${{ needs.set-tag.outputs.target_tag }} node scripts/upgradeNcGui.js
+      
+      - uses: bahmutov/npm-install@v1
+        with:
+          working-directory: ${{ env.working-directory }}
+
+      - name: Build nocodb and docker files
+        run: |
+          npm run build
+          npm run docker:build
+        working-directory: ${{ env.working-directory }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "::set-output name=uuid::$(uuidgen)"
+      
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # An anonymous, emphemeral registry built on ttl.sh
+          images: registry.uffizzi.com/${{ steps.uuid.outputs.uuid }}
+          tags: type=raw,value=24h
+      
+      - name: Build and Push Image to Uffizzi Ephemeral Registry
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.working-directory }}
+          build-args: NC_VERSION=${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  render-compose-file:
+    name: Render Docker Compose File
+    runs-on: ubuntu-latest
+    needs:
+      - build-nocodb
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+      compose-file-cache-path: docker-compose.rendered.yml
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          NOCODB_IMAGE=$(echo ${{ needs.build-nocodb.outputs.tags }})
+          export NOCODB_IMAGE
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Hash Rendered Compose File
+        id: hash
+        run: echo "::set-output name=hash::$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')"
+      - name: Cache Rendered Compose File
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ steps.hash.outputs.hash }}
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs: render-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.6.0
+    with:
+      compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: ${{ needs.render-compose-file.outputs.compose-file-cache-path }}
+      server: https://app.uffizzi.com/
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      
+  delete-uffizzi-preview:
+    name: Use Remote Workflow to Delete an Existing Preview
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.6.0
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    with:
+      compose-file-cache-key: ''
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com/
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write


### PR DESCRIPTION
## Change Summary

Add support for creating pull request environment on every PR using Uffizzi. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [x] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Build an image for every PR build in github actions 
- Uffizzi deploy github action which uses the built image to deploy the PR Environment
- Docker compose template with uses postgres instance for every PR environment

## Additional information / screenshots (optional)

I want to invite the maintainers of NocoDB to the Uffizzi project created for them. The PR setups up PR Environments for NocoDB to ease development and reviews. Reviewers should be able to see a preview of the PR as a hosted service. The URL of the service will be provided in a comment on the PR itself. I want to invite the maintainers of nocodb to the uffizzi project to get an idea of what the platform looks like. Uffizzi is free for nocodb. 
