### PR TITLE
test: cy views suite local storage & tab handling corrections

### DIFF
--- a/scripts/cypress/integration/common/00_pre_configurations.js
+++ b/scripts/cypress/integration/common/00_pre_configurations.js
@@ -164,7 +164,6 @@ export const genTest = (apiType, dbType) => {
 
         it("Admin SignUp", () => {
             cy.task("log", "This will be output to the terminal");
-            cy.saveLocalStorage();
             loginPage.signUp(roles.owner.credentials);
         });
 
@@ -250,6 +249,15 @@ export const genTest = (apiType, dbType) => {
                 else {
                     cy_createProjectBlock(proj, apiType, dbType);
                 }
+
+                // kludge: wait for page load to finish
+                cy.wait(2000);
+                // close team & auth tab
+                cy.get('button.ant-tabs-tab-remove').should('exist').click();
+                cy.wait(1000);
+
+                // first instance of updating local storage information
+                cy.saveLocalStorage();
             });
         };
 

--- a/scripts/cypress/integration/common/1a_table_operations.js
+++ b/scripts/cypress/integration/common/1a_table_operations.js
@@ -7,18 +7,25 @@ export const genTest = (apiType, dbType) => {
     describe(`${
         dbType === "xcdb" ? "Meta - " : ""
     }${apiType.toUpperCase()} api - Table`, () => {
-        before(() => {
-            cy.saveLocalStorage();
-            cy.wait(1000);
-        });
+        // before(() => {
+        //     // standalone test
+        //     // loginPage.loginAndOpenProject(apiType, dbType);
+        //
+        //     // open a table to work on views
+        //     //
+        //     // cy.restoreLocalStorage();
+        // });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
         });
 
-        after(() => {
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        // });
 
         const name = "tablex";
 

--- a/scripts/cypress/integration/common/1b_table_column_operations.js
+++ b/scripts/cypress/integration/common/1b_table_column_operations.js
@@ -34,22 +34,26 @@ export const genTest = (apiType, dbType) => {
         const randVal = "Test@1234.com";
         const updatedRandVal = "Updated@1234.com";
 
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-            cy.createTable(name);
-        });
+        // before(() => {
+        //     cy.restoreLocalStorage();
+        //     cy.createTable(name);
+        // })
 
         beforeEach(() => {
-            cy.fileHook();
+            cy.restoreLocalStorage();
         })
 
-        // delete table
-        after(() => {
-            cy.deleteTable(name, dbType);
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // // delete table
+        // after(() => {
+        //     cy.deleteTable(name, dbType);
+        // });
 
         it("Create Table Column", () => {
+            cy.createTable(name);
             mainPage.addColumn(colName, name);
         });
 
@@ -167,6 +171,9 @@ export const genTest = (apiType, dbType) => {
 
             // verify if everything is wiped off
             mainPage.getCell("Title", 1).contains("a1").should("not.exist");
+
+            // clean-up
+            cy.deleteTable(name, dbType);
         });
     });
 };

--- a/scripts/cypress/integration/common/1c_sql_view.js
+++ b/scripts/cypress/integration/common/1c_sql_view.js
@@ -10,13 +10,17 @@ export const genTest = (apiType, dbType) => {
     describe(`${apiType.toUpperCase()} SQL Views`, () => {
         // Run once before test- create project (rest/graphql)
         //
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-        });
+        // before(() => {
+        //     cy.fileHook();
+        //     mainPage.tabReset();
+        // });
 
         beforeEach(() => {
-            cy.fileHook();
+            cy.restoreLocalStorage();
+        })
+
+        afterEach(() => {
+            cy.saveLocalStorage();
         })
 
         it(`XCDB: SQL View Column operations`, () => {
@@ -167,10 +171,6 @@ export const genTest = (apiType, dbType) => {
                 cy.openViewsTab("StaffList", 2);
                 cy.closeViewsTab("StaffList");
             }
-        });
-
-        after(() => {
-            // void
         });
     });
 };

--- a/scripts/cypress/integration/common/1e_meta_sync.js
+++ b/scripts/cypress/integration/common/1e_meta_sync.js
@@ -18,22 +18,23 @@ export const genTest = (apiType, dbType) => {
         // Run once before test- create project (rest/graphql)
         //
         before(() => {
+            cy.restoreLocalStorage();
             if (isXcdb()) {
                 cy.log(getProjectString());
                 projPrefix = `${getProjectString()}`;
                 dbCmd = `sqliteExec`;
                 tblDisplayPrefix = `${getProjectString()}`;
             }
-            mainPage.tabReset();
             mainPage.openMetaTab();
-        });
+        })
 
         beforeEach(() => {
-        });
+            cy.restoreLocalStorage();
+        })
 
