### PR TITLE
feat: OpenID Connect authentication

### DIFF
--- a/packages/nc-gui/composables/useGlobal/state.ts
+++ b/packages/nc-gui/composables/useGlobal/state.ts
@@ -82,7 +82,7 @@ export function useGlobalState(storageKey = 'nocodb-gui-v2'): State {
     firstUser: true,
     githubAuthEnabled: false,
     googleAuthEnabled: true,
-    oidcAuthName: '',
+    oidcAuthName: null,
     ncMin: false,
     oneClick: false,
     projectHasAdmin: false,

--- a/packages/nc-gui/composables/useGlobal/state.ts
+++ b/packages/nc-gui/composables/useGlobal/state.ts
@@ -82,6 +82,7 @@ export function useGlobalState(storageKey = 'nocodb-gui-v2'): State {
     firstUser: true,
     githubAuthEnabled: false,
     googleAuthEnabled: true,
+    oidcAuthName: '',
     ncMin: false,
     oneClick: false,
     projectHasAdmin: false,

--- a/packages/nc-gui/composables/useGlobal/types.ts
+++ b/packages/nc-gui/composables/useGlobal/types.ts
@@ -19,6 +19,7 @@ export interface AppInfo {
   firstUser: boolean
   githubAuthEnabled: boolean
   googleAuthEnabled: boolean
+  oidcAuthName: string | null
   ncMin: boolean
   oneClick: boolean
   projectHasAdmin: boolean

--- a/packages/nc-gui/lang/ar.json
+++ b/packages/nc-gui/lang/ar.json
@@ -293,8 +293,8 @@
     "commentsOnly": "التعليقات فقط",
     "documentation": "الوثائق",
     "subscribeNewsletter": "اشترك في نشرتنا الإخبارية الأسبوعية",
-    "signUpWithGoogle": "التسجيل بواسطة Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "التسجيل بواسطة {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "بالتسجيل، أنت توافق على شروط الخدمة",
     "welcomeToNc": "مرحبا بكم في NocoDB!"
   },

--- a/packages/nc-gui/lang/bn_IN.json
+++ b/packages/nc-gui/lang/bn_IN.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/da.json
+++ b/packages/nc-gui/lang/da.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/de.json
+++ b/packages/nc-gui/lang/de.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Nur Kommentare",
     "documentation": "Dokumentation",
     "subscribeNewsletter": "Abonnieren Sie unseren wöchentlichen Newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "Mit Ihrer Anmeldung stimmen Sie den allgemeinen Nutzungsbedingungen zu",
     "welcomeToNc": "Willkommen bei NocoDB!"
   },

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/es.json
+++ b/packages/nc-gui/lang/es.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/fa.json
+++ b/packages/nc-gui/lang/fa.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/fi.json
+++ b/packages/nc-gui/lang/fi.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/fr.json
+++ b/packages/nc-gui/lang/fr.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/he.json
+++ b/packages/nc-gui/lang/he.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/he.json
+++ b/packages/nc-gui/lang/he.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithProvider": "Sign up with {provider}",
-    "signInWithProvider": "Sign in with {provider}",
+    "signUpWithProvider": "הרשם באמצעות {provider}",
+    "signInWithProvider": "התחבר באמצעות {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/hi.json
+++ b/packages/nc-gui/lang/hi.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/hr.json
+++ b/packages/nc-gui/lang/hr.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/id.json
+++ b/packages/nc-gui/lang/id.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/it.json
+++ b/packages/nc-gui/lang/it.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/ja.json
+++ b/packages/nc-gui/lang/ja.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/ko.json
+++ b/packages/nc-gui/lang/ko.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/lv.json
+++ b/packages/nc-gui/lang/lv.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/nl.json
+++ b/packages/nc-gui/lang/nl.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/no.json
+++ b/packages/nc-gui/lang/no.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/pl.json
+++ b/packages/nc-gui/lang/pl.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Tylko komentarze",
     "documentation": "Dokumentacja",
     "subscribeNewsletter": "Zapisz się do naszego cotygodniowego newslettera",
-    "signUpWithGoogle": "Zarejestruj się przez Google",
-    "signInWithGoogle": "Zaloguj się przez Google",
+    "signUpWithProvider": "Zarejestruj się przez {provider}",
+    "signInWithProvider": "Zaloguj się przez {provider}",
     "agreeToTos": "Rejestrując się, akceptujesz warunki korzystania z usługi",
     "welcomeToNc": "Witaj w NocoDB!"
   },

--- a/packages/nc-gui/lang/pt.json
+++ b/packages/nc-gui/lang/pt.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/pt_BR.json
+++ b/packages/nc-gui/lang/pt_BR.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/ru.json
+++ b/packages/nc-gui/lang/ru.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/sl.json
+++ b/packages/nc-gui/lang/sl.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/sv.json
+++ b/packages/nc-gui/lang/sv.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/th.json
+++ b/packages/nc-gui/lang/th.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/tr.json
+++ b/packages/nc-gui/lang/tr.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/uk.json
+++ b/packages/nc-gui/lang/uk.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/vi.json
+++ b/packages/nc-gui/lang/vi.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/lang/zh-Hans.json
+++ b/packages/nc-gui/lang/zh-Hans.json
@@ -293,8 +293,8 @@
     "commentsOnly": "仅注释",
     "documentation": "文档",
     "subscribeNewsletter": "订阅我们的每周新闻",
-    "signUpWithGoogle": "使用 Google 注册",
-    "signInWithGoogle": "使用 Google 登录",
+    "signUpWithProvider": "使用 {provider} 注册",
+    "signInWithProvider": "使用 {provider} 登录",
     "agreeToTos": "注册即表明您同意服务条款",
     "welcomeToNc": "欢迎来到NocoDB！"
   },

