### PR TITLE
feat(nc-gui): add web types for directives

### DIFF
--- a/packages/nc-gui/components/smartsheet-toolbar/ShareView.vue
+++ b/packages/nc-gui/components/smartsheet-toolbar/ShareView.vue
@@ -136,7 +136,6 @@ watch(passwordProtected, (value) => {
     >
       <div class="share-link-box nc-share-link-box bg-primary-50">
         <div class="flex-1 h-min text-xs">{{ sharedViewUrl }}</div>
-        <!--        <v-spacer /> -->
         <a v-e="['c:view:share:open-url']" :href="sharedViewUrl" target="_blank">
           <MdiOpenInNewIcon class="text-sm text-gray-500 mt-2" />
         </a>

--- a/packages/nc-gui/package.json
+++ b/packages/nc-gui/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "web-types": "web-types.json",
   "scripts": {
     "build": "nuxi build",
     "dev": "nuxi dev",

--- a/packages/nc-gui/web-types.json
+++ b/packages/nc-gui/web-types.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JetBrains/web-types/master/v2-preview/web-types.json",
+  "name": "nc-gui",
+  "framework": "vue",
+  "version": "1.0.0",
+  "contributions": {
+    "html": {
+      "vue-directives": [
+        {
+          "name": "e",
+          "description": "Telemetry directive"
+        },
+        {
+          "name": "t",
+          "description": "I18n directive"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Change Summary

* web-types stops Webstorm from complaining that `v-e` is an unrecognized directive

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
