### PR TITLE
feat(nc-gui): shared-view postmessage on locationchange

### DIFF
--- a/packages/nc-gui/layouts/shared-view.vue
+++ b/packages/nc-gui/layouts/shared-view.vue
@@ -1,7 +1,26 @@
 <script lang="ts" setup>
+import { useRouter } from 'vue-router'
 import { navigateTo } from '#app'
 const { isLoading, currentVersion } = useGlobal()
 const { sharedView } = useSharedView()
+const router = useRouter()
+
+if (window.parent !== window) {
+  const notifyLocationChange = (value: string) =>
+    window.parent.postMessage(
+      {
+        event: 'locationchange',
+        payload: { value },
+      },
+      '*',
+    )
+
+  router.afterEach((to) => notifyLocationChange(location.origin + to.fullPath))
+  window.addEventListener('beforeunload', () => {
+    const { href } = document.activeElement as { href?: string }
+    if (href) notifyLocationChange(href)
+  })
+}
 </script>
 
 <script lang="ts">

--- a/packages/nc-gui/layouts/shared-view.vue
+++ b/packages/nc-gui/layouts/shared-view.vue
@@ -6,6 +6,11 @@ const router = useRouter()
 
 onMounted(() => {
   // check if we are inside an iframe
+  // if we are, communicate to the parent page whenever we navigate to a new url,
+  // so that the parent page can respond to it properly.
+  // E.g. by making the browser navigate to that url, and not just the iframe.
+  // This is useful for integrating NocoDB into other products,
+  // such as Outline (https://github.com/outline/outline/pull/4184).
   if (window.parent !== window) {
     const notifyLocationChange = (value: string) =>
       window.parent.postMessage(

--- a/packages/nc-gui/layouts/shared-view.vue
+++ b/packages/nc-gui/layouts/shared-view.vue
@@ -1,26 +1,28 @@
 <script lang="ts" setup>
-import { useRouter } from 'vue-router'
-import { navigateTo } from '#app'
+import { navigateTo, useEventListener, useRouter } from '#imports'
 const { isLoading, currentVersion } = useGlobal()
 const { sharedView } = useSharedView()
 const router = useRouter()
 
-if (window.parent !== window) {
-  const notifyLocationChange = (value: string) =>
-    window.parent.postMessage(
-      {
-        event: 'locationchange',
-        payload: { value },
-      },
-      '*',
-    )
+onMounted(() => {
+  // check if we are inside an iframe
+  if (window.parent !== window) {
+    const notifyLocationChange = (value: string) =>
+      window.parent.postMessage(
+        {
+          event: 'locationchange',
+          payload: { value },
+        },
+        '*',
+      )
 
-  router.afterEach((to) => notifyLocationChange(location.origin + to.fullPath))
-  window.addEventListener('beforeunload', () => {
-    const { href } = document.activeElement as { href?: string }
-    if (href) notifyLocationChange(href)
-  })
-}
+    router.afterEach((to) => notifyLocationChange(location.origin + to.fullPath))
+    useEventListener(window, 'beforeunload', () => {
+      const { href } = document.activeElement as { href?: string }
+      if (href) notifyLocationChange(href)
+    })
+  }
+})
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Change Summary

Hopefully this is an easy change to review and accept: when a shared view is loaded into an iframe, this allows the parent page to respond to navigating away from the shared view page.

I am planning to use this in my NocoDB plugin for Outline. Right now if I click a url inside of my NocoDB table in a shared view, it loads the page in the iframe, and I want the parent page to navigate to the URL instead. Detecting navigation events from the parent directly, without using postmessage API, is not possible with the strict cross-origin policy in modern browsers.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
