### PR TITLE
fix: show attachment cell data in shared grid view

### DIFF
--- a/packages/nc-gui/components/cell/attachment/utils.ts
+++ b/packages/nc-gui/components/cell/attachment/utils.ts
@@ -18,6 +18,7 @@ import {
   useProject,
   watch,
 } from '#imports'
+import { IsFormInj } from '~/context'
 import MdiPdfBox from '~icons/mdi/pdf-box'
 import MdiFileWordOutline from '~icons/mdi/file-word-outline'
 import MdiFilePowerpointBox from '~icons/mdi/file-powerpoint-box'
@@ -36,6 +37,8 @@ export const [useProvideAttachmentCell, useAttachmentCell] = useInjectionState(
     const isReadonly = inject(ReadonlyInj, false)
 
     const isPublic = inject(IsPublicInj, ref(false))
+
+    const isForm = inject(IsFormInj, ref(false))
 
     const meta = inject(MetaInj)!
 
@@ -162,7 +165,7 @@ export const [useProvideAttachmentCell, useAttachmentCell] = useInjectionState(
     }
 
     /** our currently visible items, either the locally stored or the ones from db, depending on isPublicForm status */
-    const visibleItems = computed<any[]>(() => (isPublic.value ? storedFiles.value : attachments.value))
+    const visibleItems = computed<any[]>(() => (isPublic.value && isForm.value ? storedFiles.value : attachments.value))
 
     watch(files, (nextFiles) => nextFiles && onFileSelect(nextFiles))
 


### PR DESCRIPTION
## Change Summary

Use local storage option for attachment only in a shared public form.

re #3541 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