-        after(() => {
-            // mainPage.closeMetaTab();
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         it(`Create table`, () => {
             // Create Table

--- a/scripts/cypress/integration/common/2a_table_with_belongs_to_colulmn.js
+++ b/scripts/cypress/integration/common/2a_table_with_belongs_to_colulmn.js
@@ -5,28 +5,25 @@ export const genTest = (apiType, dbType) => {
     if (!isTestSuiteActive(apiType, dbType)) return;
 
     describe(`${apiType.toUpperCase()} api - Table: belongs to, link record`, () => {
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-            //
-            // // kludge: wait for page load to finish
-            // cy.wait(1000);
-            // // close team & auth tab
-            // cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            // cy.wait(1000);
-
-            cy.openTableTab("Country", 25);
-        });
+        // before(() => {
+        //     cy.restoreLocalStorage();
+        //     cy.openTableTab("Country", 25);
+        // });
 
         beforeEach(() => {
-            cy.fileHook();
+            cy.restoreLocalStorage();
         });
 
-        after(() => {
-          cy.closeTableTab("City");
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        //   cy.closeTableTab("City");
+        // });
 
         it("URL validation", () => {
+            cy.openTableTab("Country", 25);
             // column name validation
             // cy.get(`.project-tab:contains(Country):visible`).should("exist");
             // URL validation
@@ -103,6 +100,8 @@ export const genTest = (apiType, dbType) => {
             .find('.nc-virtual-cell > .chips-wrapper > .chips > .group > .name')
             .contains("Saudi Arabia")
             .should('exist');
+
+          cy.closeTableTab("City");
         })
     });
 };

--- a/scripts/cypress/integration/common/2b_table_with_m2m_column.js
+++ b/scripts/cypress/integration/common/2b_table_with_m2m_column.js
@@ -5,28 +5,24 @@ export const genTest = (apiType, dbType) => {
     if (!isTestSuiteActive(apiType, dbType)) return;
 
     describe(`${apiType.toUpperCase()} api - M2M Column validation`, () => {
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-
-            // // kludge: wait for page load to finish
-            // cy.wait(1000);
-            // // close team & auth tab
-            // cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            // cy.wait(1000);
-
-            cy.openTableTab("Actor", 25);
-        });
+        // before(() => {
+        //     cy.openTableTab("Actor", 25);
+        // });
 
         beforeEach(() => {
-            cy.fileHook();
-        });
+            cy.restoreLocalStorage();
+        })
 
-        after(() => {
-            cy.closeTableTab("Actor");
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        //     cy.closeTableTab("Actor");
+        // });
 
         it("Table column header, URL validation", () => {
+            cy.openTableTab("Actor", 25);
             // column name validation
             // cy.get(`.project-tab:contains(Actor):visible`).should("exist");
             // URL validation
@@ -117,6 +113,8 @@ export const genTest = (apiType, dbType) => {
                         .click();
                     cy.getActiveModal().find("button.ant-modal-close").click();
                 });
+
+          cy.closeTableTab("Actor");
         });
     });
 };

--- a/scripts/cypress/integration/common/3a_filter_sort_fields_operations.js
+++ b/scripts/cypress/integration/common/3a_filter_sort_fields_operations.js
@@ -5,212 +5,195 @@ import { isTestSuiteActive } from "../../support/page_objects/projectConstants";
 export const genTest = (apiType, dbType) => {
     if (!isTestSuiteActive(apiType, dbType)) return;
 
-    describe(`${apiType.toUpperCase()} api - Filter, Fields, Sort`, () => {
-        before(() => {
-            // loginPage.loginAndOpenProject(apiType, dbType);
+    describe(`${apiType.toUpperCase()} api - Grid operations`, () => {
+        // before(() => {
+        //     // loginPage.loginAndOpenProject(apiType, dbType);
+        //
+        //     // open country table
+        //     cy.openTableTab("Country", 25);
+        // });
+        //
+        // after(() => {
+        //     cy.closeTableTab("Country");
+        // });
 
-            // open country table
+        beforeEach(() => {
+            cy.restoreLocalStorage();
+        })
+
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        it("Check country table - Pagination", () => {
             cy.openTableTab("Country", 25);
+
+            cy.get(".nc-pagination").should("exist");
+
+            // verify > pagination option
+            mainPage.getPagination(">").click();
+            mainPage
+              .getPagination(2)
+              .should("have.class", "ant-pagination-item-active");
+
+            // verify < pagination option
+            mainPage.getPagination("<").click();
+            mainPage
+              .getPagination(1)
+              .should("have.class", "ant-pagination-item-active");
         });
 
-        after(() => {
+        // create new row using + button in header
+        //
+        it("Add row using tool header button", () => {
+            // add a row to end of Country table
+            cy.get(".nc-add-new-row-btn").click();
+            cy.wait(1000);
+            cy.get(".nc-expand-col-Country").find(".nc-cell > input").first().type("Test Country");
+            cy.getActiveDrawer()
+              .find(".ant-btn-primary")
+              .contains("Save row")
+              .click();
+
+            // cy.get("#data-table-form-Country > input")
+            //     .first()
+            //     .type("Test Country");
+            // cy.contains("Save row").filter("button").click();
+
+            cy.toastWait("updated successfully");
+            cy.getActiveDrawer()
+              .find(".ant-btn")
+              .contains("Cancel")
+              .click();
+
+            // verify
+            mainPage.getPagination(5).click();
+            // kludge: flicker on load
+            cy.wait(3000)
+            mainPage
+              .getCell("Country", 10)
+              .contains("Test Country")
+              .should("exist");
+        });
+
+        // delete single row
+        //
+        it("Delete Row", () => {
+            // delete row added in previous step
+            mainPage.getCell("Country", 10).rightclick();
+            cy.getActiveMenu(".nc-dropdown-grid-context-menu").contains("Delete Row").click();
+
+            // cy.toastWait('Deleted row successfully')
+
+            // verify
+            cy.get(`:nth-child(10) > [data-title="Country"]`).should("not.exist");
+
+            mainPage.getPagination(1).click();
+        });
+
+        // create new row using right click menu option
+        //
+        it.skip("Add row using rightclick menu option", () => {
+            // Temporary
+            mainPage.getPagination(5).click();
+
+            mainPage.getCell("Country", 9).rightclick({ force: true });
+            cy.getActiveMenu(".nc-dropdown-grid-context-menu")
+              .contains("Insert New Row")
+              .click({ force: true });
+            mainPage
+              .getCell("Country", 10)
+              .dblclick()
+              .find("input")
+              .type("Test Country-1{enter}");
+
+            mainPage.getCell("Country", 10).rightclick({ force: true });
+            cy.getActiveMenu(".nc-dropdown-grid-context-menu")
+              .contains("Insert New Row")
+              .click({ force: true });
+            mainPage
+              .getCell("Country", 11)
+              .dblclick()
+              .find("input")
+              .type("Test Country-2{enter}");
+
+            // GUI-v2 Kludge:
+            // to move cursor away from input field; enter key is not recognized
+            // mainPage.getCell("Country", 10).click()
+
+            // verify
+            mainPage
+              .getCell("Country", 10)
+              .contains("Test Country-1")
+              .should("exist");
+            mainPage
+              .getCell("Country", 11)
+              .contains("Test Country-2")
+              .should("exist");
+        });
+
+        // delete selected rows (multiple)
+        //
+        it.skip("Delete Selected", () => {
+            cy.get(".ant-checkbox").should('exist')
+              .eq(10).click({ force: true });
+            cy.get(".ant-checkbox").should('exist')
+              .eq(11).click({ force: true });
+
+            mainPage.getCell("Country", 10).rightclick({ force: true });
+            cy.getActiveMenu(".nc-dropdown-grid-context-menu")
+              .contains("Delete Selected Rows")
+              .click({ force: true });
+
+            // verify
+            // mainPage.getCell("Country", 10).should("not.exist");
+            // mainPage.getCell("Country", 11).should("not.exist");
+            cy.get(
+              `:nth-child(10) > [data-title="Country"]`
+            ).should("not.exist");
+            cy.get(
+              `:nth-child(11) > [data-title="Country"]`
+            ).should("not.exist");
+
+            mainPage.getPagination(1).click();
+        });
+
+
+        it("Enable sort", () => {
+            mainPage.sortField("Country", "Z → A");
+            cy.contains("Zambia").should("exist");
+        });
+
+        it("Disable sort", () => {
+            mainPage.clearSort();
+            cy.contains("Zambia").should("not.exist");
+        });
+
+        it("Hide field", () => {
+            mainPage.hideField("LastUpdate");
+        });
+
+        it("Show field", () => {
+            mainPage.unhideField("LastUpdate");
+        });
+
+        it("Create Filter", () => {
+            mainPage.filterField("Country", "is equal", "India");
+            // cy.get("td:contains(India)").should("exist");
+            mainPage.getCell("Country", 1)
+              .contains("India")
+              .should("exist");
+        });
+
+        it("Delete Filter", () => {
+            // remove sort and check
+            mainPage.filterReset();
+            mainPage.getCell("Country", 1)
+              .contains("India")
+              .should("not.exist");
+            // cy.contains("td:contains(India)").should("not.exist");
+
             cy.closeTableTab("Country");
-        });
-
-        describe(`Pagination`, () => {
-            beforeEach(() => {
-            })
-
-            // check pagination
-            it("Check country table - Pagination", () => {
-                cy.get(".nc-pagination").should("exist");
-
-                // verify > pagination option
-                mainPage.getPagination(">").click();
-                mainPage
-                    .getPagination(2)
-                    .should("have.class", "ant-pagination-item-active");
-
-                // verify < pagination option
-                mainPage.getPagination("<").click();
-                mainPage
-                    .getPagination(1)
-                    .should("have.class", "ant-pagination-item-active");
-            });
-        });
-
-        describe(`Row operations`, () => {
-            beforeEach(() => {
-                cy.fileHook();
-            })
-
-            // create new row using + button in header
-            //
-            it("Add row using tool header button", () => {
-                // add a row to end of Country table
-                cy.get(".nc-add-new-row-btn").click();
-                cy.wait(1000);
-                cy.get(".nc-expand-col-Country").find(".nc-cell > input").first().type("Test Country");
-                cy.getActiveDrawer()
-                    .find(".ant-btn-primary")
-                    .contains("Save row")
-                    .click();
-
-                // cy.get("#data-table-form-Country > input")
-                //     .first()
-                //     .type("Test Country");
-                // cy.contains("Save row").filter("button").click();
-
-                cy.toastWait("updated successfully");
-                cy.getActiveDrawer()
-                    .find(".ant-btn")
-                    .contains("Cancel")
-                    .click();
-
-                // verify
-                mainPage.getPagination(5).click();
-                // kludge: flicker on load
-                cy.wait(3000)
-                mainPage
-                    .getCell("Country", 10)
-                    .contains("Test Country")
-                    .should("exist");
-            });
-
-            // delete single row
-            //
-            it("Delete Row", () => {
-                // delete row added in previous step
-                mainPage.getCell("Country", 10).rightclick();
-                cy.getActiveMenu(".nc-dropdown-grid-context-menu").contains("Delete Row").click();
-
-                // cy.toastWait('Deleted row successfully')
-
-                // verify
-                cy.get(`:nth-child(10) > [data-title="Country"]`).should("not.exist");
-
-                mainPage.getPagination(1).click();
-            });
-
-            // create new row using right click menu option
-            //
-            it.skip("Add row using rightclick menu option", () => {
-                // Temporary
-                mainPage.getPagination(5).click();
-
-                mainPage.getCell("Country", 9).rightclick({ force: true });
-                cy.getActiveMenu(".nc-dropdown-grid-context-menu")
-                    .contains("Insert New Row")
-                    .click({ force: true });
-                mainPage
-                    .getCell("Country", 10)
-                    .dblclick()
-                    .find("input")
-                    .type("Test Country-1{enter}");
-
-                mainPage.getCell("Country", 10).rightclick({ force: true });
-                cy.getActiveMenu(".nc-dropdown-grid-context-menu")
-                    .contains("Insert New Row")
-                    .click({ force: true });
-                mainPage
-                    .getCell("Country", 11)
-                    .dblclick()
-                    .find("input")
-                    .type("Test Country-2{enter}");
-
-                // GUI-v2 Kludge:
-                // to move cursor away from input field; enter key is not recognized
-                // mainPage.getCell("Country", 10).click()
-
-                // verify
-                mainPage
-                    .getCell("Country", 10)
-                    .contains("Test Country-1")
-                    .should("exist");
-                mainPage
-                    .getCell("Country", 11)
-                    .contains("Test Country-2")
-                    .should("exist");
-            });
-
-            // delete selected rows (multiple)
-            //
-            it.skip("Delete Selected", () => {
-                cy.get(".ant-checkbox").should('exist')
-                  .eq(10).click({ force: true });
-                cy.get(".ant-checkbox").should('exist')
-                  .eq(11).click({ force: true });
-
-                mainPage.getCell("Country", 10).rightclick({ force: true });
-                cy.getActiveMenu(".nc-dropdown-grid-context-menu")
-                    .contains("Delete Selected Rows")
-                    .click({ force: true });
-
-                // verify
-                // mainPage.getCell("Country", 10).should("not.exist");
-                // mainPage.getCell("Country", 11).should("not.exist");
-                cy.get(
-                  `:nth-child(10) > [data-title="Country"]`
-                ).should("not.exist");
-                cy.get(
-                  `:nth-child(11) > [data-title="Country"]`
-                ).should("not.exist");
-
-                mainPage.getPagination(1).click();
-            });
-        });
-
-        describe(`Sort operations`, () => {
-            beforeEach(() => {
-                cy.fileHook();
-            })
-
-            it("Enable sort", () => {
-                mainPage.sortField("Country", "Z → A");
-                cy.contains("Zambia").should("exist");
-            });
-
-            it("Disable sort", () => {
-                mainPage.clearSort();
-                cy.contains("Zambia").should("not.exist");
-            });
-        });
-
-        describe("Field Operation", () => {
-            beforeEach(() => {
-                cy.fileHook();
-            })
-
-            it("Hide field", () => {
-                mainPage.hideField("LastUpdate");
-            });
-
-            it("Show field", () => {
-                mainPage.unhideField("LastUpdate");
-            });
-        });
-
-        describe("Filter operations", () => {
-            beforeEach(() => {
-                cy.fileHook();
-            })
-
-            it("Create Filter", () => {
-                mainPage.filterField("Country", "is equal", "India");
-                // cy.get("td:contains(India)").should("exist");
-                mainPage.getCell("Country", 1)
-                    .contains("India")
-                    .should("exist");
-            });
-
-            it("Delete Filter", () => {
-                // remove sort and check
-                mainPage.filterReset();
-                mainPage.getCell("Country", 1)
-                  .contains("India")
-                  .should("not.exist");
-                // cy.contains("td:contains(India)").should("not.exist");
-            });
         });
     });
 };

--- a/scripts/cypress/integration/common/3b_formula_column.js
+++ b/scripts/cypress/integration/common/3b_formula_column.js
@@ -11,17 +11,22 @@ export const genTest = (apiType, dbType) => {
     describe(`${apiType.toUpperCase()} api - FORMULA`, () => {
         // Run once before test- create project (rest/graphql)
         //
-        before(() => {
-            // loginPage.loginAndOpenProject(apiType, dbType)
-            cy.openTableTab("City", 25);
-        });
+        // before(() => {
+        //     // loginPage.loginAndOpenProject(apiType, dbType)
+        //     cy.openTableTab("City", 25);
+        // });
 
         beforeEach(() => {
-        });
+            cy.restoreLocalStorage();
+        })
 
-        after(() => {
-            cy.closeTableTab("City");
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        //     cy.closeTableTab("City");
+        // });
 
         // Given rowname & expected result for first 10 entries, validate
         // NOTE: Scroll issue with Cypress automation, to fix
@@ -157,6 +162,8 @@ export const genTest = (apiType, dbType) => {
         }
 
         it("Formula: ADD, AVG, LEN", () => {
+            cy.openTableTab("City", 25);
+
             addFormulaBasedColumn(
                 "NC_MATH_0",
                 "ADD({CityId}, {CountryId}) + AVG({CityId}, {CountryId}) + LEN({City})"
@@ -217,6 +224,8 @@ export const genTest = (apiType, dbType) => {
             if (dbType === 'mysql') editColumnByName("NC_MATH_2", "NC_NOW", `NOW()`);
             else editColumnByName("NC_MATH_1", "NC_NOW", `NOW()`);
             deleteColumnByName("NC_NOW");
+
+            cy.closeTableTab("City");
         });
     });
 };

--- a/scripts/cypress/integration/common/3c_lookup_column.js
+++ b/scripts/cypress/integration/common/3c_lookup_column.js
@@ -13,28 +13,32 @@ export const genTest = (apiType, dbType) => {
 
         // Run once before test- create project (rest/graphql)
         //
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-            // open a table to work on views
-            //
-
-            // // kludge: wait for page load to finish
-            // cy.wait(1000);
-            // // close team & auth tab
-            // cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            // cy.wait(1000);
-
-            cy.openTableTab("City", 25);
-        });
+        // before(() => {
+        //     cy.fileHook();
+        //     mainPage.tabReset();
+        //     // open a table to work on views
+        //     //
+        //
+        //     // // kludge: wait for page load to finish
+        //     // cy.wait(1000);
+        //     // // close team & auth tab
+        //     // cy.get('button.ant-tabs-tab-remove').should('exist').click();
+        //     // cy.wait(1000);
+        //
+        //     cy.openTableTab("City", 25);
+        // });
 
         beforeEach(() => {
-            cy.fileHook();
+            cy.restoreLocalStorage();
         });
 
-        after(() => {
-            cy.closeTableTab("City");
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        //     cy.closeTableTab("City");
+        // });
 
         // Routine to create a new look up column
         //
@@ -74,6 +78,8 @@ export const genTest = (apiType, dbType) => {
         // Test case
 
         it("Add Lookup column (Address, PostalCode) & Delete", () => {
+            cy.openTableTab("City", 25);
+
             addLookUpColumn("Address", "PostalCode");
 
             // Verify first entry, will be displayed as alias here 'childColumn (from childTable)'
@@ -82,6 +88,8 @@ export const genTest = (apiType, dbType) => {
                 .should("exist");
 
             deleteColumnByName("PostalCode");
+
+            cy.closeTableTab("City");
         });
 
         it.skip("Add Lookup column (Country, CountryId) & Delete", () => {

--- a/scripts/cypress/integration/common/3d_rollup_column.js
+++ b/scripts/cypress/integration/common/3d_rollup_column.js
@@ -14,28 +14,32 @@ export const genTest = (apiType, dbType) => {
 
         // Run once before test- create project (rest/graphql)
         //
-        before(() => {
-            cy.fileHook();
-            mainPage.tabReset();
-
-            // // kludge: wait for page load to finish
-            // cy.wait(1000);
-            // // close team & auth tab
-            // cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            // cy.wait(1000);
-
-            // open a table to work on views
-            //
-            cy.openTableTab("Country", 25);
-        });
+        // before(() => {
+        //     cy.fileHook();
+        //     mainPage.tabReset();
+        //
+        //     // // kludge: wait for page load to finish
+        //     // cy.wait(1000);
+        //     // // close team & auth tab
+        //     // cy.get('button.ant-tabs-tab-remove').should('exist').click();
+        //     // cy.wait(1000);
+        //
+        //     // open a table to work on views
+        //     //
+        //     cy.openTableTab("Country", 25);
+        // });
 
         beforeEach(() => {
-            cy.fileHook();
-        });
+            cy.restoreLocalStorage();
+        })
 
-        after(() => {
-            cy.closeTableTab("Country");
-        });
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        // after(() => {
+        //     cy.closeTableTab("Country");
+        // });
 
         // Routine to create a new look up column
         //
@@ -106,6 +110,8 @@ export const genTest = (apiType, dbType) => {
         // Test case
 
         it("Add Rollup column (City, City, count) & Delete", () => {
+            cy.openTableTab("Country", 25);
+
             addRollUpColumn("RollUpCol", "City", "City", "count");
 
             // Verify first entry, will be displayed as alias here 'childColumn (from childTable)'
@@ -116,6 +122,8 @@ export const genTest = (apiType, dbType) => {
 
             // editColumnByName("RollUpCol_2", "RollUpCol_New");
             deleteColumnByName("RollUpCol");
+
+            cy.closeTableTab("Country");
         });
 
         it.skip("Add Rollup column (City, CountryId, count) & Delete", () => {

--- a/scripts/cypress/integration/common/3f_link_to_another_record.js
+++ b/scripts/cypress/integration/common/3f_link_to_another_record.js
@@ -103,15 +103,14 @@ export const genTest = (apiType, dbType) => {
       cy.wait(1000);
     }
 
-    before(() => {
-      // required for standalone test
-      // loginPage.loginAndOpenProject(apiType, dbType);
+    // before(() => {
+    //   // required for standalone test
+    //   // loginPage.loginAndOpenProject(apiType, dbType);
+    // });
 
-      cy.createTable("Sheet1");
-      cy.createTable("Sheet2");
-
+    afterEach(() => {
       cy.saveLocalStorage();
-    });
+    })
 
     beforeEach(() => {
       cy.restoreLocalStorage();
@@ -120,6 +119,8 @@ export const genTest = (apiType, dbType) => {
     after(() => {
       // Cleanup
       //
+      cy.restoreLocalStorage();
+
       cy.openTableTab("Sheet1", 0);
       mainPage.deleteColumn("Link1-2hm");
       mainPage.deleteColumn("Link1-2mm");
@@ -127,12 +128,16 @@ export const genTest = (apiType, dbType) => {
       cy.deleteTable("Sheet1");
 
       cy.deleteTable("Sheet2");
+      cy.saveLocalStorage();
     });
 
     ///////////////////////////////////////////////////
     // Test case
 
     it("Create Link columns", () => {
+      cy.createTable("Sheet1");
+      cy.createTable("Sheet2");
+
       cy.openTableTab("Sheet1", 0);
       addRow(1, "1a");
       addRow(2, "1b");

--- a/scripts/cypress/integration/common/4a_table_view_grid_gallery_form.js
+++ b/scripts/cypress/integration/common/4a_table_view_grid_gallery_form.js
@@ -15,25 +15,24 @@ export const genTest = (apiType, dbType) => {
         //
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
-
-            mainPage.tabReset();
 
             // open a table to work on views
             //
             cy.openTableTab("Country", 25);
-
-            // toggle right navbar (open)
-            // cy.get('.nc-toggle-right-navbar').should('exist').click();
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
+        });
+
+        afterEach(() => {
+            cy.saveLocalStorage();
         });
 
         after(() => {
+            cy.restoreLocalStorage();
             cy.closeTableTab("Country");
+            cy.saveLocalStorage();
         });
 
         // Common routine to create/edit/delete GRID & GALLERY view
@@ -47,9 +46,6 @@ export const genTest = (apiType, dbType) => {
                 // Pop up window, click Submit (accepting default name for view)
                 cy.getActiveModal(".nc-modal-view-create").find(".ant-btn-primary").click();
                 cy.toastWait("View created successfully");
-
-                // kludge: right navbar closes abruptly. force it open again
-                // window.localStorage.setItem('nc-right-sidebar', '{"isOpen":true,"hasSidebar":true}')
 
                 // validate if view was created && contains default name 'Country1'
                 cy.get(`.nc-${viewType}-view-item`)
@@ -67,9 +63,6 @@ export const genTest = (apiType, dbType) => {
                     .type(`${viewType}View-1{enter}`);
                 cy.toastWait("View renamed successfully");
 
-                // kludge: right navbar closes abruptly. force it open again
-                // window.localStorage.setItem('nc-right-sidebar', '{"isOpen":true,"hasSidebar":true}')
-
                 // validate
                 cy.get(`.nc-${viewType}-view-item`)
                     .contains(`${viewType}View-1`)
@@ -85,9 +78,6 @@ export const genTest = (apiType, dbType) => {
                 cy.wait(300)
                 cy.getActiveModal(".nc-modal-view-delete").find('.ant-btn-dangerous').click();
                 cy.toastWait("View deleted successfully");
-
-                // kludge: right navbar closes abruptly. force it open again
-                // window.localStorage.setItem('nc-right-sidebar', '{"isOpen":true,"hasSidebar":true}')
 
                 // confirm if the number of veiw entries is reduced by 1
                 cy.get(".nc-view-item").its("length").should("eq", 1);

--- a/scripts/cypress/integration/common/4b_table_view_share.js
+++ b/scripts/cypress/integration/common/4b_table_view_share.js
@@ -37,11 +37,24 @@ export const genTest = (apiType, dbType) => {
         //
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
-
-            mainPage.tabReset();
             cy.openTableTab("City", 25);
+        });
 
+        beforeEach(() => {
+            cy.restoreLocalStorage();
+        });
+
+        afterEach(() => {
+            cy.saveLocalStorage();
+        });
+
+        after(() => {
+            cy.restoreLocalStorage();
+            cy.closeTableTab("City");
+            cy.saveLocalStorage();
+        });
+
+        it("Generate link with password", () => {
             // store base URL- to re-visit and delete form view later
             cy.url().then((url) => {
                 storedURL = url;
@@ -49,12 +62,6 @@ export const genTest = (apiType, dbType) => {
             generateLinkWithPwd();
 
             cy.signOut();
-        });
-
-        beforeEach(() => {
-        });
-
-        afterEach(() => {
         });
 
         it("Share view with incorrect password", () => {
@@ -99,23 +106,10 @@ export const genTest = (apiType, dbType) => {
         it("Delete view",  () => {
             loginPage.loginAndOpenProject(apiType, dbType);
             cy.openTableTab("City", 25);
-            cy.wait(500);
-            mainPage.toggleRightSidebar();
-            cy.wait(500);
-
-            cy.saveLocalStorage();
-            cy.wait(1000);
 
             // wait for page load to complete
             cy.get(".nc-grid-row").should("have.length", 25);
             mainPage.deleteCreatedViews();
-        });
-
-        after(() => {
-            cy.restoreLocalStorage();
-            cy.wait(500);
-
-            cy.closeTableTab("City");
         });
     });
 };

--- a/scripts/cypress/integration/common/4c_form_view_detailed.js
+++ b/scripts/cypress/integration/common/4c_form_view_detailed.js
@@ -58,37 +58,27 @@ export const genTest = (apiType, dbType) => {
         // Run once before test- create project (rest/graphql)
         //
         before(() => {
-            mainPage.tabReset();
+            // standalone test
             // loginPage.loginAndOpenProject(apiType, dbType);
-
-            // kludge: wait for page load to finish
-            cy.wait(2000);
-            // close team & auth tab
-            cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            cy.wait(1000);
 
             // open a table to work on views
             //
+            cy.restoreLocalStorage();
             cy.openTableTab("Country", 25);
-            mainPage.toggleRightSidebar();
-
-            cy.saveLocalStorage();
-            cy.wait(500);
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(500);
-
-            // fix me!
-            window.localStorage.setItem('nc-right-sidebar', '{"isOpen":true,"hasSidebar":true}')
         });
 
         afterEach(() => {
+            cy.saveLocalStorage();
         });
 
         after(() => {
+            cy.restoreLocalStorage();
             cy.closeTableTab("Country");
+            cy.saveLocalStorage();
         });
 
         // Common routine to create/edit/delete GRID & GALLERY view
@@ -96,6 +86,7 @@ export const genTest = (apiType, dbType) => {
         //
         const viewTest = (viewType) => {
             it(`Create ${viewType} view`, () => {
+
                 // click on 'Grid/Gallery' button on Views bar
                 cy.get(`.nc-create-${viewType}-view`).click();
 
@@ -385,35 +376,9 @@ export const genTest = (apiType, dbType) => {
 
                 // validate if form has appeared again
                 validateFormHeader();
-
-                // // verify URL & copy it for subsequent test
-                // cy.url().should("contain", `Country/Form-1`);
-                // cy.url().then((url) => {
-                //     cy.log(url);
-                //     formViewURL = url;
-                // });
-                //
-                // cy.wait(300);
             });
 
-            // it.skip(`Validate ${viewType}: URL validation after re-access`, () => {
-            //     // visit URL
-            //     cy.log(formViewURL);
-            //
-            //     cy.visit(formViewURL, {
-            //         baseUrl: null,
-            //     });
-            //
-            //     // New form appeared? Header & description should exist
-            //     validateFormHeader();
-            // });
-
             it(`Delete ${viewType} view`, () => {
-                // cy.visit("/");
-                // cy.wait(5000);
-                // projectsPage.openConfiguredProject(apiType, dbType);
-                // cy.openTableTab("Country", 25);
-
                 // number of view entries should be 2 before we delete
                 cy.get(".nc-view-item").its("length").should("eq", 2);
 

--- a/scripts/cypress/integration/common/4d_table_view_grid_locked.js
+++ b/scripts/cypress/integration/common/4d_table_view_grid_locked.js
@@ -9,24 +9,21 @@ export const genTest = (apiType, dbType) => {
         //
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(500);
-
-            mainPage.tabReset();
-
-            // open a table to work on views
-            //
             cy.openTableTab("Country", 25);
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(500);
+        });
+
+        afterEach(() => {
+            cy.saveLocalStorage();
         });
 
         after(() => {
             cy.restoreLocalStorage();
-            cy.wait(500)
             cy.closeTableTab("Country");
+            cy.saveLocalStorage();
         });
 
         const lockViewTest = (enabled) => {

--- a/scripts/cypress/integration/common/4e_form_view_share.js
+++ b/scripts/cypress/integration/common/4e_form_view_share.js
@@ -14,30 +14,22 @@ export const genTest = (apiType, dbType) => {
         //
         before(() => {
             // loginPage.loginAndOpenProject(apiType, dbType);
-            // cy.openTableTab("City", 25);
-            // cy.wait(500);
-            // mainPage.toggleRightSidebar();
-            // cy.wait(500);
-            // cy.saveLocalStorage();
-            // cy.wait(500);
-
             cy.restoreLocalStorage();
-            cy.wait(500);
-
-            mainPage.tabReset();
-            // open a table to work on views
-            //
-
             cy.openTableTab("City", 25);
         });
 
         beforeEach(() => {
+            cy.restoreLocalStorage();
+        });
+
+        afterEach(() => {
+            cy.saveLocalStorage();
         });
 
         after(() => {
             cy.restoreLocalStorage();
-            cy.wait(500);
             cy.closeTableTab("City");
+            cy.saveLocalStorage();
         });
 
         // Common routine to create/edit/delete GRID & GALLERY view
@@ -45,9 +37,6 @@ export const genTest = (apiType, dbType) => {
         //
         const viewTest = (viewType) => {
             it(`Create ${viewType} view`, () => {0
-
-              cy.restoreLocalStorage();
-              cy.wait(500);
 
               // click on create grid view button
               cy.get(`.nc-create-${viewType}-view`).click();
@@ -96,9 +85,6 @@ export const genTest = (apiType, dbType) => {
             });
 
             it(`Share form view`, () => {
-
-                cy.restoreLocalStorage();
-                cy.wait(500);
 
                 cy.get(`.nc-view-item.nc-${viewType}-view-item`)
                     .contains("Form-1")
@@ -198,11 +184,6 @@ export const genTest = (apiType, dbType) => {
                 // go back to base page
                 loginPage.loginAndOpenProject(apiType, dbType);
                 cy.openTableTab("City", 25);
-                cy.wait(500);
-                mainPage.toggleRightSidebar();
-                cy.wait(500);
-                cy.saveLocalStorage();
-                cy.wait(500);
 
                 // number of view entries should be 2 before we delete
                 cy.get(".nc-view-item").its("length").should("eq", 2);

--- a/scripts/cypress/integration/common/4f_grid_view_share.js
+++ b/scripts/cypress/integration/common/4f_grid_view_share.js
@@ -42,33 +42,23 @@ export const genTest = (apiType, dbType) => {
         //
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(500);
-
-            mainPage.tabReset();
             cy.openTableTab("Address", 25);
-
-            // loginPage.loginAndOpenProject(apiType, dbType);
-            //
-            // // open a table to work on views
-            // //
-            // cy.openTableTab("Address", 25);
-            // mainPage.toggleRightSidebar();
-            // //
-            // cy.saveLocalStorage();
         });
 
         beforeEach(() => {
+            cy.restoreLocalStorage();
         });
 
         afterEach(() => {
+            cy.saveLocalStorage();
         });
 
         after(() => {
             // close table
             // mainPage.deleteCreatedViews()
             cy.restoreLocalStorage();
-            cy.wait(500);
             cy.closeTableTab("Address");
+            cy.saveLocalStorage();
         });
 
         // Common routine to create/edit/delete GRID & GALLERY view
@@ -76,9 +66,6 @@ export const genTest = (apiType, dbType) => {
         //
         const viewTest = (viewType) => {
             it(`Create ${viewType.toUpperCase()} view`, () => {
-
-                cy.restoreLocalStorage();
-                cy.wait(500);
 
                 // create a normal public view
                 cy.get(`.nc-create-${viewType}-view`).click();
@@ -93,9 +80,6 @@ export const genTest = (apiType, dbType) => {
 
             it(`Share ${viewType.toUpperCase()} hide, sort, filter & verify`, () => {
 
-                cy.restoreLocalStorage();
-                cy.wait(500);
-
                 cy.get(`.nc-view-item.nc-${viewType}-view-item`)
                     .contains("Grid-1")
                     .click();
@@ -107,9 +91,6 @@ export const genTest = (apiType, dbType) => {
             });
 
             it(`Share GRID view : ensure we have only one link even if shared multiple times`, () => {
-
-                cy.restoreLocalStorage();
-                cy.wait(500);
 
                 // generate view link multiple times
                 generateViewLink("combined");
@@ -364,11 +345,6 @@ export const genTest = (apiType, dbType) => {
                 loginPage.loginAndOpenProject(apiType, dbType);
                 cy.openTableTab("Address", 25);
 
-                mainPage.toggleRightSidebar();
-                cy.wait(500);
-                cy.saveLocalStorage();
-                cy.wait(500);
-
                 // number of view entries should be 2 before we delete
                 cy.get(".nc-view-item").its("length").should("eq", 2);
 
@@ -387,9 +363,7 @@ export const genTest = (apiType, dbType) => {
 
     describe(`${apiType.toUpperCase()} api - Grid view/ row-column update verification`, () => {
         before(() => {
-
             cy.restoreLocalStorage();
-            cy.wait(500);
 
             // Address table has belongs to, has many & many-to-many
             cy.openTableTab("Country", 25);
@@ -401,47 +375,21 @@ export const genTest = (apiType, dbType) => {
             });
         });
 
-        after(() => {
-            // close table
-            // cy.visit(storedURL, {
-            //     baseUrl: null,
-            // });
-            // cy.wait(5000);
+        beforeEach(() => {
+            cy.restoreLocalStorage();
+        });
 
-            loginPage.loginAndOpenProject(apiType, dbType);
-            cy.openTableTab("Country", 25)
-            cy.wait(500);
-            mainPage.toggleRightSidebar();
-            cy.wait(500);
+        afterEach(() => {
             cy.saveLocalStorage();
-            cy.wait(500);
+        });
 
-            // delete row
-            mainPage.getPagination(5).click();
-            // kludge: flicker on load
-            cy.wait(3000)
-
-            // wait for page rendering to complete
-            cy.get(".nc-grid-row").should("have.length", 10);
-            mainPage.getCell("Country", 10).rightclick();
-            cy.getActiveMenu(".nc-dropdown-grid-context-menu")
-                .find('.ant-dropdown-menu-item:contains("Delete Row")')
-                .first()
-                .click();
-
-            // delete column
-            mainPage.deleteColumn("dummy");
-            mainPage.deleteCreatedViews();
-
-            // close table
+        after(() => {
+            cy.restoreLocalStorage();
             cy.closeTableTab("Country");
+            cy.saveLocalStorage();
         });
 
         it(`Generate default Shared GRID view URL`, () => {
-
-            cy.restoreLocalStorage();
-            cy.wait(500);
-
             // add row
             cy.get(".nc-add-new-row-btn").click();
             cy.get(".nc-expand-col-Country").find(".nc-cell > input")
@@ -487,6 +435,28 @@ export const genTest = (apiType, dbType) => {
         it(`Share GRID view : new column visible`, () => {
             // verify column headers
             cy.get('[data-title="dummy"]').should("exist");
+        });
+
+        it(`Clean up`, () => {
+            loginPage.loginAndOpenProject(apiType, dbType);
+            cy.openTableTab("Country", 25)
+
+            // delete row
+            mainPage.getPagination(5).click();
+            // kludge: flicker on load
+            cy.wait(3000)
+
+            // wait for page rendering to complete
+            cy.get(".nc-grid-row").should("have.length", 10);
+            mainPage.getCell("Country", 10).rightclick();
+            cy.getActiveMenu(".nc-dropdown-grid-context-menu")
+              .find('.ant-dropdown-menu-item:contains("Delete Row")')
+              .first()
+              .click();
+
+            // delete column
+            mainPage.deleteColumn("dummy");
+            mainPage.deleteCreatedViews();
         });
     });
 };

--- a/scripts/cypress/integration/common/5a_user_role.js
+++ b/scripts/cypress/integration/common/5a_user_role.js
@@ -23,25 +23,27 @@ export const genTest = (apiType, dbType) => {
 
     describe("Static user creations (different roles)", () => {
         before(() => {
-            mainPage.tabReset();
+            // standalone test
+            // loginPage.loginAndOpenProject(apiType, dbType);
 
-            // kludge: wait for page load to finish
-            cy.wait(4000);
-            // close team & auth tab
-            cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            cy.wait(1000);
-
+            // open a table to work on views
+            //
+            cy.restoreLocalStorage();
             settingsPage.openMenu(settingsPage.TEAM_N_AUTH)
-
-            cy.saveLocalStorage();
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
         });
 
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
         after(() => {
+            cy.restoreLocalStorage();
             cy.signOut();
+            cy.saveLocalStorage();
         });
 
         const addUser = (user) => {
@@ -116,7 +118,7 @@ export const genTest = (apiType, dbType) => {
         describe(`User role validation`, () => {
 
             before(() => {
-                // cy.restoreLocalStorage();
+                cy.restoreLocalStorage();
                 cy.visit(mainPage.roleURL[roleType])
                 cy.wait(5000);
 
@@ -175,9 +177,14 @@ export const genTest = (apiType, dbType) => {
                 cy.restoreLocalStorage();
             });
 
+            afterEach(() => {
+                cy.saveLocalStorage();
+            })
+
             after(() => {
-                // sign out
+                cy.restoreLocalStorage();
                 cy.signOut();
+                cy.saveLocalStorage();
             });
 
             ///////////////////////////////////////////////////////

--- a/scripts/cypress/integration/common/6b_downloadCsv.js
+++ b/scripts/cypress/integration/common/6b_downloadCsv.js
@@ -9,33 +9,22 @@ export const genTest = (apiType, dbType) => {
     if (!isTestSuiteActive(apiType, dbType)) return;
 
     describe(`${apiType.toUpperCase()} Upload/ Download CSV`, () => {
-        before(() => {
-
-            // kludge: wait for page load to finish
-            cy.wait(2000);
-            // close team & auth tab
-            cy.get('button.ant-tabs-tab-remove').should('exist').click();
-            cy.wait(1000);
-
-            cy.openTableTab("Country", 25);
-            cy.wait(1000);
-
-            cy.saveLocalStorage();
-            cy.wait(1000);
-        });
+        // before(() => {
+        //     // standalone test
+        //     // loginPage.loginAndOpenProject(apiType, dbType);
+        // });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
         });
 
-        after(() => {
-            cy.closeTableTab("Country");
+        afterEach(() => {
             cy.saveLocalStorage();
-            cy.wait(1000);
-        });
+        })
 
         it("Download verification- base view, default columns", () => {
+            cy.openTableTab("Country", 25);
+
             mainPage.hideField("LastUpdate");
             const verifyCsv = (retrievedRecords) => {
                 // expected output, statically configured
@@ -78,6 +67,8 @@ export const genTest = (apiType, dbType) => {
             // download & verify
             mainPage.downloadAndVerifyCsv(`Country_exported_1.csv`, verifyCsv);
             mainPage.unhideField("LastUpdate");
+
+            cy.closeTableTab("Country");
         });
     });
 };

--- a/scripts/cypress/integration/common/6d_language_validation.js
+++ b/scripts/cypress/integration/common/6d_language_validation.js
@@ -8,26 +8,27 @@ export const genTest = (apiType, dbType) => {
     describe(`Language support`, () => {
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
 
             cy.visit("/")
             cy.wait(5000);
-
-            cy.saveLocalStorage();
-            cy.wait(1000);
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
-        });
+        })
+
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         after(() => {
+            cy.restoreLocalStorage();
             cy.get('.nc-menu-accounts').should('exist').click();
             cy.getActiveMenu('.nc-dropdown-user-accounts-menu').find('.ant-dropdown-menu-item').eq(1).click();
 
             cy.wait(5000);
             cy.get('button:contains("SIGN")').should('exist')
+            cy.saveLocalStorage();
         })
 
         const langVerification = (idx, lang) => {

--- a/scripts/cypress/integration/common/6e_project_operations.js
+++ b/scripts/cypress/integration/common/6e_project_operations.js
@@ -8,12 +8,17 @@ export const genTest = (apiType, dbType) => {
 
         before(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
-
-            // loginPage.signIn(roles.owner.credentials);
             cy.visit("/");
             cy.wait(4000);
         });
+
+        cy.beforeEach(() => {
+            cy.restoreLocalStorage();
+        })
+
+        cy.afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         it("Delete Project", () => {
 

--- a/scripts/cypress/integration/common/6e_project_operations.js
+++ b/scripts/cypress/integration/common/6e_project_operations.js
@@ -12,11 +12,11 @@ export const genTest = (apiType, dbType) => {
             cy.wait(4000);
         });
 
-        cy.beforeEach(() => {
+        beforeEach(() => {
             cy.restoreLocalStorage();
         })
 
-        cy.afterEach(() => {
+        afterEach(() => {
             cy.saveLocalStorage();
         })
 

--- a/scripts/cypress/integration/common/6f_attachments.js
+++ b/scripts/cypress/integration/common/6f_attachments.js
@@ -9,20 +9,19 @@ export const genTest = (apiType, dbType) => {
         before(() => {
             loginPage.loginAndOpenProject(apiType, dbType);
             cy.openTableTab("Country", 25);
-            cy.wait(1000);
-
             cy.saveLocalStorage();
-            cy.wait(1000);
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
-        });
+        })
+
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         after(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
 
             // clean up
             mainPage.deleteColumn("testAttach");
@@ -44,6 +43,7 @@ export const genTest = (apiType, dbType) => {
             cy.getActiveMenu(".nc-dropdown-grid-context-menu").contains("Delete Row").click();
 
             cy.closeTableTab("Country");
+            cy.saveLocalStorage();
         });
 
         it(`Add column of type attachments`, () => {
@@ -62,9 +62,8 @@ export const genTest = (apiType, dbType) => {
         });
 
         it(`Form view with Attachment field- Submit & verify`, () => {
-
-            // open right navbar
-            cy.get('.nc-toggle-right-navbar').should('exist').click();
+            // // open right navbar
+            // cy.get('.nc-toggle-right-navbar').should('exist').click();
 
             // create form-view
             cy.get(`.nc-create-form-view`).click();
@@ -85,6 +84,8 @@ export const genTest = (apiType, dbType) => {
                     let linkText = $obj.text().trim();
                     cy.log(linkText);
 
+                    cy.signOut();
+
                     cy.visit(linkText, {
                         baseUrl: null,
                     });
@@ -101,7 +102,6 @@ export const genTest = (apiType, dbType) => {
                     cy.get('.ant-picker-dropdown').find(".ant-picker-now-btn").click();
                     cy.get('.ant-picker-dropdown').find("button.ant-btn-primary").click();
 
-
                     cy.get('.nc-attachment-cell')
                       .attachFile(`sampleFiles/1.json`, { subjectType: 'drag-n-drop' });
 
@@ -117,11 +117,11 @@ export const genTest = (apiType, dbType) => {
 
         it(`Filter column which contain only attachments, download CSV`, () => {
             // come back to main window
-            // loginPage.loginAndOpenProject(apiType, dbType);
-            cy.visit('/')
-            cy.wait(5000)
+            loginPage.loginAndOpenProject(apiType, dbType);
+            // cy.visit('/')
+            // cy.wait(5000)
+            // projectsPage.openConfiguredProject(apiType, dbType);
 
-            projectsPage.openConfiguredProject(apiType, dbType);
             cy.openTableTab("Country", 25);
             cy.wait(1000);
 

--- a/scripts/cypress/integration/common/6g_base_share.js
+++ b/scripts/cypress/integration/common/6g_base_share.js
@@ -57,20 +57,21 @@ export const genTest = (apiType, dbType) => {
 
     describe(`${apiType.toUpperCase()} Base VIEW share`, () => {
         before(() => {
-            loginPage.loginAndOpenProject(apiType, dbType);
-
+            // loginPage.loginAndOpenProject(apiType, dbType);
+            cy.restoreLocalStorage();
             cy.openTableTab("Country", 25);
-            cy.wait(1000);
-
             cy.saveLocalStorage();
-            cy.wait(1000);
         });
 
-        it(`Generate base share URL`, () => {
-
+        beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
+        })
 
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
+        it(`Generate base share URL`, () => {
             // click SHARE
             cy.get(".nc-share-base:visible").should('exist').click();
 
@@ -121,10 +122,6 @@ style="background: transparent; "></iframe>
             cy.log(linkText);
 
             cy.signOut();
-            cy.deleteLocalStorage();
-            cy.wait(1000);
-            cy.printLocalStorage();
-
         });
 
         permissionValidation("viewer");
@@ -143,10 +140,6 @@ style="background: transparent; "></iframe>
                 .click();
 
             cy.signOut();
-            cy.deleteLocalStorage();
-            cy.wait(1000);
-            cy.printLocalStorage();
-
         });
 
         permissionValidation("editor");
@@ -178,7 +171,6 @@ style="background: transparent; "></iframe>
             // validate data (row-1)
             cy.iframe().find(`.nc-grid-cell`).eq(1).contains("PENELOPE").should("exist");
             cy.iframe().find(`.nc-grid-cell`).eq(2).contains("GUINESS").should("exist");
-
         });
     })
 }

--- a/scripts/cypress/integration/common/7a_create_project_from_excel.js
+++ b/scripts/cypress/integration/common/7a_create_project_from_excel.js
@@ -68,11 +68,9 @@ export const genTest = (apiType, dbType) => {
 
     describe(`Import from excel`, () => {
         before(() => {
-
             // loginPage.signIn(roles.owner.credentials);
 
             cy.restoreLocalStorage();
-            cy.wait(1000);
 
             cy.task("readSheetList", {
                 file: `./scripts/cypress/fixtures/${filepath}`,
@@ -89,18 +87,20 @@ export const genTest = (apiType, dbType) => {
                 sheetData = rows;
             });
 
-            // loginPage.signIn(roles.owner.credentials);
+            cy.visit("/")
             projectsPage.createProject({ dbType: "none", apiType: "REST", name: "importSample" }, {})
             cy.wait(4000);
 
             cy.saveLocalStorage();
-            cy.wait(1000);
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
         });
+
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         it("File Upload: Upload excel as template", () => {
 
@@ -264,24 +264,6 @@ export const genTest = (apiType, dbType) => {
                         .should("exist");
             }
             cy.closeTableTab("Sheet1");
-        });
-
-        after(() => {
-            // delete project once all operations are completed
-            // mainPage.toolBarTopLeft(mainPage.HOME).click();
-            // projectsPage.deleteProject("importSample");
-
-            // cy.get('.nc-noco-brand-icon').click();
-            //
-            // cy.get(`.nc-action-btn`)
-            //   .should("exist")
-            //   .last()
-            //   .click();
-            //
-            // cy.getActiveModal()
-            //   .find(".ant-btn-dangerous")
-            //   .should("exist")
-            //   .click();
         });
     });
 };

--- a/scripts/cypress/integration/common/7b_import_from_airtable.js
+++ b/scripts/cypress/integration/common/7b_import_from_airtable.js
@@ -18,11 +18,20 @@ export const genTest = (apiType, dbType) => {
 
       loginPage.signIn(roles.owner.credentials);
       projectsPage.createProject({ dbType: "none", apiType: "REST", name: "importSample" }, {})
-    });
-
-    after(() => {
       cy.saveLocalStorage();
     });
+
+    beforeEach(() => {
+      cy.restoreLocalStorage();
+    });
+
+    afterEach(() => {
+      cy.saveLocalStorage();
+    });
+
+    // after(() => {
+    //   cy.saveLocalStorage();
+    // });
 
     it("Import", () => {
       cy.log(apiKey, sharedBase);

--- a/scripts/cypress/integration/common/8a_webhook.js
+++ b/scripts/cypress/integration/common/8a_webhook.js
@@ -228,20 +228,21 @@ export const genTest = (apiType, dbType) => {
         before(() => {
             loginPage.loginAndOpenProject(apiType, dbType);
             cy.createTable("Temp");
-            cy.wait(1000);
-
             cy.saveLocalStorage();
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
-            cy.wait(1000);
         });
 
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
+
         after(() => {
+            cy.restoreLocalStorage();
             cy.deleteTable("Temp");
             cy.saveLocalStorage();
-            cy.wait(1000);
         });
 
         it("Create: 'After Insert' event", () => {

--- a/scripts/cypress/integration/common/9a_QuickTest.js
+++ b/scripts/cypress/integration/common/9a_QuickTest.js
@@ -81,8 +81,6 @@ export const genTest = (apiType, dbType, testMode) => {
         }
 
         before(() => {
-            cy.restoreLocalStorage();
-
             if( testMode === 'CY_QUICK') {
                 // cy.task("copyFile")
                 loginPage.signIn(roles.owner.credentials);
@@ -93,28 +91,31 @@ export const genTest = (apiType, dbType, testMode) => {
                 // close team & auth tab
                 cy.get('button.ant-tabs-tab-remove').should('exist').click();
                 cy.wait(1000);
-
-                cy.saveLocalStorage();
             }
+            else {
+                cy.restoreLocalStorage();
+            }
+
+            cy.openTableTab("Film", 3)
+            cy.saveLocalStorage();
+
         });
 
         beforeEach(() => {
             cy.restoreLocalStorage();
         })
 
-        // afterEach(() => {
-        //     cy.saveLocalStorage();
-        // })
+        afterEach(() => {
+            cy.saveLocalStorage();
+        })
 
         after(() => {
             cy.restoreLocalStorage();
-
-            // sign out
             cy.signOut();
+            cy.saveLocalStorage();
         });
 
         it("Verify Schema", () => {
-            cy.openTableTab("Film", 3)
 
             // verify if all tables exist
             for(let i=0; i<tn.length; i++) {
@@ -129,7 +130,6 @@ export const genTest = (apiType, dbType, testMode) => {
         });
 
         it("Verify Data types", () => {
-            cy.openTableTab("Film", 3);
 
             // normal cells
             for (let [key, value] of Object.entries(records)) {
@@ -188,12 +188,9 @@ export const genTest = (apiType, dbType, testMode) => {
                 mainPage.getCell("Producer", cellIdx).find('.chip').eq(1).contains(records2.Producer[1]).should('exist')
             }
 
-            cy.closeTableTab("Film");
         });
 
         it("Verify Views & Shared base", () => {
-            cy.openTableTab("Film", 3);
-            mainPage.toggleRightSidebar();
             cy.get('.nc-form-view-item:visible')
                 .should('exist')
                 .eq(0)
@@ -333,7 +330,6 @@ export const genTest = (apiType, dbType, testMode) => {
 
         it("Verify Fields, Filter & Sort", () => {
             cy.openTableTab("Actor", 25);
-            mainPage.toggleRightSidebar();
 
             cy.get(".nc-grid-view-item").eq(1).click()
 
@@ -387,7 +383,6 @@ export const genTest = (apiType, dbType, testMode) => {
             if( testMode === 'CY_QUICK') {
 
                 cy.openTableTab("Producer", 3)
-                mainPage.toggleRightSidebar();
 
                 cy.get('.nc-grid-view-item').should('have.length', 4)
                 cy.get('.nc-form-view-item').should('have.length', 4)

--- a/scripts/cypress/integration/spec/roleValidation.spec.js
+++ b/scripts/cypress/integration/spec/roleValidation.spec.js
@@ -221,13 +221,6 @@ export function _viewMenu(roleType, mode) {
 
     cy.openTableTab(columnName, 25);
 
-    cy.get('.nc-toggle-right-navbar').click();
-    cy.wait(1000);
-
-    // hard-wire
-    // window.localStorage.setItem('nc-right-sidebar', '{"isOpen":true,"hasSidebar":true}')
-
-
     let validationString =
         true === roles[roleType].validations.shareView ? "exist" : "not.exist";
 

--- a/scripts/cypress/support/commands.js
+++ b/scripts/cypress/support/commands.js
@@ -235,39 +235,19 @@ let LOCAL_STORAGE_MEMORY = {};
 let LOCAL_STORAGE_MEMORY_v2 = {};
 
 Cypress.Commands.add('saveLocalStorage', (name) => {
-  if (name) {
-    cy.task('log', `[saveLocalStorage] ${name}`);
-    LOCAL_STORAGE_MEMORY_v2[name] = {};
-    Object.keys(localStorage).forEach((key) => {
-      LOCAL_STORAGE_MEMORY_v2[name][key] = localStorage[key];
-    });
-    return;
-  }
-
   LOCAL_STORAGE_MEMORY = {};
   Object.keys(localStorage).forEach((key) => {
     LOCAL_STORAGE_MEMORY[key] = localStorage[key];
   });
   cy.printLocalStorage();
-
 });
 
 Cypress.Commands.add('restoreLocalStorage', (name) => {
-  if (name) {
-    cy.task('log', `[restoreLocalStorage] ${name}`);
-    Object.keys(LOCAL_STORAGE_MEMORY_v2[name]).forEach((key) => {
-      localStorage.setItem(key, LOCAL_STORAGE_MEMORY_v2[name][key]);
-    });
-    return;
-  }
-
-  cy.deleteLocalStorage().then(() => {
     Object.keys(LOCAL_STORAGE_MEMORY).forEach((key) => {
       localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
     });
 
     cy.printLocalStorage();
-  });
 });
 
 Cypress.Commands.add('deleteLocalStorage', () => {


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
- Local storage handling fixed
  - save local storage after each test case
  - restore before each test case
  - after hook operations, if required: restore local storage before execution & save after
  - before hook operations, if required: restore local storage before execution & save after
- Tab assumed always available on opening table; not toggling anywhere currently
  - TBD: add test to toggle right nav bar & ensure its hidden    

## Change type
- [x] test: (adding missing tests, refactoring tests; no production code change)

## Test/ Verification
- verified in CI-CD
- at times, screen goes blank; tests failures related to this need fix; wip