### PR TITLE
fix: Import Airtable to SQL Databases - fix number as a decimal

### DIFF
--- a/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
@@ -198,7 +198,7 @@ export default async (
     multiCollaborator: UITypes.Collaborator,
     date: UITypes.Date,
     phone: UITypes.PhoneNumber,
-    number: UITypes.Number,
+    number: UITypes.Decimal,
     rating: UITypes.Rating,
     formula: UITypes.Formula,
     rollup: UITypes.Rollup,


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Airtable provides an option for the `Number` field to be displayed as either integer or decimal. Internally stores numbers as decimals. Mapping backend type as `integer` leads to an error when we attempt to store decimal values. Hence mapping all `Number` fields as `decimal` in the backend.

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)
