### PR TITLE
feat: kanban cover image

### DIFF
--- a/packages/nc-gui/components/cell/attachment/index.vue
+++ b/packages/nc-gui/components/cell/attachment/index.vue
@@ -197,7 +197,7 @@ watch(
             </template>
 
             <template v-if="isImage(item.title, item.mimetype ?? item.type) && (item.url || item.data)">
-              <div class="nc-attachment flex items-center justify-center" @click="selectedImage = item">
+              <div class="nc-attachment flex items-center justify-center" @click.stop="selectedImage = item">
                 <LazyNuxtImg
                   quality="75"
                   placeholder

--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -177,7 +177,7 @@ watch(view, async (nextView) => {
             class="!rounded-lg h-full overflow-hidden break-all max-w-[450px]"
             @click="expandFormClick($event, record)"
           >
-            <template #cover>
+            <template v-if="galleryData.fk_cover_image_col_id" #cover>
               <a-carousel v-if="!reloadAttachments && attachments(record).length" autoplay class="gallery-carousel" arrows>
                 <template #customPaging>
                   <a>

--- a/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
@@ -80,7 +80,6 @@ const coverImageColumnId = computed({
       : undefined,
   set: async (val) => {
     if (
-      val &&
       (activeView.value?.type === ViewTypes.GALLERY || activeView.value?.type === ViewTypes.KANBAN) &&
       activeView.value?.id &&
       activeView.value?.view
@@ -104,14 +103,16 @@ const coverImageColumnId = computed({
 })
 
 const coverOptions = computed<SelectProps['options']>(() => {
-  return fields.value
-    ?.filter((el) => el.fk_column_id && metaColumnById.value[el.fk_column_id].uidt === UITypes.Attachment)
-    .map((field) => {
-      return {
-        value: field.fk_column_id,
-        label: field.title,
-      }
-    })
+  const filterFields =
+    fields.value
+      ?.filter((el) => el.fk_column_id && metaColumnById.value[el.fk_column_id].uidt === UITypes.Attachment)
+      .map((field) => {
+        return {
+          value: field.fk_column_id,
+          label: field.title,
+        }
+      }) ?? []
+  return [{ value: null, label: 'No Image' }, ...filterFields]
 })
 
 const getIcon = (c: ColumnType) =>

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -383,6 +383,7 @@ export interface KanbanType {
   columns?: KanbanColumnType[];
   fk_model_id?: string;
   fk_grp_col_id?: string | null;
+  fk_cover_image_col_id?: string;
   meta?: string | object;
 }
 

--- a/packages/nocodb/src/lib/migrations/XcMigrationSourcev2.ts
+++ b/packages/nocodb/src/lib/migrations/XcMigrationSourcev2.ts
@@ -9,6 +9,7 @@ import * as nc_018_add_meta_in_view from './v2/nc_018_add_meta_in_view';
 import * as nc_019_add_meta_in_meta_tables from './v2/nc_019_add_meta_in_meta_tables';
 import * as nc_020_add_kanban_meta_col from './v2/nc_020_add_kanban_meta_col';
 import * as nc_021_rename_kanban_grp_col_id from './v2/nc_021_rename_kanban_grp_col_id';
+import * as nc_022_add_kanban_fk_cover_image_col_id from './v2/nc_022_add_kanban_fk_cover_image_col_id';
 
 // Create a custom migration source class
 export default class XcMigrationSourcev2 {
@@ -29,6 +30,7 @@ export default class XcMigrationSourcev2 {
       'nc_019_add_meta_in_meta_tables',
       'nc_020_add_kanban_meta_col',
       'nc_021_rename_kanban_grp_col_id',
+      'nc_022_add_kanban_fk_cover_image_col_id'
     ]);
   }
 
@@ -60,6 +62,8 @@ export default class XcMigrationSourcev2 {
         return nc_020_add_kanban_meta_col;
       case 'nc_021_rename_kanban_grp_col_id':
         return nc_021_rename_kanban_grp_col_id;
+      case 'nc_022_add_kanban_fk_cover_image_col_id':
+        return nc_022_add_kanban_fk_cover_image_col_id;
     }
   }
 }

--- a/packages/nocodb/src/lib/migrations/v2/nc_022_add_kanban_fk_cover_image_col_id.ts
+++ b/packages/nocodb/src/lib/migrations/v2/nc_022_add_kanban_fk_cover_image_col_id.ts
@@ -1,0 +1,41 @@
+import Knex from 'knex';
+import { MetaTable } from '../../utils/globals';
+
+const up = async (knex: Knex) => {
+  await knex.schema.alterTable(MetaTable.KANBAN_VIEW, (table) => {
+    table.string('fk_cover_image_col_id', 20);
+    table
+      .foreign('fk_cover_image_col_id')
+      .references(`${MetaTable.COLUMNS}.id`);
+  });
+};
+
+const down = async (knex) => {
+  await knex.schema.alterTable(MetaTable.KANBAN_VIEW, (table) => {
+    table.dropColumns('fk_cover_image_col_id');
+  });
+};
+
+export { up, down };
+
+/**
+ * @copyright Copyright (c) 2021, Xgene Cloud Ltd
+ *
+ * @author Wing-Kam Wong <wingkwong.code@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */

--- a/packages/nocodb/src/lib/models/KanbanView.ts
+++ b/packages/nocodb/src/lib/models/KanbanView.ts
@@ -1,5 +1,5 @@
 import Noco from '../Noco';
-import { KanbanType } from 'nocodb-sdk';
+import { KanbanType, UITypes } from 'nocodb-sdk';
 import { CacheGetType, CacheScope, MetaTable } from '../utils/globals';
 import View from './View';
 import NocoCache from '../cache/NocoCache';
@@ -10,6 +10,7 @@ export default class KanbanView implements KanbanType {
   project_id?: string;
   base_id?: string;
   fk_grp_col_id?: string;
+  fk_cover_image_col_id?: string;
   meta?: string | object;
 
   // below fields are not in use at this moment
@@ -58,11 +59,18 @@ export default class KanbanView implements KanbanType {
   }
 
   static async insert(view: Partial<KanbanView>, ncMeta = Noco.ncMeta) {
+    const columns = await View.get(view.fk_view_id, ncMeta)
+      .then((v) => v?.getModel(ncMeta))
+      .then((m) => m.getColumns(ncMeta));
+
     const insertObj = {
       project_id: view.project_id,
       base_id: view.base_id,
       fk_view_id: view.fk_view_id,
       fk_grp_col_id: view.fk_grp_col_id,
+      fk_cover_image_col_id:
+        view?.fk_cover_image_col_id ||
+        columns?.find((c) => c.uidt === UITypes.Attachment)?.id,
       meta: view.meta,
     };
 

--- a/packages/nocodb/src/lib/models/View.ts
+++ b/packages/nocodb/src/lib/models/View.ts
@@ -355,8 +355,7 @@ export default class View implements ViewType {
     {
       let order = 1;
       let galleryShowLimit = 0;
-      let kanbanShowCount = 0;
-      let kanbanAttachmentCount = 0;
+      let kanbanShowLimit = 0;
 
       if (view.type === ViewTypes.KANBAN && !copyFromView) {
         // sort by primary value & attachment first, then by singleLineText & Number
@@ -401,22 +400,14 @@ export default class View implements ViewType {
           if (vCol.id === kanbanView?.fk_grp_col_id) {
             // include grouping field if it exists
             show = true;
-          } else if (vCol.pv) {
-            // Show primary key
+          } else if (vCol.id === kanbanView.fk_cover_image_col_id || vCol.pv) {
+            // Show cover image or primary key
             show = true;
-            kanbanShowCount++;
-          } else if (
-            vCol.uidt === UITypes.Attachment &&
-            kanbanAttachmentCount < 1
-          ) {
-            // Show at most 1 attachment
-            show = true;
-            kanbanAttachmentCount++;
-            kanbanShowCount++;
-          } else if (kanbanShowCount < 3 && !isSystemColumn(vCol)) {
+            kanbanShowLimit++;
+          } else if (kanbanShowLimit < 3 && !isSystemColumn(vCol)) {
             // show at most 3 non-system columns
             show = true;
-            kanbanShowCount++;
+            kanbanShowLimit++;
           } else {
             // other columns will be hidden
             show = false;

--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -7919,6 +7919,9 @@
               "null"
             ]
           },
+          "fk_cover_image_col_id": {
+            "type": "string"
+          },
           "meta": {
             "type": [
               "string",


### PR DESCRIPTION
## Change Summary

- add cover image to kanban view
- introduce no image option in cover image fields menu

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

No Cover Image (no attachment column) / No Image is selected.

![image](https://user-images.githubusercontent.com/35857179/195008818-be1b266d-6727-4d1e-8020-31e1725de400.png)

![image](https://user-images.githubusercontent.com/35857179/195040241-f25a900f-6e11-4079-8820-1eb7109d4f82.png)

With Cover Image

![image](https://user-images.githubusercontent.com/35857179/195008977-05fe3e7b-3b07-4c41-a125-0112475fd835.png)

With Cover Image but no value

![image](https://user-images.githubusercontent.com/35857179/195009128-ad9ddace-14b1-4e58-947d-88fc86d45ad7.png)

