### PR TITLE
Fix: add singletext number-based sort support

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/sortV2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/sortV2.ts
@@ -232,8 +232,19 @@ export default async function sortV2(
           break;
         }
       default:
-        qb.orderBy(sanitize(column.column_name), sort.direction || 'asc');
+      {
+        const clientType = knex.clientType();
+        if (clientType === 'mssql') {
+          qb
+            .orderBy(sanitize(knex.raw('LEN(??)', [column.column_name])))
+            .orderBy(sanitize(column.column_name), sort.direction || 'asc');
+        } else {
+          qb
+            .orderBy(sanitize(knex.raw('LENGTH(??)', [column.column_name])))
+            .orderBy(sanitize(column.column_name), sort.direction || 'asc');
+        }
         break;
+      }
     }
   }
 }


### PR DESCRIPTION
## Change Summary

To support number-based sort on varchar, normally, it is achieved by `ORDER BY LENGTH(column_name), column_name`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)
<img width="1185" alt="Screen Shot 2565-10-04 at 10 06 39 AM" src="https://user-images.githubusercontent.com/17776837/193725898-0eb05344-7ca6-46e9-8278-a9bf543739c5.png">

Anything for maintainers to be made aware of
