### PR TITLE
fix(nc-gui): gallery cover image is clipped

### DIFF
--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -200,7 +200,7 @@ watch(view, async (nextView) => {
                   :key="`carousel-${record.row.id}-${index}`"
                   quality="90"
                   placeholder
-                  class="h-52 object-cover"
+                  class="h-52 object-contain"
                   :src="attachment.url"
                 />
               </a-carousel>
@@ -289,7 +289,7 @@ watch(view, async (nextView) => {
 .ant-carousel.gallery-carousel :deep(.slick-dots) {
   position: relative;
   height: auto;
-  bottom: 0px;
+  bottom: 0;
 }
 
 .ant-carousel.gallery-carousel :deep(.slick-dots li div > div) {


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

ref: #3599

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

No test changes

## Additional information / screenshots (optional)

This PR changes the styling of cover images from `object-cover`, which scales down the image to the smallest size so it fills the entire container, to `object-contain` which scales the image so it fits entirely within the container. 

**Old:** `object-cover` looks better in terms of design, since each card is uniformly filled with the image. However, information is lost in this case.
<img width="978" alt="image" src="https://user-images.githubusercontent.com/6614995/196759249-40550275-bc1e-42bd-9fd3-c64558b7aa52.png">

**New:** `object-contain` displays the full image, albeit much smaller in the case of wider or longer images. 
<img width="975" alt="image" src="https://user-images.githubusercontent.com/6614995/196759681-6de7001b-98f1-4d08-9c72-0c02f4ccec17.png">

Since the cards are responsive and their width varies, it's unadvisable to fix their size to the size of the image.

Ideally, the user would be able to choose how the image is displayed, similar to this UI from [Craft](https://www.craft.do/). I can see both use cases being valid for users.
<img width="338" alt="image" src="https://user-images.githubusercontent.com/6614995/196760525-edb14412-e570-4bc4-99b3-380d72f4d406.png">


