### PR TITLE
fix(nc-gui): search option for webhook-header dropdown

### DIFF
--- a/packages/nc-gui/components/api-client/Headers.vue
+++ b/packages/nc-gui/components/api-client/Headers.vue
@@ -93,8 +93,9 @@ const deleteHeaderRow = (idx: number) => vModel.value.splice(idx, 1)
                 placeholder="Key"
                 class="nc-input-hook-header-key"
                 dropdown-class-name="nc-dropdown-webhook-header"
+                show-search
               >
-                <a-select-option v-for="(header, i) in headerList" :key="i" :value="header">
+                <a-select-option v-for="header in headerList" :key="header" :value="header">
                   {{ header }}
                 </a-select-option>
               </a-select>


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
webhook header dropdown made searchable

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification
locally verified