### PR TITLE
refactor(nc-gui): extend tooltip toggle conditions

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView.vue
+++ b/packages/nc-gui/components/dashboard/TreeView.vue
@@ -323,7 +323,7 @@ function openTableCreateDialog() {
                 :data-id="table.id"
                 @click="addTableTab(table)"
               >
-                <GeneralTooltip wrapper-class="pl-5 pr-3 py-2" modifier-key="Alt">
+                <GeneralTooltip class="pl-5 pr-3 py-2" modifier-key="Alt">
                   <template #title>{{ table.table_name }}</template>
                   <div class="flex items-center gap-2 h-full" @contextmenu="setMenuContext('table', table)">
                     <div class="flex w-auto">

--- a/packages/nc-gui/components/general/Tooltip.vue
+++ b/packages/nc-gui/components/general/Tooltip.vue
@@ -48,16 +48,19 @@ onKeyStroke(
 watch([isHovering, () => modifierKey], ([hovering, key]) => {
   if (!hovering) {
     showTooltip.value = false
+    return
   }
 
   // Show tooltip on mouseover if no modifier key is provided
   if (hovering && !key) {
     showTooltip.value = true
+    return
   }
 
   // While hovering if the modifier key was changed and the key is not pressed, hide tooltip
   if (hovering && key && !isKeyPressed.value) {
     showTooltip.value = false
+    return
   }
 
   // When mouse leaves the element, then re-enters the element while key stays pressed, show the tooltip

--- a/packages/nc-gui/components/general/Tooltip.vue
+++ b/packages/nc-gui/components/general/Tooltip.vue
@@ -1,46 +1,79 @@
 <script lang="ts" setup>
 import { onKeyStroke } from '@vueuse/core'
-import { ref, watch } from '#imports'
+import type { CSSProperties } from '@vue/runtime-dom'
+import { ref, useElementHover, watch } from '#imports'
 
 interface Props {
   // Key to be pressed on hover to trigger the tooltip
   modifierKey?: string
-  wrapperClass?: string
+  tooltipStyle?: CSSProperties
 }
 
-const { modifierKey, wrapperClass } = defineProps<Props>()
+const { modifierKey, tooltipStyle } = defineProps<Props>()
+
+const el = ref()
 
 const showTooltip = ref(false)
 
-const isMouseOver = ref(false)
+const isHovering = useElementHover(() => el.value)
 
-if (modifierKey) {
-  onKeyStroke(modifierKey, (e) => {
+const isKeyPressed = ref(false)
+
+onKeyStroke(
+  (e) => e.key === modifierKey,
+  (e) => {
     e.preventDefault()
-    if (modifierKey && isMouseOver.value) {
+    if (modifierKey && isHovering.value) {
       showTooltip.value = true
     }
-  })
-}
 
-watch(isMouseOver, (val) => {
-  if (!val) {
+    isKeyPressed.value = true
+  },
+  { eventName: 'keydown' },
+)
+
+onKeyStroke(
+  (e) => e.key === modifierKey,
+  (e) => {
+    e.preventDefault()
+    if (modifierKey) {
+      showTooltip.value = false
+    }
+
+    isKeyPressed.value = false
+  },
+  { eventName: 'keyup' },
+)
+
+watch([isHovering, () => modifierKey], ([hovering, key]) => {
+  if (!hovering) {
     showTooltip.value = false
   }
 
   // Show tooltip on mouseover if no modifier key is provided
-  if (val && !modifierKey) {
+  if (hovering && !key) {
+    showTooltip.value = true
+  }
+
+  // While hovering if the modifier key was changed and the key is not pressed, hide tooltip
+  if (hovering && key && !isKeyPressed.value) {
+    showTooltip.value = false
+  }
+
+  // When mouse leaves the element, then re-enters the element while key stays pressed, show the tooltip
+  if (!showTooltip.value && hovering && key && isKeyPressed.value) {
     showTooltip.value = true
   }
 })
 </script>
 
 <template>
-  <a-tooltip v-model:visible="showTooltip" :trigger="[]">
+  <a-tooltip v-model:visible="showTooltip" :overlay-style="tooltipStyle" :trigger="[]">
     <template #title>
       <slot name="title" />
     </template>
-    <div class="w-full" :class="wrapperClass" @mouseenter="isMouseOver = true" @mouseleave="isMouseOver = false">
+
+    <div ref="el" class="w-full" :class="$attrs.class" :style="$attrs.style">
       <slot />
     </div>
   </a-tooltip>

--- a/packages/nc-gui/components/general/Tooltip.vue
+++ b/packages/nc-gui/components/general/Tooltip.vue
@@ -23,7 +23,8 @@ onKeyStroke(
   (e) => e.key === modifierKey,
   (e) => {
     e.preventDefault()
-    if (modifierKey && isHovering.value) {
+
+    if (isHovering.value) {
       showTooltip.value = true
     }
 
@@ -36,10 +37,8 @@ onKeyStroke(
   (e) => e.key === modifierKey,
   (e) => {
     e.preventDefault()
-    if (modifierKey) {
-      showTooltip.value = false
-    }
 
+    showTooltip.value = false
     isKeyPressed.value = false
   },
   { eventName: 'keyup' },


### PR DESCRIPTION
# What's changed?

- toggle tooltip when key is pressed and mouse leaves/reenters element
- toggle tooltip on modifier key change
- use isHovering to detect element hover

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