--- a/packages/nc-gui/lang/zh-Hant.json
+++ b/packages/nc-gui/lang/zh-Hant.json
@@ -293,8 +293,8 @@
     "commentsOnly": "Comments only",
     "documentation": "Documentation",
     "subscribeNewsletter": "Subscribe to our weekly newsletter",
-    "signUpWithGoogle": "Sign up with Google",
-    "signInWithGoogle": "Sign in with Google",
+    "signUpWithProvider": "Sign up with {provider}",
+    "signInWithProvider": "Sign in with {provider}",
     "agreeToTos": "By signing up, you agree to the Terms of Service",
     "welcomeToNc": "Welcome to NocoDB!"
   },

--- a/packages/nc-gui/middleware/auth.global.ts
+++ b/packages/nc-gui/middleware/auth.global.ts
@@ -37,7 +37,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
   const { allRoles } = useRoles()
 
   /** if user isn't signed in and google auth is enabled, try to check if sign-in data is present */
-  if (!state.signedIn && state.appInfo.value.googleAuthEnabled) await tryGoogleAuth(api, state.signIn)
+  if (!state.signedIn) await tryLoginCallback(api, state.signIn)
 
   /** if public allow all visitors */
   if (to.meta.public) return
@@ -86,15 +86,21 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
 })
 
 /**
- * If present, try using google auth data to sign user in before navigating to the next page
+ * If present, try using the auth data to sign user in before navigating to the next page
  */
