### PR TITLE
chore(CICD): conditionally trigger CICD for draft PR

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,7 @@ on:
 jobs:
     cypress-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -66,7 +66,7 @@ jobs:
             retention-days: 2
     cypress-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -111,7 +111,7 @@ jobs:
             retention-days: 2
     cypress-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -156,7 +156,7 @@ jobs:
             retention-days: 2
     cypress-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -201,7 +201,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -246,7 +246,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -291,7 +291,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -336,7 +336,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -381,7 +381,7 @@ jobs:
             retention-days: 2
     cypress-pg-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -426,7 +426,7 @@ jobs:
             retention-days: 2
     cypress-pg-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -471,7 +471,7 @@ jobs:
             retention-days: 2
     cypress-pg-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -516,7 +516,7 @@ jobs:
             retention-days: 2
     cypress-pg-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -561,7 +561,7 @@ jobs:
             retention-days: 2
     cy-quick-sqlite:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -607,7 +607,7 @@ jobs:
             retention-days: 2
     cy-quick-pg:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -652,7 +652,7 @@ jobs:
             retention-days: 2
     unit-tests:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -692,7 +692,7 @@ jobs:
           run: npm run test:unit
     cypress-db-independent:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,7 @@ on:
             - "packages/nocodb/**"
             - ".github/workflows/ci-cd.yml"
     pull_request:
+        types: [opened, reopened, synchronize, ready_for_review, labeled]
         branches: [develop]
         paths:
             - "packages/nc-gui/**"
@@ -21,7 +22,7 @@ on:
 jobs:
     cypress-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -66,7 +67,7 @@ jobs:
             retention-days: 2
     cypress-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -111,7 +112,7 @@ jobs:
             retention-days: 2
     cypress-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -156,7 +157,7 @@ jobs:
             retention-days: 2
     cypress-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -201,7 +202,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -246,7 +247,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -291,7 +292,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -336,7 +337,7 @@ jobs:
             retention-days: 2
     cypress-xcdb-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -381,7 +382,7 @@ jobs:
             retention-days: 2
     cypress-pg-restTableOps-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -426,7 +427,7 @@ jobs:
             retention-days: 2
     cypress-pg-restViews-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -471,7 +472,7 @@ jobs:
             retention-days: 2
     cypress-pg-restRoles-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -516,7 +517,7 @@ jobs:
             retention-days: 2
     cypress-pg-restMisc-run-cache:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -561,7 +562,7 @@ jobs:
             retention-days: 2
     cy-quick-sqlite:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -607,7 +608,7 @@ jobs:
             retention-days: 2
     cy-quick-pg:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -652,7 +653,7 @@ jobs:
             retention-days: 2
     unit-tests:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1
@@ -692,7 +693,7 @@ jobs:
           run: npm run test:unit
     cypress-db-independent:
       runs-on: ubuntu-20.04
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'trigger-CI' || !github.event.pull_request.draft }}
+      if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
       steps:
         - name: Setup Node
           uses: actions/setup-node@v1

--- a/scripts/cypress/integration/common/00_pre_configurations.js
+++ b/scripts/cypress/integration/common/00_pre_configurations.js
@@ -165,7 +165,6 @@ export const genTest = (apiType, dbType) => {
     it("Admin SignUp", () => {
       cy.task("log", "This will be output to the terminal");
       cy.task("log", "This will be output to the terminal");
-      loginPage.signUp(roles.owner.credentials);
     });
 
     function cy_createProjectBlock(proj, apiType, dbType) {

--- a/scripts/cypress/integration/common/00_pre_configurations.js
+++ b/scripts/cypress/integration/common/00_pre_configurations.js
@@ -164,6 +164,7 @@ export const genTest = (apiType, dbType) => {
 
     it("Admin SignUp", () => {
       cy.task("log", "This will be output to the terminal");
+      cy.task("log", "This will be output to the terminal");
       loginPage.signUp(roles.owner.credentials);
     });
 

--- a/scripts/cypress/integration/common/00_pre_configurations.js
+++ b/scripts/cypress/integration/common/00_pre_configurations.js
@@ -164,7 +164,7 @@ export const genTest = (apiType, dbType) => {
 
     it("Admin SignUp", () => {
       cy.task("log", "This will be output to the terminal");
-      cy.task("log", "This will be output to the terminal");
+      loginPage.signUp(roles.owner.credentials);
     });
 
     function cy_createProjectBlock(proj, apiType, dbType) {


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Often it's required to trigger CICD even when PR is in a draft state (specifically when making changes to CY). Marking it as `ready for review` would also start the `release PR` action. Hence introducing conditional triggering of CI even if PR is in draft state if it includes label `trigger-CI`


## Change type
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
- Verified triggering of CI when label `trigger-CI` is included
- Verified skipping of CI when label is excluded (status quo)

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
