### PR TITLE
fix: at import failing if more than 64 select options provided

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/MysqlUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/MysqlUi.ts
@@ -944,7 +944,7 @@ export class MysqlUi {
     }
   }
 
-  static getDataTypeForUiType(col: { uidt: UITypes }, idType?: IDType) {
+  static getDataTypeForUiType(col: { uidt: UITypes, dtxp?: string, colOptions?: any }, idType?: IDType) {
     const colProp: any = {};
     switch (col.uidt) {
       case 'ID':
@@ -977,6 +977,9 @@ export class MysqlUi {
         break;
       case 'MultiSelect':
         colProp.dt = 'set';
+        if (col.colOptions?.options.length > 64 || col.dtxp?.split(',').length > 64) {
+          colProp.dt = 'text';
+        }
         break;
       case 'SingleSelect':
         colProp.dt = 'enum';

--- a/packages/nocodb/src/lib/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/meta/api/columnApis.ts
@@ -935,17 +935,30 @@ export async function columnUpdate(req: Request, res: Response<TableType>) {
             }
           } else if (column.uidt === UITypes.MultiSelect) {
             if (driverType === 'mysql' || driverType === 'mysql2') {
-              await dbDriver.raw(
-                `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), ',')) WHERE FIND_IN_SET(?, ??)`,
-                [
-                  table.table_name,
-                  column.column_name,
-                  column.column_name,
-                  option.title,
-                  option.title,
-                  column.column_name,
-                ]
-              );
+              if (colBody.dt === 'set') {
+                await dbDriver.raw(
+                  `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), ',')) WHERE FIND_IN_SET(?, ??)`,
+                  [
+                    table.table_name,
+                    column.column_name,
+                    column.column_name,
+                    option.title,
+                    option.title,
+                    column.column_name,
+                  ]
+                );
+              } else {
+                await dbDriver.raw(
+                  `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), ','))`,
+                  [
+                    table.table_name,
+                    column.column_name,
+                    column.column_name,
+                    option.title,
+                  ]
+                );
+              }
+              
             } else if (driverType === 'pg') {
               await dbDriver.raw(
                 `UPDATE ?? SET ??  = array_to_string(array_remove(string_to_array(??, ','), ?), ',')`,
@@ -1101,18 +1114,31 @@ export async function columnUpdate(req: Request, res: Response<TableType>) {
             }
           } else if (column.uidt === UITypes.MultiSelect) {
             if (driverType === 'mysql' || driverType === 'mysql2') {
-              await dbDriver.raw(
-                `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ','))) WHERE FIND_IN_SET(?, ??)`,
-                [
-                  table.table_name,
-                  column.column_name,
-                  column.column_name,
-                  option.title,
-                  newOp.title,
-                  option.title,
-                  column.column_name,
-                ]
-              );
+              if (colBody.dt === 'set') {
+                await dbDriver.raw(
+                  `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ','))) WHERE FIND_IN_SET(?, ??)`,
+                  [
+                    table.table_name,
+                    column.column_name,
+                    column.column_name,
+                    option.title,
+                    newOp.title,
+                    option.title,
+                    column.column_name,
+                  ]
+                );
+              } else {
+                await dbDriver.raw(
+                  `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ',')))`,
+                  [
+                    table.table_name,
+                    column.column_name,
+                    column.column_name,
+                    option.title,
+                    newOp.title,
+                  ]
+                );
+              } 
             } else if (driverType === 'pg') {
               await dbDriver.raw(
                 `UPDATE ?? SET ??  = array_to_string(array_replace(string_to_array(??, ','), ?, ?), ',')`,
@@ -1174,18 +1200,33 @@ export async function columnUpdate(req: Request, res: Response<TableType>) {
           }
         } else if (column.uidt === UITypes.MultiSelect) {
           if (driverType === 'mysql' || driverType === 'mysql2') {
-            await dbDriver.raw(
-              `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ','))) WHERE FIND_IN_SET(?, ??)`,
-              [
-                table.table_name,
-                column.column_name,
-                column.column_name,
-                ch.temp_title,
-                newOp.title,
-                ch.temp_title,
-                column.column_name,
-              ]
-            );
+            if (colBody.dt === 'set') {
+              await dbDriver.raw(
+                `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ','))) WHERE FIND_IN_SET(?, ??)`,
+                [
+                  table.table_name,
+                  column.column_name,
+                  column.column_name,
+                  ch.temp_title,
+                  newOp.title,
+                  ch.temp_title,
+                  column.column_name,
+                ]
+              );
+            } else {
+              await dbDriver.raw(
+                `UPDATE ?? SET ?? = TRIM(BOTH ',' FROM REPLACE(CONCAT(',', ??, ','), CONCAT(',', ?, ','), CONCAT(',', ?, ',')))`,
+                [
+                  table.table_name,
+                  column.column_name,
+                  column.column_name,
+                  ch.temp_title,
+                  newOp.title,
+                  ch.temp_title,
+                  column.column_name,
+                ]
+              );
+            }
           } else if (driverType === 'pg') {
             await dbDriver.raw(
               `UPDATE ?? SET ??  = array_to_string(array_replace(string_to_array(??, ','), ?, ?), ',')`,

--- a/packages/nocodb/src/lib/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/meta/api/columnApis.ts
@@ -605,6 +605,12 @@ export async function columnAdd(req: Request, res: Response<TableType>) {
             ) {
               colBody.dtxp = "''";
             }
+
+            if (colBody.dt === 'set') {
+              if (colBody.colOptions?.options.length > 64) {
+                colBody.dt = 'text';
+              }
+            }
           }
         }
 
@@ -900,6 +906,12 @@ export async function columnUpdate(req: Request, res: Response<TableType>) {
           (!colBody.dtxp || colBody.dtxp === '')
         ) {
           colBody.dtxp = "''";
+        }
+
+        if (colBody.dt === 'set') {
+          if (colBody.colOptions?.options.length > 64) {
+            colBody.dt = 'text';
+          }
         }
       }
 

--- a/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
@@ -577,11 +577,15 @@ export default async (
             ncCol.colOptions = {
               options: [...colOptions.data],
             };
-            // if options are empty, configure '' as default option
-            ncCol.dtxp =
-              colOptions.data
-                .map((el) => `'${el.title.replace(/'/gi, "''")}'`)
-                .join(',') || "''";
+
+            if (['mysql', 'mysql2'].includes(getRootDbType())) {
+              // if options are empty, configure '' as an option
+              ncCol.dtxp =
+                colOptions.data
+                  .map((el) => `'${el.title.replace(/'/gi, "''")}'`)
+                  .join(',') || "''";
+            }
+            
             break;
           case undefined:
             break;

--- a/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
@@ -446,7 +446,7 @@ export default async (
           // TODO fix record mapping (this causes every record to map first option, we can't handle them using data api as they don't provide option id within data we might instead get the correct mapping from schema file )
           let dupNo = 1;
           const defaultName = (value as any).name;
-          while (options.find((el) => el.title === (value as any).name)) {
+          while (options.find((el) => el.title.toLowerCase() === (value as any).name.toLowerCase())) {
             (value as any).name = `${defaultName}_${dupNo++}`;
           }
           options.push({


### PR DESCRIPTION
## Change Summary

MySQL: we use enum for single select and set for multi select but [set only allow 64 distinct members](https://dev.mysql.com/doc/refman/8.0/en/set.html). So we will fallback using text for multi-select when importing a multi-select column with options more than 64.
- MySQL use find_in_set only if dt is set (this logic was missing from column apis)
- AT import:
  - match select options case-insensitive (as this leads duplicate entries on db level)
  - use text as dt if 64 or more options provided for multiselect on MySQL
- use text as dt if 64 or more options provided for multiselect on MySQL (Extended this fix to column api level)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
