### PR TITLE
Fix: Grid view - multiselect copy bug

### DIFF
--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -229,7 +229,7 @@ export function useMultiSelect(
               cpcols.forEach((col) => {
                 // todo: JSON stringify the attachment cell and LTAR contents for copy
                 // filter attachment cells and LATR cells from copy
-                if (col.uidt === UITypes.Attachment || col.uidt === UITypes.LinkToAnotherRecord) {
+                if (col.uidt !== UITypes.Attachment && col.uidt !== UITypes.LinkToAnotherRecord) {
                   cptext = `${cptext} ${row.row[col.title]} \t`
                 }
               })


### PR DESCRIPTION
Signed-off-by: Pranav C <pranavxc@gmail.com>

## Change Summary

Currently, it's ignoring all the cells except the attachment and LTAR but we need the reverse.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
