### PR TITLE
fix: theme palette

### DIFF
--- a/packages/nc-gui-v2/components/general/ChromeWrapper.vue
+++ b/packages/nc-gui-v2/components/general/ChromeWrapper.vue
@@ -1,0 +1,30 @@
+<script lang="ts" setup>
+import { Chrome } from '@ckpack/vue-color'
+import { computed } from '#imports'
+
+interface Props {
+  modelValue?: any
+  mode?: 'hex' | 'hex8' | 'hsl' | 'hsv' | 'rgba'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: () => '#00FFFFFF',
+  mode: () => 'hex8',
+})
+
+const emit = defineEmits(['update:modelValue', 'input'])
+
+const picked = computed({
+  get: () => props.modelValue || '#00FFFFFF',
+  set: (val) => {
+    emit('update:modelValue', val[props.mode] || null)
+    emit('input', val[props.mode] || null)
+  },
+})
+</script>
+
+<template>
+  <Chrome v-model="picked" />
+</template>
+
+<style scoped></style>

--- a/packages/nc-gui-v2/components/general/ColorPicker.vue
+++ b/packages/nc-gui-v2/components/general/ColorPicker.vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { Chrome } from '@ckpack/vue-color'
 import { computed, enumColor, ref, watch } from '#imports'
 
 interface Props {
@@ -18,27 +17,28 @@ const props = withDefaults(defineProps<Props>(), {
   pickButton: false,
 })
 
-const emit = defineEmits(['update:modelValue'])
+const emit = defineEmits(['update:modelValue', 'input'])
 
 const vModel = computed({
   get: () => props.modelValue,
   set: (val) => {
-    emit('update:modelValue', val.hex8 ? val.hex8 : val || null)
+    emit('update:modelValue', val || null)
+    emit('input', val || null)
   },
 })
 
-const picked = ref<string | Record<string, any>>(props.modelValue || enumColor.light[0])
+const picked = ref<string>(props.modelValue || enumColor.light[0])
 
-const selectColor = (color: string | Record<string, any>) => {
-  picked.value = typeof color === 'string' ? color : color.hex8 ? color.hex8 : color
-  vModel.value = typeof color === 'string' ? color : color.hex8 ? color.hex8 : color
+const selectColor = (color: string) => {
+  picked.value = color
+  if (props.pickButton) vModel.value = color
 }
 
 const compare = (colorA: string, colorB: string) => colorA.toLowerCase() === colorB.toLowerCase()
 
 watch(picked, (n, _o) => {
   if (!props.pickButton) {
-    vModel.value = typeof n === 'string' ? n : n.hex8 ? n.hex8 : n
+    vModel.value = n
   }
 })
 </script>
@@ -50,11 +50,11 @@ watch(picked, (n, _o) => {
         v-for="(color, i) of colors.slice((colId - 1) * rowSize, colId * rowSize)"
         :key="`color-${colId}-${i}`"
         class="color-selector"
-        :class="compare(typeof picked === 'string' ? picked : picked.hex8, color) ? 'selected' : ''"
+        :class="compare(picked, color) ? 'selected' : ''"
         :style="{ 'background-color': `${color}` }"
         @click="selectColor(color)"
       >
-        {{ compare(typeof picked === 'string' ? picked : picked.hex8, color) ? '&#10003;' : '' }}
+        {{ compare(picked, color) ? '&#10003;' : '' }}
       </button>
     </div>
     <a-card v-if="props.advanced" class="w-full mt-2" :body-style="{ padding: '0px' }" :bordered="false">
@@ -64,7 +64,7 @@ watch(picked, (n, _o) => {
             Pick Color
           </a-button>
           <div class="flex justify-center py-4">
-            <Chrome v-model="picked" class="!w-full !shadow-none" />
+            <GeneralChromeWrapper v-model="picked" class="!w-full !shadow-none" />
           </div>
         </a-collapse-panel>
       </a-collapse>

--- a/packages/nc-gui-v2/composables/useProject.ts
+++ b/packages/nc-gui-v2/composables/useProject.ts
@@ -10,7 +10,7 @@ const [setup, use] = useInjectionState((_projectId?: MaybeRef<string>) => {
   const { $api } = useNuxtApp()
   const route = useRoute()
   const { includeM2M } = useGlobal()
-  const { setTheme } = useTheme()
+  const { setTheme, theme } = useTheme()
 
   const projectId = computed(() => (_projectId ? unref(_projectId) : (route.params.projectId as string)))
   const project = ref<ProjectType>({})
@@ -99,15 +99,21 @@ const [setup, use] = useInjectionState((_projectId?: MaybeRef<string>) => {
     }
   }
 
-  async function saveTheme(theme: Partial<ThemeConfig>) {
+  async function saveTheme(_theme: Partial<ThemeConfig>) {
+    const fullTheme = {
+      primaryColor: theme.value.primaryColor,
+      accentColor: theme.value.accentColor,
+      ..._theme,
+    }
+
     await updateProject({
-      color: theme.primaryColor,
+      color: fullTheme.primaryColor,
       meta: {
         ...projectMeta.value,
-        theme,
+        theme: fullTheme,
       },
     })
-    setTheme(theme)
+    setTheme(fullTheme)
   }
 
   watch(

--- a/packages/nc-gui-v2/pages/[projectType]/[projectId]/index.vue
+++ b/packages/nc-gui-v2/pages/[projectType]/[projectId]/index.vue
@@ -17,7 +17,6 @@ import {
   useProject,
   useRoute,
   useTabs,
-  useTheme,
   useUIPermission,
 } from '#imports'
 import { TabType } from '~/composables'

--- a/packages/nc-gui-v2/pages/index/index/index.vue
+++ b/packages/nc-gui-v2/pages/index/index/index.vue
@@ -83,7 +83,24 @@ const handleProjectColor = async (projectId: string, color: string) => {
         },
       }),
     })
+    // Update local project
+    const localProject = projects.value?.find((p) => p.id === projectId)
+    if (localProject) {
+      localProject.color = color
+      localProject.meta = JSON.stringify({
+        ...meta,
+        theme: {
+          primaryColor: color,
+          accentColor: complement.toHex8String(),
+        },
+      })
+    }
   }
+}
+
+const getProjectPrimary = (project: ProjectType) => {
+  const meta = project?.meta && typeof project.meta === 'string' ? JSON.parse(project.meta) : project.meta || {}
+  return meta?.theme?.primaryColor || themeV2Colors['royal-blue'].DEFAULT
 }
 </script>
 
@@ -192,7 +209,7 @@ const handleProjectColor = async (projectId: string, color: string) => {
                         <div
                           class="color-selector"
                           :style="{
-                            'background-color': record.color || themeV2Colors['royal-blue'].DEFAULT,
+                            'background-color': getProjectPrimary(record),
                             'width': '8px',
                             'height': '100%',
                           }"


### PR DESCRIPTION
## Change Summary

Re #3459
- Wrapper component for Chrome (ChromeWrapper)
  - This emits input on color change and usable without v-model (broken for vue-color library we use)
  - Allows returning of any color mode vue-color supports (hex, hex8, hsl, hsv, rgba) instead of full object
- Handle theme colors using events emitted and functions instead of watchers
- Change ColorPicker to use ChromeWrapper (returns hex8 easier to handle / cleaner code)
- SaveTheme allows either only primaryColor or accentColor and uses theme color for missing prop

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
