### PR TITLE
fix: operator does not exist: double precision % integer

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
@@ -54,7 +54,7 @@ const pg = {
           : fn(pt.arguments[0])
       }) - 1 - ${getWeekdayByText(
         pt?.arguments[1]?.value
-      )} % 7 + 7) % 7 ${colAlias}`
+      )} % 7 + 7) ::INTEGER % 7 ${colAlias}`
     );
   },
 };


### PR DESCRIPTION
## Change Summary

- ref: #3417 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/188136838-a415ab4b-a9da-4341-929a-01b06a637154.png)
