### PR TITLE
feat(nc-gui): toggle skeleton mode in erd when zooming out too far 

### DIFF
--- a/packages/nc-gui/assets/style.scss
+++ b/packages/nc-gui/assets/style.scss
@@ -281,3 +281,7 @@ a {
 .nc-toolbar-btn {
   @apply !shadow-none rounded hover:(ring-1 ring-primary ring-opacity-100) focus:(ring-1 ring-accent ring-opacity-100);
 }
+
+.ant-modal {
+  @apply !top-[50px];
+}

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -39,14 +39,18 @@ watch(
     layout(isSkeleton)
     setTimeout(() => {
       fitView({
-        duration: 500,
-        minZoom: showSkeleton ? undefined : viewport.value.zoom,
-        maxZoom: showSkeleton ? viewport.value.zoom : undefined,
+        duration: 300,
+        minZoom: isSkeleton ? undefined : viewport.value.zoom,
+        maxZoom: isSkeleton ? viewport.value.zoom : undefined,
       })
     }, 100)
   },
   { flush: 'post' },
 )
+
+const zoomIn = () => {
+  fitView({ duration: 300, minZoom: 0.3 })
+}
 
 onScopeDispose($destroy)
 </script>
@@ -81,12 +85,15 @@ onScopeDispose($destroy)
       </div>
     </div>
 
