### PR TITLE
chore(nc-gui): env var for info-msg duration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start:xcdb-api:cache-v1-backup": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk; npm install; NC_DISABLE_TELE=true NC_INFLECTION=camelize DATABASE_URL=sqlite:../../../scripts/cypress/fixtures/sqlite-sakila/sakila.db npm run watch:run:cypress",
     "start:xcdb-api:cache": "npm run build:common ; cd ./packages/nocodb; npm install ../nocodb-sdk; npm install; NC_EXPORT_MAX_TIMEOUT=60000 NC_DISABLE_TELE=true NC_INFLECTION=camelize DATABASE_URL=sqlite:../../../scripts/cypress/fixtures/sqlite-sakila/sakila.db npm run watch:run:cypress",
     "start:web-v1-backup": "npm run build:common ; cd ./packages/nc-gui; npm install ../nocodb-sdk; npm install; npm run dev",
-    "start:web": "npm run build:common ; cd ./packages/nc-gui; npm install ../nocodb-sdk; npm install; npm run dev",
+    "start:web": "npm run build:common ; cd ./packages/nc-gui; npm install ../nocodb-sdk; npm install; ANT_MESSAGE_DURATION=0.2 npm run dev",
     "cypress-v1-backup:run": "cypress run --config-file ./scripts/cypress/cypress.json",
     "cypress-v1-backup:open": "cypress open --config-file ./scripts/cypress/cypress.json",
     "cypress:run": "cypress run --config-file ./scripts/cypress/cypress.json",

--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -84,6 +84,7 @@ export default defineNuxtConfig({
     define: {
       'process.env.DEBUG': 'false',
       'process.nextTick': () => {},
+      'process.env.ANT_MESSAGE_DURATION': process.env.ANT_MESSAGE_DURATION,
     },
     server: {
       watch: {

--- a/packages/nc-gui/plugins/ant.ts
+++ b/packages/nc-gui/plugins/ant.ts
@@ -1,7 +1,10 @@
-import { Menu as AntMenu, Modal as AntModal } from 'ant-design-vue'
+import { Menu as AntMenu, Modal as AntModal, message } from 'ant-design-vue'
 import { defineNuxtPlugin } from '#imports'
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.component(AntMenu.name, AntMenu)
   nuxtApp.vueApp.component(AntModal.name, AntModal)
+  message.config({
+    duration: +(process.env.ANT_MESSAGE_DURATION ?? 3),
+  })
 })


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Toast duration is made configurable.
Would help in reducing CY test execution time.

## Change type
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
Locally verified