### PR TITLE
feat: automatically create a new row on navigating next within last row

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -126,7 +126,7 @@ const {
 const syncAndNavigate = (dir: NavigateDir, e: KeyboardEvent) => {
   if (isJSON.value) return
 
-  if (currentRow.value.rowMeta.changed) {
+  if (currentRow.value.rowMeta.changed || currentRow.value.rowMeta.new) {
     emit('save')
     currentRow.value.rowMeta.changed = false
   }

--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -293,7 +293,7 @@ async function reloadViewDataHandler(shouldShowLoading: boolean | void) {
 }
 
 async function openNewRecordHandler() {
-  const newRow = await addEmptyRow()
+  const newRow = addEmptyRow()
   expandForm(newRow, undefined, true)
 }
 

--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -235,7 +235,8 @@ const onNavigate = (dir: NavigateDir) => {
       if (selected.row < data.value.length - 1) {
         selected.row++
       } else {
-        editEnabled = false
+        addEmptyRow()
+        selected.row++
       }
       break
     case NavigateDir.PREV:


### PR DESCRIPTION
## Change Summary

Re #4018
- Automatically create a new row on navigating next within last row
- Save new created row if pressed enter even if content is empty (smart spreadsheet behavior)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