-    <div
-      v-if="showSkeleton && config.showAllColumns"
-      class="absolute bottom-2 left-[50%] transform translate-x-[-50%] text-slate-400 font-semibold"
-    >
-      Zoom in to view columns
-    </div>
+    <Transition name="layout">
+      <div
+        v-if="showSkeleton && config.showAllColumns"
+        class="color-transition z-5 cursor-pointer absolute bottom-4 left-[50%] transform translate-x-[-50%] text-slate-400 hover:(text-slate-900 ring ring-accent ring-opacity-100) font-semibold px-4 py-2 bg-slate-100/50 hover:bg-slate-100/90 rounded"
+        @click="zoomIn"
+      >
+        Zoom in to view columns
+      </div>
+    </Transition>
   </VueFlow>
 </template>
 

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -34,21 +34,17 @@ function zoomIn() {
 
 onPaneReady(init)
 
-watch(tables, init, { flush: 'post' })
-watch(
-  showSkeleton,
-  (isSkeleton) => {
-    layout(isSkeleton)
-    setTimeout(() => {
-      fitView({
-        duration: 300,
-        minZoom: isSkeleton ? undefined : viewport.value.zoom,
-        maxZoom: isSkeleton ? viewport.value.zoom : undefined,
-      })
-    }, 100)
-  },
-  { flush: 'post' },
-)
+watch(tables, init)
+watch(showSkeleton, (isSkeleton) => {
+  layout(isSkeleton)
+  setTimeout(() => {
+    fitView({
+      duration: 300,
+      minZoom: isSkeleton ? undefined : viewport.value.zoom,
+      maxZoom: isSkeleton ? viewport.value.zoom : undefined,
+    })
+  }, 100)
+})
 
 onScopeDispose($destroy)
 </script>

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -19,7 +19,7 @@ const { $destroy, fitView, onPaneReady, viewport, onNodeDoubleClick } = useVueFl
 
 const { layout, elements } = useErdElements(tables, config)
 
-const showSkeleton = computed(() => viewport.value.zoom < 0.25)
+const showSkeleton = computed(() => viewport.value.zoom < 0.2)
 
 function init() {
   layout(showSkeleton.value)
@@ -29,10 +29,16 @@ function init() {
 }
 
 function zoomIn(nodeId?: string) {
-  fitView({ nodes: nodeId ? [nodeId] : undefined, duration: 300, minZoom: 0.4 })
+  fitView({ nodes: nodeId ? [nodeId] : undefined, duration: 300, minZoom: 0.3 })
 }
 
-onPaneReady(init)
+onPaneReady(() => {
+  layout(showSkeleton.value)
+
+  setTimeout(() => {
+    fitView({ duration: 250, padding: 0.5 })
+  }, 100)
+})
 
 onNodeDoubleClick(({ node }) => {
   if (showSkeleton.value) zoomIn()

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -65,7 +65,7 @@ onScopeDispose($destroy)
 
 <template>
   <VueFlow v-model="elements">
-    <Controls position="top-right" :show-fit-view="false" :show-interactive="false" />
+    <Controls class="rounded" position="top-right" :show-fit-view="false" :show-interactive="false" />
 
     <template #node-custom="{ data }">
       <ErdTableNode :data="data" :show-skeleton="showSkeleton" />
@@ -108,5 +108,13 @@ onScopeDispose($destroy)
 <style>
 .vue-flow__edges {
   z-index: 1000 !important;
+}
+
+.vue-flow__controls-zoomin {
+  @apply rounded-t;
+}
+
+.vue-flow__controls-zoomout {
+  @apply rounded-b;
 }
 </style>

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -23,9 +23,11 @@ const showSkeleton = computed(() => viewport.value.zoom < 0.25)
 
 function init() {
   layout(showSkeleton.value)
-  setTimeout(() => {
-    fitView({ duration: 500 })
-  }, 100)
+  if (!showSkeleton.value) {
+    setTimeout(() => {
+      fitView({ duration: 300 })
+    }, 100)
+  }
 }
 
 onPaneReady(init)

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -15,7 +15,7 @@ const props = defineProps<Props>()
 
 const { tables, config } = toRefs(props)
 
-const { $destroy, fitView, onPaneReady, viewport } = useVueFlow({ minZoom: 0.1, maxZoom: 2 })
+const { $destroy, fitView, onPaneReady, viewport, onNodeDoubleClick } = useVueFlow({ minZoom: 0.1, maxZoom: 2 })
 
 const { layout, elements } = useErdElements(tables, config)
 
@@ -28,11 +28,19 @@ function init() {
   }
 }
 
-function zoomIn() {
-  fitView({ duration: 300, minZoom: 0.3 })
+function zoomIn(nodeId?: string) {
+  fitView({ nodes: nodeId ? [nodeId] : undefined, duration: 300, minZoom: 0.4 })
 }
 
 onPaneReady(init)
+
+onNodeDoubleClick(({ node }) => {
+  if (showSkeleton.value) zoomIn()
+
+  setTimeout(() => {
+    zoomIn(node.id)
+  }, 250)
+})
 
 watch(tables, init)
 watch(showSkeleton, (isSkeleton) => {

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Background, Controls } from '@vue-flow/additional-components'
+import { Background, Controls, Panel } from '@vue-flow/additional-components'
 import { VueFlow, useVueFlow } from '@vue-flow/core'
 import type { TableType } from 'nocodb-sdk'
 import type { ErdFlowConfig } from './utils'
@@ -15,11 +15,11 @@ const props = defineProps<Props>()
 
 const { tables, config } = toRefs(props)
 
-const { $destroy, fitView, onPaneReady, viewport, onNodeDoubleClick } = useVueFlow({ minZoom: 0.1, maxZoom: 2 })
+const { $destroy, fitView, onPaneReady, viewport, onNodeDoubleClick } = useVueFlow({ minZoom: 0.05, maxZoom: 2 })
 
 const { layout, elements } = useErdElements(tables, config)
 
-const showSkeleton = computed(() => viewport.value.zoom < 0.2)
+const showSkeleton = computed(() => viewport.value.zoom < 0.15)
 
 function init() {
   layout(showSkeleton.value)
@@ -29,7 +29,7 @@ function init() {
 }
 
 function zoomIn(nodeId?: string) {
-  fitView({ nodes: nodeId ? [nodeId] : undefined, duration: 300, minZoom: 0.3 })
+  fitView({ nodes: nodeId ? [nodeId] : undefined, duration: 300, minZoom: 0.2 })
 }
 
 onPaneReady(() => {
@@ -77,21 +77,23 @@ onScopeDispose($destroy)
 
     <Background :size="showSkeleton ? 2 : undefined" :gap="showSkeleton ? 50 : undefined" />
 
-    <div
+    <Panel
       v-if="!config.singleTableMode"
-      class="absolute bottom-0 right-0 flex flex-col text-xs bg-white px-2 py-1 border-1 rounded-md border-gray-200 z-50 nc-erd-histogram"
-      style="font-size: 0.6rem"
+      class="text-xs bg-white border-1 rounded border-gray-200 z-50 nc-erd-histogram"
+      position="bottom-right"
     >
-      <div class="flex flex-row items-center space-x-1 border-b-1 pb-1 border-gray-100">
-        <MdiTableLarge class="text-primary" />
-        <div>{{ $t('objects.table') }}</div>
-      </div>
+      <div class="flex flex-col divide-y-1">
+        <div class="flex items-center gap-1 px-2 py-1">
+          <MdiTableLarge class="text-primary" />
+          <div>{{ $t('objects.table') }}</div>
+        </div>
 
-      <div class="flex flex-row items-center space-x-1 pt-1">
-        <MdiEyeCircleOutline class="text-primary" />
-        <div>{{ $t('objects.sqlVIew') }}</div>
+        <div class="flex items-center gap-1 px-2 py-1">
+          <MdiEyeCircleOutline class="text-primary" />
+          <div>{{ $t('objects.sqlVIew') }}</div>
+        </div>
       </div>
-    </div>
+    </Panel>
 
     <Transition name="layout">
       <div

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -24,10 +24,12 @@ const showSkeleton = computed(() => viewport.value.zoom < 0.25)
 function init() {
   layout(showSkeleton.value)
   if (!showSkeleton.value) {
-    setTimeout(() => {
-      fitView({ duration: 300 })
-    }, 100)
+    setTimeout(zoomIn, 100)
   }
+}
+
+function zoomIn() {
+  fitView({ duration: 300, minZoom: 0.3 })
 }
 
 onPaneReady(init)
@@ -47,10 +49,6 @@ watch(
   },
   { flush: 'post' },
 )
-
-const zoomIn = () => {
-  fitView({ duration: 300, minZoom: 0.3 })
-}
 
 onScopeDispose($destroy)
 </script>

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -33,7 +33,16 @@ onPaneReady(init)
 watch(tables, init, { flush: 'post' })
 watch(
   showSkeleton,
-  layout,
+  (isSkeleton) => {
+    layout(isSkeleton)
+    setTimeout(() => {
+      fitView({
+        duration: 500,
+        minZoom: showSkeleton ? undefined : viewport.value.zoom,
+        maxZoom: showSkeleton ? viewport.value.zoom : undefined,
+      })
+    }, 100)
+  },
   { flush: 'post' },
 )
 
@@ -68,6 +77,13 @@ onScopeDispose($destroy)
         <MdiEyeCircleOutline class="text-primary" />
         <div>{{ $t('objects.sqlVIew') }}</div>
       </div>
+    </div>
+
+    <div
+      v-if="showSkeleton && config.showAllColumns"
+      class="absolute bottom-2 left-[50%] transform translate-x-[-50%] text-slate-400 font-semibold"
+    >
+      Zoom in to view columns
     </div>
   </VueFlow>
 </template>

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -70,32 +70,33 @@ export default {
     </linearGradient>
   </defs>
 
-  <path
-    :id="id"
-    class="opacity-100 hover:(opacity-0) stroke-slate-500"
-    :class="selected || isHovering ? 'opacity-0' : ''"
-    :style="style"
-    :stroke-width="showSkeleton ? baseStroke * 4 : baseStroke"
-    fill="none"
-    :d="edgePath[0]"
-    :marker-end="showSkeleton ? markerEnd : ''"
-  />
+  <Transition name="layout" :duration="50" mode="in-out">
+    <path
+      v-if="selected || isHovering"
+      style="stroke: url(#linear-gradient)"
+      :stroke-width="(showSkeleton ? baseStroke * 12 : baseStroke * 8) / (selected || isHovering ? 2 : 1)"
+      fill="none"
+      :d="edgePath[0]"
+      :marker-end="showSkeleton ? markerEnd : ''"
+    />
 
-  <path
-    class="opacity-0 hover:(opacity-100 transition-all duration-100 ease)"
-    :class="selected || isHovering ? 'opacity-100' : ''"
-    style="stroke: url(#linear-gradient)"
-    :stroke-width="(showSkeleton ? baseStroke * 12 : baseStroke * 8) / (selected || isHovering ? 2 : 1)"
-    fill="none"
-    :d="edgePath[0]"
-    :marker-end="showSkeleton ? markerEnd : ''"
-  />
+    <path
+      v-else
+      :id="id"
+      class="stroke-slate-500"
+      :style="style"
+      :stroke-width="showSkeleton ? baseStroke * 4 : baseStroke"
+      fill="none"
+      :d="edgePath[0]"
+      :marker-end="showSkeleton ? markerEnd : ''"
+    />
+  </Transition>
 
   <path class="opacity-0" :stroke-width="showSkeleton ? baseStroke * 12 : baseStroke * 8" fill="none" :d="edgePath[0]" />
 
   <Transition name="layout">
     <EdgeText
-      v-if="data.label?.length > 0 && isHovering"
+      v-if="data.label?.length > 0 && (selected || isHovering)"
       :key="`edge-text-${id}.${showSkeleton}`"
       :class="`nc-erd-table-label-${data.label.toLowerCase().replace(' ', '-').replace('\(', '').replace(')', '')}`"
       :x="edgePath[1]"

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -20,6 +20,7 @@ interface RelationEdgeProps extends EdgeProps {
   style: CSSProperties
   selected?: boolean
   showSkeleton: boolean
+  markerEnd: string
 }
 
 const props = defineProps<RelationEdgeProps>()
@@ -70,6 +71,7 @@ export default {
     :stroke-width="2"
     fill="none"
     :d="edgePath[0]"
+    :marker-end="showSkeleton ? markerEnd : ''"
   />
   <path
     class="opacity-0 hover:(opacity-100 transition-all duration-100 ease)"
@@ -78,6 +80,7 @@ export default {
     :stroke-width="7"
     fill="none"
     :d="edgePath[0]"
+    :marker-end="showSkeleton ? markerEnd : ''"
   />
 
   <EdgeText

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -73,7 +73,7 @@ export default {
   <path
     :id="id"
     class="opacity-100 hover:(opacity-0) stroke-slate-500"
-    :class="selected ? 'opacity-0' : ''"
+    :class="selected || isHovering ? 'opacity-0' : ''"
     :style="style"
     :stroke-width="showSkeleton ? baseStroke * 4 : baseStroke"
     fill="none"
@@ -83,9 +83,9 @@ export default {
 
   <path
     class="opacity-0 hover:(opacity-100 transition-all duration-100 ease)"
-    :class="selected ? 'opacity-100' : ''"
+    :class="selected || isHovering ? 'opacity-100' : ''"
     style="stroke: url(#linear-gradient)"
-    :stroke-width="(showSkeleton ? baseStroke * 12 : baseStroke * 8) / (isHovering || selected ? 2 : 1)"
+    :stroke-width="(showSkeleton ? baseStroke * 12 : baseStroke * 8) / (selected || isHovering ? 2 : 1)"
     fill="none"
     :d="edgePath[0]"
     :marker-end="showSkeleton ? markerEnd : ''"

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -2,9 +2,10 @@
 import type { EdgeProps, Position } from '@vue-flow/core'
 import { EdgeText, getBezierPath } from '@vue-flow/core'
 import type { CSSProperties } from '@vue/runtime-dom'
+import type { EdgeData } from './utils'
 import { computed, toRef } from '#imports'
 
-interface RelationEdgeProps extends EdgeProps {
+interface RelationEdgeProps extends EdgeProps<EdgeData> {
   id: string
   sourceX: number
   sourceY: number
@@ -12,12 +13,7 @@ interface RelationEdgeProps extends EdgeProps {
   targetY: number
   sourcePosition: Position
   targetPosition: Position
-  data: {
-    isManyToMany: boolean
-    isSelfRelation: boolean
-    label: string
-    color: string
-  }
+  data: EdgeData
   style: CSSProperties
   selected?: boolean
   showSkeleton: boolean

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -98,10 +98,13 @@ export default {
     <EdgeText
       v-if="data.label?.length > 0 && (selected || isHovering)"
       :key="`edge-text-${id}.${showSkeleton}`"
-      :class="`nc-erd-table-label-${data.label.toLowerCase().replace(' ', '-').replace('\(', '').replace(')', '')}`"
+      :class="[
+        showSkeleton ? '!text-5xl' : '!text-xs',
+        `nc-erd-table-label-${data.label.toLowerCase().replace(' ', '-').replace('\(', '').replace(')', '')}`,
+      ]"
       :x="edgePath[1]"
       :y="edgePath[2]"
-      :label="data.label"
+      :label="showSkeleton ? data.simpleLabel : data.label"
       :label-style="{ fill: 'white', fontSize: `${showSkeleton ? baseStroke * 2 : baseStroke / 2}rem` }"
       :label-show-bg="true"
       :label-bg-style="{ fill: data.color }"

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -27,22 +27,17 @@ const props = defineProps<RelationEdgeProps>()
 
 const data = toRef(props, 'data')
 
+const baseStroke = 2
+
 const edgePath = computed(() => {
   if (data.value.isSelfRelation) {
     const { sourceX, sourceY, targetX, targetY } = props
     const radiusX = (sourceX - targetX) * 0.6
     const radiusY = 50
-    return `M ${sourceX} ${sourceY} A ${radiusX} ${radiusY} 0 1 0 ${targetX} ${targetY}`
+    return [`M ${sourceX} ${sourceY} A ${radiusX} ${radiusY} 0 1 0 ${targetX} ${targetY}`]
   }
 
-  return getBezierPath({
-    sourceX: props.sourceX,
-    sourceY: props.sourceY,
-    sourcePosition: props.sourcePosition,
-    targetX: props.targetX,
-    targetY: props.targetY,
-    targetPosition: props.targetPosition,
-  })
+  return getBezierPath({ ...props })
 })
 </script>
 
@@ -68,7 +63,7 @@ export default {
     class="opacity-100 hover:(opacity-0)"
     :class="selected ? 'opacity-0' : ''"
     :style="style"
-    :stroke-width="2"
+    :stroke-width="showSkeleton ? baseStroke * 4 : baseStroke"
     fill="none"
     :d="edgePath[0]"
     :marker-end="showSkeleton ? markerEnd : ''"
@@ -77,7 +72,7 @@ export default {
     class="opacity-0 hover:(opacity-100 transition-all duration-100 ease)"
     :class="selected ? 'opacity-100' : ''"
     style="stroke: url(#linear-gradient)"
-    :stroke-width="7"
+    :stroke-width="showSkeleton ? baseStroke * 8 : 7"
     fill="none"
     :d="edgePath[0]"
     :marker-end="showSkeleton ? markerEnd : ''"
@@ -96,29 +91,31 @@ export default {
     :label-bg-border-radius="2"
   />
 
-  <rect
-    class="nc-erd-edge-rect"
-    :x="sourceX"
-    :y="sourceY - 4"
-    width="8"
-    height="8"
-    fill="#fff"
-    stroke="#6F3381"
-    :stroke-width="1.5"
-    :transform="`rotate(45,${sourceX + 2},${sourceY - 4})`"
-  />
+  <template v-if="!showSkeleton">
+    <rect
+      class="nc-erd-edge-rect"
+      :x="sourceX"
+      :y="sourceY - 4"
+      :width="8"
+      :height="8"
+      fill="#fff"
+      stroke="#6F3381"
+      :stroke-width="2"
+      :transform="`rotate(45,${sourceX + 2},${sourceY - 4})`"
+    />
 
-  <rect
-    v-if="data.isManyToMany"
-    class="nc-erd-edge-rect"
-    :x="targetX"
-    :y="targetY - 4"
-    width="8"
-    height="8"
-    fill="#fff"
-    stroke="#6F3381"
-    :stroke-width="1.5"
-    :transform="`rotate(45,${targetX + 2},${targetY - 4})`"
-  />
-  <circle v-else class="nc-erd-edge-circle" :cx="targetX" :cy="targetY" fill="#fff" :r="5" stroke="#6F3381" :stroke-width="1.5" />
+    <rect
+      v-if="data.isManyToMany"
+      class="nc-erd-edge-rect"
+      :x="targetX"
+      :y="targetY - 4"
+      :width="8"
+      :height="8"
+      fill="#fff"
+      stroke="#6F3381"
+      :stroke-width="2"
+      :transform="`rotate(45,${targetX + 2},${targetY - 4})`"
+    />
+    <circle v-else class="nc-erd-edge-circle" :cx="targetX" :cy="targetY" fill="#fff" :r="5" stroke="#6F3381" :stroke-width="2" />
+  </template>
 </template>

--- a/packages/nc-gui/components/erd/RelationEdge.vue
+++ b/packages/nc-gui/components/erd/RelationEdge.vue
@@ -19,6 +19,7 @@ interface RelationEdgeProps extends EdgeProps {
   }
   style: CSSProperties
   selected?: boolean
+  showSkeleton: boolean
 }
 
 const props = defineProps<RelationEdgeProps>()
@@ -66,7 +67,7 @@ export default {
     class="opacity-100 hover:(opacity-0)"
     :class="selected ? 'opacity-0' : ''"
     :style="style"
-    :stroke-width="3"
+    :stroke-width="2"
     fill="none"
     :d="edgePath[0]"
   />

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { NodeProps } from '@vue-flow/core'
-import { Handle, Position } from '@vue-flow/core'
+import { Handle, Position, useVueFlow } from '@vue-flow/core'
 import type { LinkToAnotherRecordType } from 'nocodb-sdk'
 import { UITypes, isVirtualCol } from 'nocodb-sdk'
 import type { NodeData } from './utils'
@@ -12,6 +12,8 @@ interface Props extends NodeProps<NodeData> {
 }
 
 const { data, showSkeleton } = defineProps<Props>()
+
+const { viewport } = useVueFlow()
 
 const table = toRef(data, 'table')
 
@@ -26,17 +28,22 @@ const hasColumns = computed(() => data.pkAndFkColumns.length || data.nonPkColumn
 </script>
 
 <template>
-  <div
-    class="relative h-full flex flex-col justify-center bg-slate-50 min-w-16 min-h-8 rounded-lg nc-erd-table-node"
-    :class="[
-      `nc-erd-table-node-${table.table_name}`,
-      showSkeleton ? 'cursor-pointer items-center bg-slate-200 min-h-200px min-w-300px px-4' : '',
-    ]"
-    @click="$e('c:erd:node-click')"
+  <GeneralTooltip
+    class="h-full flex flex-1 justify-center items-center"
+    :modifier-key="showSkeleton || viewport.zoom > 0.35 ? 'Alt' : undefined"
   >
-    <GeneralTooltip class="h-full flex flex-1 justify-center items-center" modifier-key="Alt">
-      <template #title> {{ table.table_name }} </template>
+    <template #title>
+      <div class="capitalize">{{ table.table_name }}</div>
+    </template>
 
+    <div
+      class="relative h-full flex flex-col justify-center bg-slate-50 min-w-16 min-h-8 rounded-lg nc-erd-table-node"
+      :class="[
+        `nc-erd-table-node-${table.table_name}`,
+        showSkeleton ? 'cursor-pointer items-center bg-slate-200 min-h-200px min-w-300px px-4' : '',
+      ]"
+      @click="$e('c:erd:node-click')"
+    >
       <div
         :class="[showSkeleton ? '' : 'bg-primary bg-opacity-10', hasColumns ? 'border-b-1' : '']"
         class="text-slate-600 text-md py-2 border-slate-500 rounded-t-lg w-full h-full px-3 font-semibold flex items-center"
@@ -48,69 +55,67 @@ const hasColumns = computed(() => data.pkAndFkColumns.length || data.nonPkColumn
           {{ table.title }}
         </div>
       </div>
-    </GeneralTooltip>
 
-    <div v-if="showSkeleton">
-      <Handle style="left: -20px" class="opacity-0" :position="Position.Left" type="target" :connectable="false" />
-      <Handle style="right: -15px" class="opacity-0" :position="Position.Right" type="source" :connectable="false" />
-    </div>
-
-    <div v-else-if="hasColumns">
-      <div
-        v-for="col in data.pkAndFkColumns"
-        :key="col.title"
-        class="w-full border-b-1 py-2 border-slate-200 bg-slate-100"
-        :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
-      >
-        <LazySmartsheetHeaderCell v-if="col" :column="col" :hide-menu="true" />
+      <div v-if="showSkeleton">
+        <Handle style="left: -20px" class="opacity-0" :position="Position.Left" type="target" :connectable="false" />
+        <Handle style="right: -15px" class="opacity-0" :position="Position.Right" type="source" :connectable="false" />
       </div>
 
-      <div v-if="data.nonPkColumns.length" class="w-full mb-1"></div>
-
-      <div v-for="(col, index) in data.nonPkColumns" :key="col.title">
+      <div v-else-if="hasColumns">
         <div
-          class="relative w-full h-full flex items-center min-w-32 border-slate-200 py-2 px-1"
-          :class="index + 1 === data.nonPkColumns.length ? 'rounded-b-lg' : 'border-b-1'"
+          v-for="col in data.pkAndFkColumns"
+          :key="col.title"
+          class="w-full h-full min-w-32 border-b-1 py-2 px-1 border-slate-200 bg-slate-100"
+          :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
         >
+          <LazySmartsheetHeaderCell v-if="col" :column="col" :hide-menu="true" />
+        </div>
+
+        <div v-for="(col, index) in data.nonPkColumns" :key="col.title">
           <div
-            v-if="col.uidt === UITypes.LinkToAnotherRecord"
-            class="flex w-full"
-            :class="`nc-erd-table-node-${table.table_name}-column-${col.title?.toLowerCase().replace(' ', '_')}`"
+            class="relative w-full h-full flex items-center min-w-32 border-slate-200 py-2 px-1"
+            :class="index + 1 === data.nonPkColumns.length ? 'rounded-b-lg' : 'border-b-1'"
           >
-            <Handle
-              :id="`s-${relatedColumnId(col.colOptions)}-${table.id}`"
-              class="opacity-0 !right-[-1px]"
-              type="source"
-              :position="Position.Right"
-              :connectable="false"
+            <div
+              v-if="col.uidt === UITypes.LinkToAnotherRecord"
+              class="flex w-full"
+              :class="`nc-erd-table-node-${table.table_name}-column-${col.title?.toLowerCase().replace(' ', '_')}`"
+            >
+              <Handle
+                :id="`s-${relatedColumnId(col.colOptions)}-${table.id}`"
+                class="opacity-0 !right-[-1px]"
+                type="source"
+                :position="Position.Right"
+                :connectable="false"
+              />
+
+              <Handle
+                :id="`d-${relatedColumnId(col.colOptions)}-${table.id}`"
+                class="opacity-0 !left-[-1px]"
+                type="target"
+                :position="Position.Left"
+                :connectable="false"
+              />
+
+              <LazySmartsheetHeaderVirtualCell :column="col" :hide-menu="true" />
+            </div>
+
+            <LazySmartsheetHeaderVirtualCell
+              v-else-if="isVirtualCol(col)"
+              :column="col"
+              :hide-menu="true"
+              :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
             />
 
-            <Handle
-              :id="`d-${relatedColumnId(col.colOptions)}-${table.id}`"
-              class="opacity-0 !left-[-1px]"
-              type="target"
-              :position="Position.Left"
-              :connectable="false"
+            <LazySmartsheetHeaderCell
+              v-else
+              :column="col"
+              :hide-menu="true"
+              :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
             />
-
-            <LazySmartsheetHeaderVirtualCell :column="col" :hide-menu="true" />
           </div>
-
-          <LazySmartsheetHeaderVirtualCell
-            v-else-if="isVirtualCol(col)"
-            :column="col"
-            :hide-menu="true"
-            :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
-          />
-
-          <LazySmartsheetHeaderCell
-            v-else
-            :column="col"
-            :hide-menu="true"
-            :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
-          />
         </div>
       </div>
     </div>
-  </div>
+  </GeneralTooltip>
 </template>

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -56,7 +56,7 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
         class="text-slate-600 text-md py-2 border-slate-500 rounded-t-lg w-full h-full px-3 font-semibold flex items-center"
       >
         <MdiTableLarge v-if="data.type === 'table'" class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
-        <MdiEyeCircleOutline v-else class="text-primary" />
+        <MdiEyeCircleOutline v-else class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
 
         <div :class="showSkeleton ? 'text-6xl' : ''" class="flex px-2">
           {{ data.title }}

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -3,7 +3,7 @@ import type { NodeProps } from '@vue-flow/core'
 import { Handle, Position } from '@vue-flow/core'
 import type { ColumnType, LinkToAnotherRecordType, TableType } from 'nocodb-sdk'
 import { UITypes, isVirtualCol } from 'nocodb-sdk'
-import { MetaInj, provide, toRef, useNuxtApp } from '#imports'
+import { MetaInj, computed, provide, toRef, useNuxtApp } from '#imports'
 
 interface NodeData {
   table: TableType
@@ -29,6 +29,8 @@ const { $e } = useNuxtApp()
 
 const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
   colOptions.type === 'mm' ? colOptions.fk_parent_column_id : colOptions.fk_child_column_id
+
+const hasColumns = computed(() => data.pkAndFkColumns.length || data.nonPkColumns.length)
 </script>
 
 <template>
@@ -44,7 +46,7 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
       <template #title> {{ table.table_name }} </template>
 
       <div
-        :class="[showSkeleton ? '' : 'bg-primary bg-opacity-10 border-b-1']"
+        :class="[showSkeleton ? '' : 'bg-primary bg-opacity-10', hasColumns ? 'border-b-1' : '']"
         class="text-slate-600 text-md py-2 border-slate-500 rounded-t-lg w-full h-full px-3 font-semibold flex items-center"
       >
         <MdiTableLarge v-if="table.type === 'table'" class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
@@ -61,7 +63,7 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
       <Handle style="right: -15px" class="opacity-0" :position="Position.Right" type="source" :connectable="false" />
     </div>
 
-    <div v-else-if="data.nonPkColumns.length || data.pkAndFkColumns.length">
+    <div v-else-if="hasColumns">
       <div
         v-for="col in data.pkAndFkColumns"
         :key="col.title"

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -45,7 +45,10 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
 <template>
   <div
     class="relative h-full flex flex-col justify-center items-center bg-slate-50 min-w-16 rounded-lg nc-erd-table-node"
-    :class="[`nc-erd-table-node-${data.table_name}`, showSkeleton ? 'bg-slate-200 min-h-200px min-w-300px px-4' : '']"
+    :class="[
+      `nc-erd-table-node-${data.table_name}`,
+      showSkeleton ? 'cursor-pointer bg-slate-200 min-h-200px min-w-300px px-4' : '',
+    ]"
     @click="$e('c:erd:node-click')"
   >
     <GeneralTooltip class="h-full flex flex-1 justify-center items-center" modifier-key="Alt">

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -3,40 +3,29 @@ import type { NodeProps } from '@vue-flow/core'
 import { Handle, Position } from '@vue-flow/core'
 import type { ColumnType, LinkToAnotherRecordType, TableType } from 'nocodb-sdk'
 import { UITypes, isVirtualCol } from 'nocodb-sdk'
-import type { Ref } from 'vue'
-import { MetaInj, computed, provide, toRefs, useNuxtApp } from '#imports'
+import { MetaInj, provide, toRef, useNuxtApp } from '#imports'
 
-interface Props extends NodeProps {
-  data: TableType & { showPkAndFk: boolean; showAllColumns: boolean; color: string }
+interface NodeData {
+  table: TableType
+  pkAndFkColumns: ColumnType[]
+  nonPkColumns: ColumnType[]
+  showPkAndFk: boolean
+  showAllColumns: boolean
+  color: string
+}
+
+interface Props extends NodeProps<NodeData> {
+  data: NodeData
   showSkeleton: boolean
 }
 
-const props = defineProps<Props>()
+const { data, showSkeleton } = defineProps<Props>()
 
-const { data } = toRefs(props)
+const table = toRef(data, 'table')
 
-provide(MetaInj, data as Ref<TableType>)
+provide(MetaInj, table)
 
 const { $e } = useNuxtApp()
-
-const columns = computed(() => {
-  // Hide hm ltar created for `mm` relations
-  return data.value.columns?.filter((col) => !(col.uidt === UITypes.LinkToAnotherRecord && col.system === 1))
-})
-
-const pkAndFkColumns = computed(() => {
-  return columns.value
-    ?.filter(() => data.value.showPkAndFk && data.value.showAllColumns)
-    .filter((col) => col.pk || col.uidt === UITypes.ForeignKey)
-})
-
-const nonPkColumns = computed(() => {
-  return columns.value
-    ?.filter(
-      (col: ColumnType) => data.value.showAllColumns || (!data.value.showAllColumns && col.uidt === UITypes.LinkToAnotherRecord),
-    )
-    .filter((col: ColumnType) => !col.pk && col.uidt !== UITypes.ForeignKey)
-})
 
 const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
   colOptions.type === 'mm' ? colOptions.fk_parent_column_id : colOptions.fk_child_column_id
@@ -46,23 +35,23 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
   <div
     class="relative h-full flex flex-col justify-center items-center bg-slate-50 min-w-16 rounded-lg nc-erd-table-node"
     :class="[
-      `nc-erd-table-node-${data.table_name}`,
+      `nc-erd-table-node-${table.table_name}`,
       showSkeleton ? 'cursor-pointer bg-slate-200 min-h-200px min-w-300px px-4' : '',
     ]"
     @click="$e('c:erd:node-click')"
   >
     <GeneralTooltip class="h-full flex flex-1 justify-center items-center" modifier-key="Alt">
-      <template #title> {{ data.table_name }} </template>
+      <template #title> {{ table.table_name }} </template>
 
       <div
         :class="[showSkeleton ? '' : 'bg-primary bg-opacity-10 border-b-1']"
         class="text-slate-600 text-md py-2 border-slate-500 rounded-t-lg w-full h-full px-3 font-semibold flex items-center"
       >
-        <MdiTableLarge v-if="data.type === 'table'" class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
+        <MdiTableLarge v-if="table.type === 'table'" class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
         <MdiEyeCircleOutline v-else class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
 
         <div :class="showSkeleton ? 'text-6xl' : ''" class="flex px-2">
-          {{ data.title }}
+          {{ table.title }}
         </div>
       </div>
     </GeneralTooltip>
@@ -72,30 +61,30 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
       <Handle style="right: -15px" class="opacity-0" :position="Position.Right" type="source" :connectable="false" />
     </div>
 
-    <div v-else-if="nonPkColumns.length || pkAndFkColumns.length">
+    <div v-else-if="data.nonPkColumns.length || data.pkAndFkColumns.length">
       <div
-        v-for="col in pkAndFkColumns"
+        v-for="col in data.pkAndFkColumns"
         :key="col.title"
         class="w-full border-b-1 py-2 border-slate-200 bg-slate-100"
-        :class="`nc-erd-table-node-${data.table_name}-column-${col.column_name}`"
+        :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
       >
         <LazySmartsheetHeaderCell v-if="col" :column="col" :hide-menu="true" />
       </div>
 
-      <div v-if="nonPkColumns.length" class="w-full mb-1"></div>
+      <div v-if="data.nonPkColumns.length" class="w-full mb-1"></div>
 
-      <div v-for="(col, index) in nonPkColumns" :key="col.title">
+      <div v-for="(col, index) in data.nonPkColumns" :key="col.title">
         <div
           class="relative w-full h-full flex items-center min-w-32 border-slate-200 py-2 px-1"
-          :class="index + 1 === nonPkColumns.length ? 'rounded-b-lg' : 'border-b-1'"
+          :class="index + 1 === data.nonPkColumns.length ? 'rounded-b-lg' : 'border-b-1'"
         >
           <div
             v-if="col.uidt === UITypes.LinkToAnotherRecord"
             class="flex w-full"
-            :class="`nc-erd-table-node-${data.table_name}-column-${col.title?.toLowerCase().replace(' ', '_')}`"
+            :class="`nc-erd-table-node-${table.table_name}-column-${col.title?.toLowerCase().replace(' ', '_')}`"
           >
             <Handle
-              :id="`s-${relatedColumnId(col.colOptions)}-${data.id}`"
+              :id="`s-${relatedColumnId(col.colOptions)}-${table.id}`"
               class="opacity-0 !right-[-1px]"
               type="source"
               :position="Position.Right"
@@ -103,7 +92,7 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
             />
 
             <Handle
-              :id="`d-${relatedColumnId(col.colOptions)}-${data.id}`"
+              :id="`d-${relatedColumnId(col.colOptions)}-${table.id}`"
               class="opacity-0 !left-[-1px]"
               type="target"
               :position="Position.Left"
@@ -117,14 +106,14 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
             v-else-if="isVirtualCol(col)"
             :column="col"
             :hide-menu="true"
-            :class="`nc-erd-table-node-${data.table_name}-column-${col.column_name}`"
+            :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
           />
 
           <LazySmartsheetHeaderCell
             v-else
             :column="col"
             :hide-menu="true"
-            :class="`nc-erd-table-node-${data.table_name}-column-${col.column_name}`"
+            :class="`nc-erd-table-node-${table.table_name}-column-${col.column_name}`"
           />
         </div>
       </div>

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -1,18 +1,10 @@
 <script lang="ts" setup>
 import type { NodeProps } from '@vue-flow/core'
 import { Handle, Position } from '@vue-flow/core'
-import type { ColumnType, LinkToAnotherRecordType, TableType } from 'nocodb-sdk'
+import type { LinkToAnotherRecordType } from 'nocodb-sdk'
 import { UITypes, isVirtualCol } from 'nocodb-sdk'
+import type { NodeData } from './utils'
 import { MetaInj, computed, provide, toRef, useNuxtApp } from '#imports'
-
-interface NodeData {
-  table: TableType
-  pkAndFkColumns: ColumnType[]
-  nonPkColumns: ColumnType[]
-  showPkAndFk: boolean
-  showAllColumns: boolean
-  color: string
-}
 
 interface Props extends NodeProps<NodeData> {
   data: NodeData
@@ -35,10 +27,10 @@ const hasColumns = computed(() => data.pkAndFkColumns.length || data.nonPkColumn
 
 <template>
   <div
-    class="relative h-full flex flex-col justify-center items-center bg-slate-50 min-w-16 rounded-lg nc-erd-table-node"
+    class="relative h-full flex flex-col justify-center bg-slate-50 min-w-16 min-h-8 rounded-lg nc-erd-table-node"
     :class="[
       `nc-erd-table-node-${table.table_name}`,
-      showSkeleton ? 'cursor-pointer bg-slate-200 min-h-200px min-w-300px px-4' : '',
+      showSkeleton ? 'cursor-pointer items-center bg-slate-200 min-h-200px min-w-300px px-4' : '',
     ]"
     @click="$e('c:erd:node-click')"
   >

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -7,7 +7,7 @@ import type { Ref } from 'vue'
 import { MetaInj, computed, provide, toRefs, useNuxtApp } from '#imports'
 
 interface Props extends NodeProps {
-  data: TableType & { showPkAndFk: boolean; showAllColumns: boolean }
+  data: TableType & { showPkAndFk: boolean; showAllColumns: boolean; color: string }
   showSkeleton: boolean
 }
 
@@ -44,46 +44,46 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
 
 <template>
   <div
-    class="relative h-full flex flex-col justify-center items-center min-w-16 rounded-lg nc-erd-table-node"
-    :class="[`nc-erd-table-node-${data.table_name}`, showSkeleton ? 'bg-gray-100 min-h-100px' : 'bg-gray-50']"
+    class="relative h-full flex flex-col justify-center items-center bg-slate-50 min-w-16 rounded-lg nc-erd-table-node"
+    :class="[`nc-erd-table-node-${data.table_name}`, showSkeleton ? 'bg-slate-200 min-h-200px min-w-300px px-4' : '']"
     @click="$e('c:erd:node-click')"
   >
-    <GeneralTooltip modifier-key="Alt">
+    <GeneralTooltip class="h-full flex flex-1 justify-center items-center" modifier-key="Alt">
       <template #title> {{ data.table_name }} </template>
 
       <div
-        :class="[showSkeleton ? '' : 'border-b-1']"
-        class="text-gray-600 text-md py-2 border-gray-200 rounded-t-lg w-full pr-3 pl-2 bg-gray-100 font-semibold flex flex-row items-center"
+        :class="[showSkeleton ? '' : 'bg-primary bg-opacity-10 border-b-1']"
+        class="text-slate-600 text-md py-2 border-slate-500 rounded-t-lg w-full h-full px-3 font-semibold flex items-center"
       >
-        <MdiTableLarge v-if="data.type === 'table'" class="text-primary" />
+        <MdiTableLarge v-if="data.type === 'table'" class="text-primary" :class="showSkeleton ? 'text-6xl !px-2' : ''" />
         <MdiEyeCircleOutline v-else class="text-primary" />
 
-        <div :class="showSkeleton ? 'text-5xl font-semibold !px-2' : ''" class="flex px-1.5">
+        <div :class="showSkeleton ? 'text-6xl' : ''" class="flex px-2">
           {{ data.title }}
         </div>
       </div>
     </GeneralTooltip>
 
     <div v-if="showSkeleton">
-      <Handle :position="Position.Left" type="target" :connectable="false" />
-      <Handle :position="Position.Right" type="source" :connectable="false" />
+      <Handle style="left: -20px" class="opacity-0" :position="Position.Left" type="target" :connectable="false" />
+      <Handle style="right: -15px" class="opacity-0" :position="Position.Right" type="source" :connectable="false" />
     </div>
 
-    <div v-else>
+    <div v-else-if="nonPkColumns.length || pkAndFkColumns.length">
       <div
         v-for="col in pkAndFkColumns"
         :key="col.title"
-        class="w-full border-b-1 py-2 border-gray-100 keys"
+        class="w-full border-b-1 py-2 border-slate-200 bg-slate-100"
         :class="`nc-erd-table-node-${data.table_name}-column-${col.column_name}`"
       >
         <LazySmartsheetHeaderCell v-if="col" :column="col" :hide-menu="true" />
       </div>
 
-      <div class="w-full mb-1"></div>
+      <div v-if="nonPkColumns.length" class="w-full mb-1"></div>
 
       <div v-for="(col, index) in nonPkColumns" :key="col.title">
         <div
-          class="relative w-full h-full flex items-center min-w-32 border-gray-100 py-2 px-1"
+          class="relative w-full h-full flex items-center min-w-32 border-slate-200 py-2 px-1"
           :class="index + 1 === nonPkColumns.length ? 'rounded-b-lg' : 'border-b-1'"
         >
           <div
@@ -93,16 +93,18 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
           >
             <Handle
               :id="`s-${relatedColumnId(col.colOptions)}-${data.id}`"
-              class="opacity-0 !right-[-3px]"
+              class="opacity-0 !right-[-1px]"
               type="source"
               :position="Position.Right"
+              :connectable="false"
             />
 
             <Handle
               :id="`d-${relatedColumnId(col.colOptions)}-${data.id}`"
-              class="opacity-0"
+              class="opacity-0 !left-[-1px]"
               type="target"
               :position="Position.Left"
+              :connectable="false"
             />
 
             <LazySmartsheetHeaderVirtualCell :column="col" :hide-menu="true" />
@@ -126,9 +128,3 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
     </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-.keys {
-  background-color: #f6f6f6;
-}
-</style>

--- a/packages/nc-gui/components/erd/TableNode.vue
+++ b/packages/nc-gui/components/erd/TableNode.vue
@@ -8,6 +8,7 @@ import { MetaInj, computed, provide, toRefs, useNuxtApp } from '#imports'
 
 interface Props extends NodeProps {
   data: TableType & { showPkAndFk: boolean; showAllColumns: boolean }
+  showSkeleton: boolean
 }
 
 const props = defineProps<Props>()
@@ -43,24 +44,32 @@ const relatedColumnId = (colOptions: LinkToAnotherRecordType | any) =>
 
 <template>
   <div
-    class="h-full flex flex-col min-w-16 bg-gray-50 rounded-lg border-1 nc-erd-table-node"
-    :class="`nc-erd-table-node-${data.table_name}`"
+    class="relative h-full flex flex-col justify-center items-center min-w-16 rounded-lg nc-erd-table-node"
+    :class="[`nc-erd-table-node-${data.table_name}`, showSkeleton ? 'bg-gray-100 min-h-100px' : 'bg-gray-50']"
     @click="$e('c:erd:node-click')"
   >
     <GeneralTooltip modifier-key="Alt">
       <template #title> {{ data.table_name }} </template>
+
       <div
-        class="text-gray-600 text-md py-2 border-b-1 border-gray-200 rounded-t-lg w-full pr-3 pl-2 bg-gray-100 font-semibold flex flex-row items-center"
+        :class="[showSkeleton ? '' : 'border-b-1']"
+        class="text-gray-600 text-md py-2 border-gray-200 rounded-t-lg w-full pr-3 pl-2 bg-gray-100 font-semibold flex flex-row items-center"
       >
         <MdiTableLarge v-if="data.type === 'table'" class="text-primary" />
         <MdiEyeCircleOutline v-else class="text-primary" />
-        <div class="flex pl-1.5">
+
+        <div :class="showSkeleton ? 'text-5xl font-semibold !px-2' : ''" class="flex px-1.5">
           {{ data.title }}
         </div>
       </div>
     </GeneralTooltip>
 
-    <div>
+    <div v-if="showSkeleton">
+      <Handle :position="Position.Left" type="target" :connectable="false" />
+      <Handle :position="Position.Right" type="source" :connectable="false" />
+    </div>
+
+    <div v-else>
       <div
         v-for="col in pkAndFkColumns"
         :key="col.title"

--- a/packages/nc-gui/components/erd/View.vue
+++ b/packages/nc-gui/components/erd/View.vue
@@ -107,7 +107,7 @@ watch(
       <LazyErdFlow :tables="tables" :config="config" />
 
       <div
-        class="absolute top-3 right-12 flex-col bg-white py-2 px-4 border-1 border-gray-100 rounded-md z-50 space-y-1 nc-erd-context-menu z-50"
+        class="absolute top-3.5 right-12 flex-col bg-white shadow-sm px-3 py-0.75 border-1 border-gray-100 rounded z-50 space-y-1 nc-erd-context-menu z-50"
       >
         <div class="flex flex-row items-center">
           <a-checkbox

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -97,7 +97,7 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
     }, [] as Relation[]),
   )
 
-  function edgeLabel({ type, source, target, modelId, childColId, parentColId }: Relation) {
+  function edgeLabel({ type, source, target, modelId, childColId, parentColId }: Relation, simple = false) {
     const typeLabel = type === 'mm' ? 'many to many' : 'has many'
 
     const parentCol = metasWithIdAsKey.value[source].columns?.find((col) => {
@@ -136,7 +136,11 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
       }
     }
 
-    return `${parentCol.title} ${typeLabel} ${childCol.title}`
+    if (simple) {
+      return `${metasWithIdAsKey.value[source].title} ${type} ${metasWithIdAsKey.value[target].title}`
+    }
+
+    return `[${metasWithIdAsKey.value[source].title}] ${parentCol.title} ${typeLabel} ${childCol.title} [${metasWithIdAsKey.value[target].title}]`
   }
 
   function createNodes() {
@@ -212,6 +216,7 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
           isManyToMany: type === 'mm',
           isSelfRelation: source === target && sourceColumnId === targetColumnId,
           label: edgeLabel({ type, source, target, childColId, parentColId, modelId }),
+          simpleLabel: edgeLabel({ type, source, target, childColId, parentColId, modelId }, true),
         },
       } as Edge)
 

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -3,7 +3,7 @@ import { UITypes } from 'nocodb-sdk'
 import dagre from 'dagre'
 import type { Edge, Elements } from '@vue-flow/core'
 import type { MaybeRef } from '@vueuse/core'
-import { Position, isEdge, isNode } from '@vue-flow/core'
+import { MarkerType, Position, isEdge, isNode } from '@vue-flow/core'
 import { scaleLinear as d3ScaleLinear } from 'd3-scale'
 import { computed, ref, unref, useMetas, useTheme } from '#imports'
 
@@ -160,6 +160,7 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
         sourceHandle: `s-${sourceColumnId}-${source}`,
         targetHandle: `d-${targetColumnId}-${target}`,
         type: 'custom',
+        markerEnd: MarkerType.ArrowClosed,
         data: {
           isManyToMany: type === 'mm',
           isSelfRelation: source === target && sourceColumnId === targetColumnId,
@@ -213,7 +214,7 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
       if (isNode(el)) {
         dagreGraph.setNode(el.id, {
           width: skeleton ? nodeWidth * 2 : nodeWidth,
-          height: nodeHeight + (skeleton ? 100 : nodeHeight * el.data.columnLength),
+          height: nodeHeight + (skeleton ? 250 : nodeHeight * el.data.columnLength),
         })
       } else if (isEdge(el)) {
         // avoid duplicate edges when using skeleton

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -27,7 +27,7 @@ interface Relation {
 }
 
 const nodeWidth = 300
-const nodeHeight = 35
+const nodeHeight = 50
 
 export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<ErdFlowConfig>) {
   const elements = ref<Elements>([])
@@ -149,7 +149,7 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
 
       const columns =
         metasWithIdAsKey.value[table.id].columns?.filter(
-          (col) => !(col.uidt === UITypes.LinkToAnotherRecord && col.system === 1),
+          (col) => config.showAllColumns || (!config.showAllColumns && col.uidt === UITypes.LinkToAnotherRecord),
         ) || []
 
       const pkAndFkColumns = columns
@@ -263,15 +263,13 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
   }
 
   const layout = (skeleton = false) => {
-    if (!skeleton) elements.value = [...createNodes(), ...createEdges()]
-
-    if (!config.singleTableMode) connectNonConnectedNodes()
+    elements.value = [...createNodes(), ...createEdges()]
 
     elements.value.forEach((el) => {
       if (isNode(el)) {
         dagreGraph.setNode(el.id, {
           width: skeleton ? nodeWidth * 2.5 : nodeWidth,
-          height: 50 + (skeleton ? 250 : nodeHeight * el.data.columnLength),
+          height: nodeHeight + (skeleton ? 250 : nodeHeight * el.data.columnLength),
         })
       } else if (isEdge(el)) {
         // avoid duplicate edges when using skeleton

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -137,10 +137,10 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
     }
 
     if (simple) {
-      return `${metasWithIdAsKey.value[source].title} ${type} ${metasWithIdAsKey.value[target].title}`
+      return `${metasWithIdAsKey.value[source].title} - ${typeLabel} - ${metasWithIdAsKey.value[target].title}`
     }
 
-    return `[${metasWithIdAsKey.value[source].title}] ${parentCol.title} ${typeLabel} ${childCol.title} [${metasWithIdAsKey.value[target].title}]`
+    return `[${metasWithIdAsKey.value[source].title}] ${parentCol.title} - ${typeLabel} - ${childCol.title} [${metasWithIdAsKey.value[target].title}]`
   }
 
   function createNodes() {

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -25,6 +25,9 @@ interface Relation {
   type: 'mm' | 'hm'
 }
 
+const nodeWidth = 300
+const nodeHeight = 35
+
 export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<ErdFlowConfig>) {
   const elements = ref<Elements>([])
 
@@ -201,16 +204,22 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
     })
   }
 
-  const layout = () => {
-    elements.value = [...createNodes(), ...createEdges()]
+  const layout = (skeleton = false) => {
+    if (!skeleton) elements.value = [...createNodes(), ...createEdges()]
 
     if (!config.singleTableMode) connectNonConnectedNodes()
 
     elements.value.forEach((el) => {
       if (isNode(el)) {
-        dagreGraph.setNode(el.id, { width: 300, height: 35 + 50 * el.data.columnLength + 1 })
+        dagreGraph.setNode(el.id, {
+          width: skeleton ? nodeWidth * 2 : nodeWidth,
+          height: nodeHeight + (skeleton ? 100 : nodeHeight * el.data.columnLength),
+        })
       } else if (isEdge(el)) {
-        dagreGraph.setEdge(el.source, el.target)
+        // avoid duplicate edges when using skeleton
+        if ((skeleton && !dagreGraph.edge(el.source, el.target)) || !skeleton) {
+          dagreGraph.setEdge(el.source, el.target)
+        }
       }
     })
 

--- a/packages/nc-gui/components/erd/utils.ts
+++ b/packages/nc-gui/components/erd/utils.ts
@@ -26,7 +26,7 @@ interface Relation {
 }
 
 const nodeWidth = 300
-const nodeHeight = 35
+const nodeHeight = 50
 
 export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<ErdFlowConfig>) {
   const elements = ref<Elements>([])
@@ -234,9 +234,9 @@ export function useErdElements(tables: MaybeRef<TableType[]>, props: MaybeRef<Er
         el.targetPosition = Position.Left
         el.sourcePosition = Position.Right
         el.position = { x: nodeWithPosition.x, y: nodeWithPosition.y }
-        el.class = 'rounded-lg'
+        el.class = ['rounded-lg'].join(' ')
         el.data.color = color
-        el.style = { boxShadow: `0 0 0 2px ${color}` }
+        el.style = { boxShadow: `0 0 0 ${skeleton ? '15px' : '2px'} ${color}` }
       } else if (isEdge(el)) {
         const node = elements.value.find((nodes) => nodes.id === el.source)
         if (node) {

--- a/packages/nc-gui/components/smartsheet/toolbar/Erd.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/Erd.vue
@@ -25,16 +25,14 @@ const selectedView = inject(ActiveViewInj)
     transition-name="fade"
     :destroy-on-close="true"
   >
-    <div class="flex flex-row justify-between w-full items-center mb-1">
-      <a-typography-title class="ml-4 select-none" type="secondary" :level="5">
+    <div class="flex justify-between w-full items-start px-[24px] pt-6 pb-4 border-b-1">
+      <div class="select-none text-slate-500 font-semibold">
         {{ `${$t('title.erdView')}: ${selectedView?.title}` }}
-      </a-typography-title>
+      </div>
 
-      <a-button type="text" class="!rounded-md border-none -mt-1.5 -mr-1" @click="vModel = false">
-        <template #icon>
-          <MdiClose class="cursor-pointer mt-1 nc-modal-close" />
-        </template>
-      </a-button>
+      <div class="flex h-full items-center justify-center rounded group" @click="vModel = false">
+        <MdiClose class="cursor-pointer mt-1 nc-modal-close group-hover:text-accent text-opacity-100" />
+      </div>
     </div>
 
     <div class="w-full h-full !py-0 !px-2" style="height: 70vh">
@@ -44,7 +42,12 @@ const selectedView = inject(ActiveViewInj)
 </template>
 
 <style>
-.ant-modal {
-  @apply !top-[50px];
+.erd-single-table-modal {
+  .ant-modal {
+    @apply !top-[50px];
+  }
+  .ant-modal-body {
+    @apply !p-0;
+  }
 }
 </style>

--- a/packages/nc-gui/package-lock.json
+++ b/packages/nc-gui/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@ckpack/vue-color": "^1.2.0",
         "@vue-flow/additional-components": "^1.1.0",
-        "@vue-flow/core": "^1.1.1",
+        "@vue-flow/core": "^1.1.3",
         "@vuelidate/core": "^2.0.0-alpha.44",
         "@vuelidate/validators": "^2.0.0-alpha.31",
         "@vueuse/core": "^9.0.2",
@@ -3550,9 +3550,9 @@
       }
     },
     "node_modules/@vue-flow/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-zXEmZl9Rxrpi9+EzQoa//u0+pCzStwlISGdWw/WjXvVrBBfg6goW20k66TjHoJbzK3yNRN5b4lBBR0lVWZh/0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-MuJjWLexkZ5RiMY/LmuyRZXiXKo8ttaKSPk02RYP8SoWVj6Kr0XglWh6FJdQE0bQhqpwsXBka+4EQrI4B/ueSw==",
       "dependencies": {
         "@vueuse/core": "^9.3.0",
         "d3-drag": "^3.0.0",
@@ -19551,9 +19551,9 @@
       "requires": {}
     },
     "@vue-flow/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-zXEmZl9Rxrpi9+EzQoa//u0+pCzStwlISGdWw/WjXvVrBBfg6goW20k66TjHoJbzK3yNRN5b4lBBR0lVWZh/0w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-flow/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-MuJjWLexkZ5RiMY/LmuyRZXiXKo8ttaKSPk02RYP8SoWVj6Kr0XglWh6FJdQE0bQhqpwsXBka+4EQrI4B/ueSw==",
       "requires": {
         "@vueuse/core": "^9.3.0",
         "d3-drag": "^3.0.0",

--- a/packages/nc-gui/package.json
+++ b/packages/nc-gui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@ckpack/vue-color": "^1.2.0",
     "@vue-flow/additional-components": "^1.1.0",
-    "@vue-flow/core": "^1.1.1",
+    "@vue-flow/core": "^1.1.3",
     "@vuelidate/core": "^2.0.0-alpha.44",
     "@vuelidate/validators": "^2.0.0-alpha.31",
     "@vueuse/core": "^9.0.2",


### PR DESCRIPTION
## Change Summary

- when zooming out in ERD, show a more basic version of the flow (skeleton mode)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

https://user-images.githubusercontent.com/78412429/195872423-8e41af7b-0cf2-4eeb-a38a-0422b3f99d2a.mov

https://user-images.githubusercontent.com/78412429/195872645-fd62232c-f8a7-48f6-bca3-fafa0a6757f6.mov

https://user-images.githubusercontent.com/78412429/195872525-123a2949-13d1-4dd4-89a9-7db2a307b034.mov

https://user-images.githubusercontent.com/78412429/195872573-2b4ce52e-ca85-49c2-a143-e66f644a3d56.mov
