### PR TITLE
fix(nc-gui): remove `useMetas` from watch cb

### DIFF
--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -14,12 +14,15 @@ import {
   OpenNewRecordFormHookInj,
   PaginationDataInj,
   ReadonlyInj,
+  ReloadRowDataHookInj,
   ReloadViewDataHookInj,
+  computed,
   createEventHook,
   extractPkFromRow,
   inject,
   isColumnRequiredAndNull,
   message,
+  onBeforeUnmount,
   onClickOutside,
   onMounted,
   provide,
@@ -27,6 +30,7 @@ import {
   useEventListener,
   useGridViewColumnWidth,
   useI18n,
+  useMetas,
   useMultiSelect,
   useRoute,
   useSmartsheetStoreOrThrow,
@@ -97,6 +101,8 @@ const {
   selectedAllRecords,
   removeRowIfNew,
 } = useViewData(meta, view, xWhere)
+
+const { getMeta } = useMetas()
 
 const { loadGridViewColumns, updateWidth, resizingColWidth, resizingCol } = useGridViewColumnWidth(view)
 
@@ -336,7 +342,6 @@ watch(
     if (next && next.id !== old?.id) {
       // whenever tab changes or view changes save any unsaved data
       if (old?.id) {
-        const { getMeta } = useMetas()
         const oldMeta = await getMeta(old.fk_model_id!)
         if (oldMeta) {
           await saveOrUpdateRecords({


### PR DESCRIPTION
## Change Summary

* Fixes issue where navigating between views causes warnings about injections only being usable in setup()

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
