### PR TITLE
fix(nc-gui): adding max-width-250px to sharedViewList password

### DIFF
--- a/packages/nc-gui/components/smartsheet-toolbar/SharedViewList.vue
+++ b/packages/nc-gui/components/smartsheet-toolbar/SharedViewList.vue
@@ -125,7 +125,7 @@ const deleteLink = async (id: string) => {
         <template #default="{ record }">
           <div class="flex items-center items-center gap-1">
             <template v-if="record.password">
-              <span class="h-min">{{ record.showPassword ? record.password : '***************************' }}</span>
+              <span class="h-min max-w-[250px]">{{ record.showPassword ? record.password : Array(record.password.length + 1).join("*") }}</span>
               <component
                 :is="record.showPassword ? MdiVisibilityOffIcon : MdiVisibilityOnIcon"
                 @click="record.showPassword = !record.showPassword"


### PR DESCRIPTION
## Change Summary

Adding max-width-[250px] to wrap the password and generating `"` based on the length of the password.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [X] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi-colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

None

## Additional information / screenshots (optional)
![Screenshot 2022-09-24 at 4 04 08 AM](https://user-images.githubusercontent.com/16558205/192066772-8ef8ce68-8a4a-4350-99ea-ff68e3ed5e29.png)

![Screenshot 2022-09-24 at 4 04 16 AM](https://user-images.githubusercontent.com/16558205/192066778-23b736c8-48e9-41aa-859b-965fc5f2687c.png)


