### PR TITLE
fix(gui-v2): missing data in quick import after renaming

### DIFF
--- a/packages/nc-gui-v2/components/template/Editor.vue
+++ b/packages/nc-gui-v2/components/template/Editor.vue
@@ -128,8 +128,15 @@ const isValid = computed(() => {
   return true
 })
 
+const prevEditableTn = ref<string[]>([])
+
 onMounted(() => {
   parseAndLoadTemplate()
+
+  // used to record the previous EditableTn values
+  // for checking the table duplication in current import
+  // and updating the key in importData
+  prevEditableTn.value = data.tables.map((t) => t.ref_table_name)
 
   nextTick(() => {
     inputRefs.value[0]?.focus()
@@ -508,6 +515,22 @@ onMounted(() => {
     mapDefaultColumns()
   }
 })
+
+function handleEditableTnChange(idx: number) {
+  const oldValue = prevEditableTn.value[idx]
+  const newValue = data.tables[idx].ref_table_name
+  if (data.tables.filter((t) => t.ref_table_name === newValue).length > 1) {
+    message.warn('Duplicate Table Name')
+    data.tables[idx].ref_table_name = oldValue
+  } else {
+    prevEditableTn.value[idx] = newValue
+    if (oldValue != newValue) {
+      // update the key name of importData
+      delete Object.assign(importData, { [newValue]: importData[oldValue] })[oldValue]
+    }
+  }
+  setEditableTn(idx, false)
+}
 </script>
 
 <template>
@@ -589,8 +612,8 @@ onMounted(() => {
                   size="large"
                   hide-details
                   @click="$event.stopPropagation()"
-                  @blur="setEditableTn(tableIdx, false)"
-                  @keydown.enter="setEditableTn(tableIdx, false)"
+                  @blur="handleEditableTnChange(tableIdx)"
+                  @keydown.enter="handleEditableTnChange(tableIdx)"
                 />
               </a-form-item>
 

--- a/packages/nc-gui-v2/components/template/Editor.vue
+++ b/packages/nc-gui-v2/components/template/Editor.vue
@@ -524,7 +524,7 @@ function handleEditableTnChange(idx: number) {
     data.tables[idx].ref_table_name = oldValue
   } else {
     prevEditableTn.value[idx] = newValue
-    if (oldValue != newValue) {
+    if (oldValue !== newValue) {
       // update the key name of importData
       delete Object.assign(importData, { [newValue]: importData[oldValue] })[oldValue]
     }


### PR DESCRIPTION
## Change Summary

ref: #3427

Currently the key names in `importData` won't be updated when `editableTn` got updated. This PR is to handle this case. Also it checks if the current import include duplicate table names.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