-async function tryGoogleAuth(api: Api<any>, signIn: Actions['signIn']) {
+async function tryLoginCallback(api: Api<any>, signIn: Actions['signIn']) {
   if (window.location.search && /\bscope=|\bstate=/.test(window.location.search) && /\bcode=/.test(window.location.search)) {
     try {
+      let authProvider = 'google';
+      if (window.location.search.includes('state=github')) {
+        authProvider = 'github';
+      } else if (window.location.search.includes('state=oidc')) {
+        authProvider = 'oidc';
+      }
       const {
         data: { token },
       } = await api.instance.post(
-        `/auth/${window.location.search.includes('state=github') ? 'github' : 'google'}/genTokenByCode${window.location.search}`,
+        `/auth/${authProvider}/genTokenByCode${window.location.search}`,
       )
 
       signIn(token)

--- a/packages/nc-gui/pages/signin.vue
+++ b/packages/nc-gui/pages/signin.vue
@@ -74,7 +74,7 @@ function resetError() {
 
         <h1 class="prose-2xl font-bold self-center my-4">{{ $t('general.signIn') }}</h1>
 
-        <a-form ref="formValidator" :model="form" layout="vertical" no-style @finish="signIn">
+        <a-form ref="formValidator" :model="form" layout="vertical" no-style @finish="signIn" v-if="appInfo.oidcAuthName == ''">
           <Transition name="layout">
             <div v-if="error" class="self-center mb-4 bg-red-500 text-white rounded-lg w-3/4 mx-auto p-1">
               <div class="flex items-center gap-2 justify-center">
@@ -134,7 +134,7 @@ function resetError() {
               <span class="flex items-center gap-2">
                 <LogosGoogleGmail />
 
-                {{ $t('labels.signInWithGoogle') }}
+                {{ $t('labels.signInWithProvider', { provider: 'Google' }) }}
               </span>
             </a>
 
@@ -150,6 +150,22 @@ function resetError() {
             </div>
           </div>
         </a-form>
+        <div
+          v-if="appInfo.oidcAuthName != ''"
+          class="self-center flex flex-col flex-wrap gap-4 items-center mt-4 justify-center">
+            <a
+              :href="`${appInfo.ncSiteUrl}/auth/oidc`"
+              class=" !text-primary !no-underline"
+            >
+            <button type="button" class="scaling-btn bg-opacity-100">
+              <span class="flex items-center gap-2">
+                <MdiLogin />
+
+                {{ $t('labels.signInWithProvider', { provider: appInfo.oidcAuthName }) }}
+              </span>
+            </button>
+          </a>
+        </div>
       </div>
     </div>
   </NuxtLayout>

--- a/packages/nc-gui/pages/signin.vue
+++ b/packages/nc-gui/pages/signin.vue
@@ -74,7 +74,7 @@ function resetError() {
 
         <h1 class="prose-2xl font-bold self-center my-4">{{ $t('general.signIn') }}</h1>
 
-        <a-form ref="formValidator" :model="form" layout="vertical" no-style @finish="signIn" v-if="appInfo.oidcAuthName == ''">
+        <a-form ref="formValidator" :model="form" layout="vertical" no-style @finish="signIn" v-if="!appInfo.oidcAuthName">
           <Transition name="layout">
             <div v-if="error" class="self-center mb-4 bg-red-500 text-white rounded-lg w-3/4 mx-auto p-1">
               <div class="flex items-center gap-2 justify-center">
@@ -151,7 +151,7 @@ function resetError() {
           </div>
         </a-form>
         <div
-          v-if="appInfo.oidcAuthName != ''"
+          v-if="appInfo.oidcAuthName"
           class="self-center flex flex-col flex-wrap gap-4 items-center mt-4 justify-center">
             <a
               :href="`${appInfo.ncSiteUrl}/auth/oidc`"

--- a/packages/nc-gui/pages/signup/[[token]].vue
+++ b/packages/nc-gui/pages/signup/[[token]].vue
@@ -97,7 +97,7 @@ function resetError() {
           {{ $t('msg.info.signUp.superAdmin') }}
         </h2>
 
-        <a-form ref="formValidator" :model="form" layout="vertical" no-style @finish="signUp">
+        <a-form v-if="appInfo.oidcAuthName == ''" ref="formValidator" :model="form" layout="vertical" no-style @finish="signUp">
           <Transition name="layout">
             <div v-if="error" class="self-center mb-4 bg-red-500 text-white rounded-lg w-3/4 mx-auto p-1">
               <div class="flex items-center gap-2 justify-center">
@@ -138,7 +138,7 @@ function resetError() {
               <span class="flex items-center gap-2">
                 <LogosGoogleGmail />
 
-                {{ $t('labels.signUpWithGoogle') }}
+                {{ $t('labels.signUpWithProvider', { provider: 'Google' }) }}
               </span>
             </a>
 
@@ -158,6 +158,23 @@ function resetError() {
             </div>
           </div>
         </a-form>
+
+        <div
+          v-if="appInfo.oidcAuthName != ''"
+          class="self-center flex flex-col flex-wrap gap-4 items-center mt-4 justify-center">
+            <a
+              :href="`${appInfo.ncSiteUrl}/auth/oidc`"
+              class=" !text-primary !no-underline"
+            >
+            <button type="button" class="scaling-btn bg-opacity-100">
+              <span class="flex items-center gap-2">
+                <MdiLogin />
+
+                {{ $t('labels.signUpWithProvider', { provider: appInfo.oidcAuthName }) }}
+              </span>
+            </button>
+          </a>
+        </div>
       </div>
 
       <div class="prose-sm mt-4 text-gray-500">

--- a/packages/nc-gui/pages/signup/[[token]].vue
+++ b/packages/nc-gui/pages/signup/[[token]].vue
@@ -97,7 +97,7 @@ function resetError() {
           {{ $t('msg.info.signUp.superAdmin') }}
         </h2>
 
-        <a-form v-if="appInfo.oidcAuthName == ''" ref="formValidator" :model="form" layout="vertical" no-style @finish="signUp">
+        <a-form v-if="!appInfo.oidcAuthName" ref="formValidator" :model="form" layout="vertical" no-style @finish="signUp">
           <Transition name="layout">
             <div v-if="error" class="self-center mb-4 bg-red-500 text-white rounded-lg w-3/4 mx-auto p-1">
               <div class="flex items-center gap-2 justify-center">
@@ -160,7 +160,7 @@ function resetError() {
         </a-form>
 
         <div
-          v-if="appInfo.oidcAuthName != ''"
+          v-if="appInfo.oidcAuthName"
           class="self-center flex flex-col flex-wrap gap-4 items-center mt-4 justify-center">
             <a
               :href="`${appInfo.ncSiteUrl}/auth/oidc`"

--- a/packages/noco-docs/content/en/getting-started/installation.md
+++ b/packages/noco-docs/content/en/getting-started/installation.md
@@ -485,6 +485,13 @@ It is mandatory to configure `NC_DB` environment variables for production usecas
 | NC_DASHBOARD_URL                   | No        | Custom dashboard url path                                                                                               | `/dashboard`                                                                                   |   |
 | NC_GOOGLE_CLIENT_ID                | No        | Google client id to enable google authentication                                                                        |                                                                                                |   |
 | NC_GOOGLE_CLIENT_SECRET            | No        | Google client secret to enable google authentication                                                                    |                                                                                                |   |
+| NC_OIDC_ISSUER                     | No        | OIDC Issuer URL to enable OpenID Connect authentication | | |
+| NC_OIDC_AUTH_URL                   | No        | OIDC Authorization endpoint to enable OpenID Connect authentication | | |
+| NC_OIDC_TOKEN_URL                  | No        | OIDC Token endpoint to enable OpenID Connect authentication | | |
+| NC_OIDC_USERINFO_URL               | No        | OIDC User info URL to enable OpenID Connect authentication | | |
+| NC_OIDC_CLIENT_ID                  | No        | OIDC client ID to enable OpenID Connect authentication | | |
+| NC_OIDC_CLIENT_SECRET              | No        | OIDC client secret to enable OpenID Connect authentication | | |
+| NC_OIDC_DISPLAY_NAME               | No        | OIDC provider display name (in the sign in and sign up pages) | `Your Identity Provider` | |
 | NC_MIGRATIONS_DISABLED             | No        | Disable NocoDB migration                                                                                                |                                                                                                |   |
 | NC_ONE_CLICK                       | No        | Used for Heroku one-click deployment                                                                                    |                                                                                                |   |
 | NC_MIN                             | No        | If set to any non-empty string the default splash screen(initial welcome animation) and matrix screensaver will disable |                                                                                                |   |

--- a/packages/noco-docs/content/en/setup-and-usages/team-and-auth.md
+++ b/packages/noco-docs/content/en/setup-and-usages/team-and-auth.md
@@ -6,7 +6,7 @@ category: 'Product'
 menuTitle: 'Team & Auth'
 ---
 
-# Accessing Team & Auth 
+## Accessing Team & Auth 
 - Click on `Team & Settings` from the `Project Menu` 
 - Access `Team & Auth` under `Settings`
   
@@ -42,7 +42,58 @@ If you do not have an SMTP sender configured, make sure to copy the invite link 
 ------
 
 
-# User Role Permissions
+## OpenID Connect authentication
+
+OpenID Connect (OIDC) is a simple identity layer built on top of the OAuth 2.0 protocol, which allows clients to verify the identity of an end-user based on the authentication performed by an authorization server or an identity provider (IdP), as well as to obtain basic profile information about the end-user.
+
+### User provisioning
+
+Unlike the Google login which requires a local user account to exist in advance, OIDC users are created automatically when they log in for the first time. It is important that you only assigned the users you wish to access in the application configured in your IdP.
+
+You may still use the users invivation to create an account for a user in advance, provided the email matches the user's email in your IdP.
+
+### Setup
+
+In your IdP, create a new application and register the allowed callback URL to be NocoDb's dashboard URL (e.g., `http://localhost:8000/dashboard`).
+
+Configure the following environment variables in your NocoDb instance (you could use `<Issuer URL>/.well-known/openid-configuration` to find the values):
+
+![OpenID Configuration JSON](https://user-images.githubusercontent.com/679761/194699139-65ad6c5b-fbce-48fa-8494-db58068e18a9.png)
+
+- `NC_OIDC_ISSUER`: The issuer URL. (`issuer`)
+- `NC_OIDC_AUTH_URL`: The authorization endpoint. (`authorization_endpoint`)
+- `NC_OIDC_TOKEN_URL`: The token exchange endpoint. (`token_endpoint`)
+- `NC_OIDC_USERINFO_URL`: The userinfo endpoint. (`device_authorization_endpoint`)
+- `NC_OIDC_CLIENT_ID`: the application's client id.
+- `NC_OIDC_CLIENT_SECRET`: the application's client secret.
+
+### Customization
+
+If you want to write your IdP's name instead of `Your Identity Provider`, set the `NC_OIDC_DISPLAY_NAME` environment variable.
+
+### IdP Configuration Examples
+
+#### Auth0
+
+Create a new *Regular Web Applications* application:
+
+![Auth0 application creation](https://user-images.githubusercontent.com/679761/194699261-151bd274-a771-48ed-9024-4a1fde26f7df.png)
+
+In the **Settings** tab, take a note of the *Domain* as `NC_OIDC_ISSUER`, *Client ID* as `NC_OIDC_CLIENT_ID` and *Client Secret* as `NC_OIDC_CLIENT_SECRET`:
+
+![Auth0 application values](https://user-images.githubusercontent.com/679761/194699258-2d4df10f-a7e7-4645-a91a-d3c55c5e5f1b.png)
+
+Using the `openid-coniguration` url from above, fill `NC_OIDC_AUTH_URL`, `NC_OIDC_TOKEN_URL` and `NC_OIDC_USERINFO_URL` as well.
+
+Under the *Application URIs* section, add your dashboard URL in *Allowed Callback URLs*:
+
+![Auth0 callback URLs](https://user-images.githubusercontent.com/679761/194699256-4a5f61d8-00be-4d7f-98d7-4845378bd197.png)
+
+
+------
+
+
+## User Role Permissions
 
 ### Advanced Options & Configurations
 | &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; | &nbsp; &nbsp; Owner &nbsp; &nbsp;| &nbsp; &nbsp; Creator &nbsp; &nbsp; | &nbsp; &nbsp; Editor &nbsp; &nbsp;| Commenter | &nbsp; &nbsp; Viewer &nbsp; &nbsp;|

--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/storage": "^5.7.2",
         "@graphql-tools/merge": "^6.0.12",
         "@sentry/node": "^6.3.5",
+        "@techpass/passport-openidconnect": "^0.3.3",
         "airtable": "^0.11.3",
         "archiver": "^5.0.2",
         "auto-bind": "^4.0.0",
@@ -1237,6 +1238,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@techpass/passport-openidconnect": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@techpass/passport-openidconnect/-/passport-openidconnect-0.3.3.tgz",
+      "integrity": "sha512-i2X/CofjnGBqpTmw6b+Ex3Co/NrR2xjnIHvnOJk62XIlJJHNSTwmhJ1PkXoA5RGKlxZWchADFGjLTJnebvRj7A==",
+      "dependencies": {
+        "base64url": "^3.0.1",
+        "oauth": "^0.9.15",
+        "passport-strategy": "^1.0.0",
+        "request": "^2.88.0",
+        "webfinger": "^0.4.2"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -14454,6 +14470,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/step": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
+      "integrity": "sha512-qSSeQinUJk2w38vUFobjFoE307GqsozMC8VisOCkJLpklvKPT0ptPHwWOrENoag8rgLudvTkfP3bancwP93/Jw=="
+    },
     "node_modules/stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -16777,6 +16798,29 @@
         "@zxing/text-encoding": "0.9.0"
       }
     },
+    "node_modules/webfinger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webfinger/-/webfinger-0.4.2.tgz",
+      "integrity": "sha512-PvvQ/k74HkC3q5G7bGu4VYeKDt3ePZMzT5qFPtEnOL8eyIU1/06OtDn9X5vlkQ23BlegA3eN89rDLiYUife3xQ==",
+      "dependencies": {
+        "step": "0.0.x",
+        "xml2js": "0.1.x"
+      },
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/webfinger/node_modules/xml2js": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+      "integrity": "sha512-pbdws4PPPNc1HPluSUKamY4GWMk592K7qwcj6BExbVOhhubub8+pMda/ql68b6L3luZs/OGjGSB5goV7SnmgnA==",
+      "dependencies": {
+        "sax": ">=0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -19015,6 +19059,18 @@
       "dev": true,
       "requires": {
         "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@techpass/passport-openidconnect": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@techpass/passport-openidconnect/-/passport-openidconnect-0.3.3.tgz",
+      "integrity": "sha512-i2X/CofjnGBqpTmw6b+Ex3Co/NrR2xjnIHvnOJk62XIlJJHNSTwmhJ1PkXoA5RGKlxZWchADFGjLTJnebvRj7A==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "oauth": "^0.9.15",
+        "passport-strategy": "^1.0.0",
+        "request": "^2.88.0",
+        "webfinger": "^0.4.2"
       }
     },
     "@tootallnate/once": {
@@ -29371,6 +29427,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "step": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/step/-/step-0.0.6.tgz",
+      "integrity": "sha512-qSSeQinUJk2w38vUFobjFoE307GqsozMC8VisOCkJLpklvKPT0ptPHwWOrENoag8rgLudvTkfP3bancwP93/Jw=="
+    },
     "stoppable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -31207,6 +31268,25 @@
       "requires": {
         "@zxing/text-encoding": "0.9.0",
         "util": "^0.12.3"
+      }
+    },
+    "webfinger": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webfinger/-/webfinger-0.4.2.tgz",
+      "integrity": "sha512-PvvQ/k74HkC3q5G7bGu4VYeKDt3ePZMzT5qFPtEnOL8eyIU1/06OtDn9X5vlkQ23BlegA3eN89rDLiYUife3xQ==",
+      "requires": {
+        "step": "0.0.x",
+        "xml2js": "0.1.x"
+      },
+      "dependencies": {
+        "xml2js": {
+          "version": "0.1.14",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.1.14.tgz",
+          "integrity": "sha512-pbdws4PPPNc1HPluSUKamY4GWMk592K7qwcj6BExbVOhhubub8+pMda/ql68b6L3luZs/OGjGSB5goV7SnmgnA==",
+          "requires": {
+            "sax": ">=0.1.1"
+          }
+        }
       }
     },
     "webidl-conversions": {

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -55,6 +55,7 @@
     "@google-cloud/storage": "^5.7.2",
     "@graphql-tools/merge": "^6.0.12",
     "@sentry/node": "^6.3.5",
+    "@techpass/passport-openidconnect": "^0.3.3",
     "airtable": "^0.11.3",
     "archiver": "^5.0.2",
     "auto-bind": "^4.0.0",

--- a/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/userApis.ts
@@ -244,6 +244,24 @@ async function googleSignin(req, res, next) {
   )(req, res, next);
 }
 
+async function oidcSignin(req, res, next) {
+  passport.authenticate(
+    'openidconnect',
+    {
+      callbackURL: req.ncSiteUrl + Noco.getConfig().dashboardPath,
+    },
+    async (err, user, info): Promise<any> =>
+      await successfulSignIn({
+        user,
+        err,
+        info,
+        req,
+        res,
+        auditDescription: 'signed in using OpenID Connect',
+      })
+  )(req, res, next);
+}
+
 function setTokenCookie(res, token): void {
   // create http only cookie with refresh token that expires in 7 days
   const cookieOptions = {
@@ -512,6 +530,15 @@ const mapRoutes = (router) => {
       callbackURL: req.ncSiteUrl + Noco.getConfig().dashboardPath,
     })(req, res, next)
   );
+
+  /* OpenID Connect APIs */
+  router.post('/auth/oidc/genTokenByCode', catchError(oidcSignin));
+  router.get('/auth/oidc', (req: any, res, next) =>
+    passport.authenticate('openidconnect', {
+      scope: ['profile', 'email'],
+      callbackURL: req.ncSiteUrl + Noco.getConfig().dashboardPath,
+    })(req, res, next)
+  )
 
   // deprecated APIs
   router.post('/api/v1/db/auth/user/signup', catchError(signup));

--- a/packages/nocodb/src/lib/meta/api/utilApis.ts
+++ b/packages/nocodb/src/lib/meta/api/utilApis.ts
@@ -35,7 +35,7 @@ export async function appInfo(req: Request, res: Response) {
     process.env.NC_OIDC_CLIENT_ID &&
     process.env.NC_OIDC_CLIENT_SECRET) ?
       ( process.env.NC_OIDC_DISPLAY_NAME ?? 'Your Identity Provider' ) :
-      '';
+      null;
   const result = {
     authType: 'jwt',
     projectHasAdmin,

--- a/packages/nocodb/src/lib/meta/api/utilApis.ts
+++ b/packages/nocodb/src/lib/meta/api/utilApis.ts
@@ -28,6 +28,14 @@ export async function testConnection(req: Request, res: Response) {
 
 export async function appInfo(req: Request, res: Response) {
   const projectHasAdmin = !(await User.isFirst());
+  const oidcAuthName = !!(process.env.NC_OIDC_ISSUER &&
+    process.env.NC_OIDC_AUTH_URL &&
+    process.env.NC_OIDC_TOKEN_URL &&
+    process.env.NC_OIDC_USERINFO_URL &&
+    process.env.NC_OIDC_CLIENT_ID &&
+    process.env.NC_OIDC_CLIENT_SECRET) ?
+      ( process.env.NC_OIDC_DISPLAY_NAME ?? 'Your Identity Provider' ) :
+      '';
   const result = {
     authType: 'jwt',
     projectHasAdmin,
@@ -40,6 +48,7 @@ export async function appInfo(req: Request, res: Response) {
     githubAuthEnabled: !!(
       process.env.NC_GITHUB_CLIENT_ID && process.env.NC_GITHUB_CLIENT_SECRET
     ),
+    oidcAuthName,
     oneClick: !!process.env.NC_ONE_CLICK,
     connectToExternalDB: !process.env.NC_CONNECT_TO_EXTERNAL_DB_DISABLED,
     version: packageVersion,

--- a/packages/nocodb/src/lib/utils/globals.ts
+++ b/packages/nocodb/src/lib/utils/globals.ts
@@ -135,6 +135,7 @@ export enum CacheScope {
   MODEL_ROLE_VISIBILITY = 'modelRoleVisibility',
   API_TOKEN = 'apiToken',
   INSTANCE_META = 'instanceMeta',
+  LOGIN = 'login',
 }
 export enum CacheGetType {
   TYPE_ARRAY = 'TYPE_ARRAY',


### PR DESCRIPTION
## Change Summary

Add the option to configure an OpenID Connect identity provider as a sign-in option.

Resolves #742

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

### Without any modifications

- [x] Sign in with email & password
- [x] Sign up with email & password

### Defining an OIDC provider

- [x] Login screen without a display name

<img width="535" alt="Login without a display name" src="https://user-images.githubusercontent.com/679761/194699478-1297a8fa-750f-444a-ba18-18b1013747e4.png">

- [x] Signup screen without a display name

- [x] Login screen with a display name

<img width="525" alt="Login with a display name" src="https://user-images.githubusercontent.com/679761/194699508-2015c1ef-e587-430e-830e-38fed336fd7c.png">

- [x] Signup screen with a display name
- [x] The first signup assigns the *Owner* role to the new user.
- [x] Invited users with the same email defined by the IdP can accept invitations.

## Additional information / screenshots (optional)

### Forcing the IdP

When the provider is set, it overrides the option to use another identity method (such as email & password or Google Login).
Is this the expected behavior? I would say organizations want to restrict access to their installations, which is the appropriate way to ensure only the IdP will be able to dictate who should be able to login.
