### PR TITLE
fix(gui-v2): make i18n globally available outside setup

### DIFF
--- a/packages/nc-gui-v2/plugins/a.i18n.ts
+++ b/packages/nc-gui-v2/plugins/a.i18n.ts
@@ -1,6 +1,8 @@
 import { defineNuxtPlugin } from 'nuxt/app'
 import { createI18n } from 'vue-i18n'
 
+let i18n: ReturnType<typeof createI18n>
+
 export const createI18nPlugin = async () =>
   createI18n({
     locale: 'en', // Set the initial locale
@@ -44,9 +46,11 @@ export const createI18nPlugin = async () =>
   })
 
 export default defineNuxtPlugin(async (nuxtApp) => {
-  const i18n = await createI18nPlugin()
+  i18n = (await createI18nPlugin()) as any
 
   nuxtApp.vueApp.i18n = i18n.global as any
 
   nuxtApp.vueApp.use(i18n)
 })
+
+export const getI18n = () => i18n


### PR DESCRIPTION
## Change Summary

Allow using `i18n` outside setup, like within a composable which invoke from a plugin.

Sample usage:

```typescript

import { getI18n } from '~/plugins/a.i18n'


export function useSample(){

  const { t } = getI18n().global

  console.log(t('general.home'))


}


```


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
