### PR TITLE
fix: interpret `bigint` and `bigserial` as number on UI level

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
@@ -1367,9 +1367,6 @@ export class PgUi {
 
       case 'bit':
         return 'integer';
-      case 'bigint':
-      case 'bigserial':
-        return 'string';
 
       case 'bool':
         return 'boolean';
@@ -1412,6 +1409,8 @@ export class PgUi {
       case 'int4':
       case 'int8':
       case 'integer':
+      case 'bigint':
+      case 'bigserial':
         return 'integer';
       case 'int4range':
       case 'int8range':


### PR DESCRIPTION
## Change Summary

Re #3955
- Interpret `bigint` and `bigserial` as number on UI level

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
