### PR TITLE
fix: gallery card cover image distortion

### DIFF
--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -144,7 +144,7 @@ openNewRecordFormHook?.on(async () => {
                 <img
                   v-for="(attachment, index) in attachments(record)"
                   :key="`carousel-${record.row.id}-${index}`"
-                  class="h-52"
+                  class="h-52 object-cover"
                   :src="attachment.url"
                 />
               </a-carousel>


### PR DESCRIPTION
## Change Summary

Re #3599 
Use object-cover for gallery card cover image

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Additional information / screenshots (optional)

![Screenshot_2022-09-14_01-43-30](https://user-images.githubusercontent.com/59797957/190023152-8f84ee38-0d2f-4f3b-bf25-e3b96a1af502.png)

As we use object-cover some parts of the image might be missed, an alternative approach would have been using object-contain but it results with extra space for most aspect ratios.

Example:
![Screenshot_2022-09-14_01-44-06](https://user-images.githubusercontent.com/59797957/190023528-b6c1cac1-f2ce-4001-958b-93302f9cd470.png)

Open for any suggestion / alternative


