### PR TITLE
fix(nc-gui): add number type to checkbox modelValue

### DIFF
--- a/packages/nc-gui/components/cell/Checkbox.vue
+++ b/packages/nc-gui/components/cell/Checkbox.vue
@@ -4,7 +4,7 @@ import { ColumnInj, IsFormInj, ReadonlyInj, getMdiIcon, inject } from '#imports'
 interface Props {
   // If the previous cell value was a text, the initial checkbox value is a string type
   // otherwise it can be either a boolean, or a string representing a boolean, i.e '0' or '1'
-  modelValue?: boolean | string | '0' | '1'
+  modelValue?: boolean | string | number | '0' | '1'
 }
 
 interface Emits {
@@ -16,7 +16,7 @@ const props = defineProps<Props>()
 const emits = defineEmits<Emits>()
 
 let vModel = $computed({
-  get: () => !!props.modelValue && props.modelValue !== '0',
+  get: () => !!props.modelValue && props.modelValue !== '0' && props.modelValue !== 0,
   set: (val) => emits('update:modelValue', val),
 })
 


### PR DESCRIPTION
## Change Summary

- Allow number for checkbox modelValue as sqlite3 returns 1/0 for boolean causing following warning
![image](https://user-images.githubusercontent.com/59797957/195981091-0aa2f3b5-904f-44ce-9afa-35279571ef4c.png)


## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

