### PR TITLE
fix(nc-gui): adding min-w-4 to icons in gallery view drawer

### DIFF
--- a/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
@@ -67,8 +67,12 @@ const copyRecordUrl = () => {
         {{ table }}
       </template>
       -->
-
-      <template v-if="primaryValue">: {{ primaryValue }}</template>
+      <template v-if="primaryValue"
+        >:
+        {{
+          primaryValue + 'something https://github.com/nocodb/nocodb/issues/3647 https://github.com/nocodb/nocodb/issues/3647 '
+        }}</template
+      >
     </h5>
 
     <div class="flex-1" />

--- a/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
@@ -67,6 +67,7 @@ const copyRecordUrl = () => {
         {{ table }}
       </template>
       -->
+
       <template v-if="primaryValue">: {{ primaryValue }}</template>
     </h5>
 
@@ -75,14 +76,18 @@ const copyRecordUrl = () => {
       <template #title>
         <div class="text-center w-full">{{ $t('general.reload') }}</div>
       </template>
-      <mdi-reload v-if="!isNew" class="cursor-pointer select-none text-gray-500 mx-1" @click="loadRow" />
+      <mdi-reload v-if="!isNew" class="cursor-pointer select-none text-gray-500 mx-1 min-w-4" @click="loadRow" />
     </a-tooltip>
     <a-tooltip placement="bottom">
       <template #title>
         <!-- todo: i18n -->
         <div class="text-center w-full">Copy record URL</div>
       </template>
-      <mdi-link v-if="!isNew" class="cursor-pointer select-none text-gray-500 mx-1 nc-copy-row-url" @click="copyRecordUrl" />
+      <mdi-link
+        v-if="!isNew"
+        class="cursor-pointer select-none text-gray-500 mx-1 nc-copy-row-url min-w-4"
+        @click="copyRecordUrl"
+      />
     </a-tooltip>
     <a-tooltip v-if="!isSqlView" placement="bottom">
       <!--      Toggle comments draw -->
@@ -92,7 +97,7 @@ const copyRecordUrl = () => {
       <MdiCommentTextOutline
         v-if="isUIAllowed('rowComments') && !isNew"
         v-e="['c:row-expand:comment-toggle']"
-        class="cursor-pointer select-none nc-toggle-comments text-gray-500 mx-1"
+        class="cursor-pointer select-none nc-toggle-comments text-gray-500 mx-1 min-w-4"
         @click="commentsDrawer = !commentsDrawer"
       />
     </a-tooltip>

--- a/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Header.vue
@@ -67,12 +67,7 @@ const copyRecordUrl = () => {
         {{ table }}
       </template>
       -->
-      <template v-if="primaryValue"
-        >:
-        {{
-          primaryValue + 'something https://github.com/nocodb/nocodb/issues/3647 https://github.com/nocodb/nocodb/issues/3647 '
-        }}</template
-      >
+      <template v-if="primaryValue">: {{ primaryValue }}</template>
     </h5>
 
     <div class="flex-1" />


### PR DESCRIPTION
## Change Summary

Added `min-w-4` so that icons in gallery view don't get squished.
Issue - https://github.com/nocodb/nocodb/issues/3647

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [X] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

None

## Additional information / screenshots (optional)

![Screenshot 2022-09-26 at 3 47 25 AM](https://user-images.githubusercontent.com/16558205/192168013-933070aa-9c53-42e2-bc1d-2351e930a273.png)

