### PR TITLE
fix(nc-gui): checkbox cell unselectable 

### DIFF
--- a/packages/nc-gui/components/cell/Checkbox.vue
+++ b/packages/nc-gui/components/cell/Checkbox.vue
@@ -2,18 +2,23 @@
 import { ColumnInj, IsFormInj, ReadonlyInj, getMdiIcon, inject } from '#imports'
 
 interface Props {
-  modelValue?: boolean | undefined | number
+  // If the previous cell value was a text, the initial checkbox value is a string type
+  // otherwise it can be either a boolean, or a string representing a boolean, i.e '0' or '1'
+  modelValue?: boolean | string | '0' | '1'
 }
 
 interface Emits {
-  (event: 'update:modelValue', model: boolean | undefined | number): void
+  (event: 'update:modelValue', model: boolean): void
 }
 
 const props = defineProps<Props>()
 
 const emits = defineEmits<Emits>()
 
-let vModel = $(useVModel(props, 'modelValue', emits))
+let vModel = $computed({
+  get: () => !!props.modelValue && props.modelValue !== '0',
+  set: (val) => emits('update:modelValue', val),
+})
 
 const column = inject(ColumnInj)
 


### PR DESCRIPTION
## Change Summary

* changed checkbox cell prop type to allow string
	* if previous value was a string val, the initial val is also a string, which causes warnings - might be a TODO to fix this properly
* changed vModel to support this behavior 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
