### PR TITLE
fix: swagger.json

### DIFF
--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -573,15 +573,6 @@
         },
         "tags": [
           "Project"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "number",
-              "minimum": 1,
-              "multipleOf": 1
-            }
-          }
         ]
       }
     },

--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -4524,7 +4524,7 @@
               "type": "string"
             },
             "in": "header",
-            "name": "TODO"
+            "name": "xc-password"
           }
         ]
       }

--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -581,7 +581,8 @@
               "minimum": 1,
               "multipleOf": 1
             },
-            "in": "query"
+            "in": "query",
+            "name": "TODO"
           }
         ]
       }
@@ -4533,7 +4534,8 @@
             "schema": {
               "type": "string"
             },
-            "in": "header"
+            "in": "header",
+            "name": "TODO"
           }
         ]
       }
@@ -5567,6 +5569,16 @@
       "post": {
         "summary": "",
         "operationId": "utils-url-to-config",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        },
         "tags": [
           "Utils"
         ],

--- a/scripts/sdk/swagger.json
+++ b/scripts/sdk/swagger.json
@@ -580,9 +580,7 @@
               "type": "number",
               "minimum": 1,
               "multipleOf": 1
-            },
-            "in": "query",
-            "name": "TODO"
+            }
           }
         ]
       }


### PR DESCRIPTION
## Change Summary

I tried to generate Dart client from swagger.json and ran into errors.
This change will resolve those errors.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

### Before

```
$ git rev-parse --short HEAD
1e8c56a1c

$ openapi-generator generate -i scripts/sdk/swagger.json -g dart-dio -o ./openapi/client
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 6, Warning count: 24
Errors: 
	-attribute paths.'/api/v1/db/meta/projects/{projectId}/info'(get).parameters.[['unknown']].name is missing
	-attribute paths.'/api/v1/db/data/{orgs}/{projectName}/{tableName}/views/{viewName}/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/db/data/{orgs}/{projectName}/{tableName}/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/db/public/shared-view/{sharedViewUuid}/rows'(post).parameters.[['unknown']].name is missing
	-attribute paths.'/api/v1/db/public/shared-view/{sharedViewUuid}/rows/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/url_to_config'(post).responses is missing
Warnings: 
	-attribute paths.'/api/v1/db/meta/projects/{projectId}/info'(get).parameters.[['unknown']].name is missing
	-attribute paths.'/api/v1/db/data/{orgs}/{projectName}/{tableName}/views/{viewName}/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/db/data/{orgs}/{projectName}/{tableName}/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/db/public/shared-view/{sharedViewUuid}/rows'(post).parameters.[['unknown']].name is missing
	-attribute paths.'/api/v1/db/public/shared-view/{sharedViewUuid}/rows/export/{type}'(get).wrapped is unexpected
	-attribute paths.'/api/v1/url_to_config'(post).responses is missing

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:604)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:631)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:457)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)
```

### After

```
$ openapi-generator generate -i scripts/sdk/swagger.json -g dart-dio -o ./openapi/client
...
[main] INFO  o.o.codegen.TemplateManager - writing file /Users/enm10k/w/nocodb/./openapi/client/.openapi-generator-ignore
[main] INFO  o.o.codegen.TemplateManager - writing file /Users/enm10k/w/nocodb/./openapi/client/.openapi-generator/VERSION
[main] INFO  o.o.codegen.TemplateManager - writing file /Users/enm10k/w/nocodb/./openapi/client/.openapi-generator/FILES
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
################################################################################
```

## Additional information / screenshots (optional)

There are still some exitsting issues to fix.
Could you give me advice on these?

1.  ~~I needed to remove some `wrapped` fileds to make it pass.~~
    - ~~From what I found, `wrapped` should be specified for XML Object. https://swagger.io/specification/~~
    - Resolved. By using `--skip-validate-spec` option, no need to remove `wrapped` fields.
2. There were some missing `name` fields and I couldn't find right names for it.
    - I set `TODO` for those fields provisionally