### PR TITLE
fix(nc-gui): overlay z-index

### DIFF
--- a/packages/nc-gui/components/general/Overlay.vue
+++ b/packages/nc-gui/components/general/Overlay.vue
@@ -48,7 +48,7 @@ export default {
         v-show="!!vModel"
         v-bind="$attrs"
         :class="[inline ? 'absolute' : 'fixed']"
-        class="z-100 top-0 left-0 bottom-0 right-0 bg-gray-700/75"
+        class="z-2000 top-0 left-0 bottom-0 right-0 bg-gray-700/75"
       >
         <slot :is-open="vModel" />
       </div>


### PR DESCRIPTION
## Change Summary

ref: #4004

- change z-index of overlay from 100 to 2000. (since default z-index for drawer mask is 1000, so we need to set to a value which is greater than 1000)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/195044046-7b1c2ea0-9b5f-4d0f-9100-81b16b35ed29.png)

![image](https://user-images.githubusercontent.com/35857179/195043946-1b548911-b5ad-4f93-919d-fc6f21d66285.png)
