### PR TITLE
fix(ng-gui): find unique neighbours

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/FormulaOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/FormulaOptions.vue
@@ -252,11 +252,15 @@ function validateAgainstMeta(parsedTree: any, errors = new Set(), typeErrors = n
     const formulaPaths = columns.value
       .filter((c: Record<string, any>) => c.id !== column.value?.id && c.uidt === UITypes.Formula)
       .reduce((res: Record<string, any>[], c: Record<string, any>) => {
-        // in `formula`, get all the target neighbours
+        // in `formula`, get all the (unique) target neighbours
         // i.e. all column id (e.g. cl_xxxxxxxxxxxxxx) with formula type
-        const neighbours = (c.colOptions.formula.match(/cl_\w{14}/g) || []).filter(
-          (colId: string) => columns.value.filter((col: ColumnType) => col.id === colId && col.uidt === UITypes.Formula).length,
-        )
+        const neighbours = [
+          ...new Set(
+            (c.colOptions.formula.match(/cl_\w{14}/g) || []).filter(
+              (colId: string) => columns.value.filter((col: ColumnType) => col.id === colId && col.uidt === UITypes.Formula).length,
+            ),
+          ),
+        ]
         if (neighbours.length > 0) {
           // e.g. formula column 1 -> [formula column 2, formula column3]
           res.push({ [c.id]: neighbours })


### PR DESCRIPTION
## Change Summary

Find unique neighbours on formula paths, therefore avoiding "circular
reference" incorrect error validation while editing formula columns.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [X] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Use `new Set` to create a array of graph dependencies without dupications.

## Additional information / screenshots (optional)

### Before

https://user-images.githubusercontent.com/3846247/195473594-0dbc4807-1c05-40d0-8e93-fb2b6fbc7191.mov

### After

https://user-images.githubusercontent.com/3846247/195473738-810be0db-0183-4c00-bed8-acea09daf498.mov

(IMO, I think this part of the code could use some unit testing - adding the duplicated graph depedencies scenario would be straightforward and it would be easier to "see" the coverage of use cases)

ref: #4024