### PR TITLE
fix(nc-gui): make dateformat in date picker reactive

### DIFF
--- a/packages/nc-gui/components/cell/DatePicker.vue
+++ b/packages/nc-gui/components/cell/DatePicker.vue
@@ -16,7 +16,7 @@ const readOnly = inject(ReadonlyInj, false)
 
 let isDateInvalid = $ref(false)
 
-const dateFormat = columnMeta?.value?.meta?.date_format ?? 'YYYY-MM-DD'
+const dateFormat = $computed(() => columnMeta?.value?.meta?.date_format ?? 'YYYY-MM-DD')
 
 const localState = $computed({
   get() {


### PR DESCRIPTION
## Change Summary

Make the date format in the date picker reactive so the date will be displayed with the new format immediately.

Fix https://github.com/nocodb/nocodb/issues/4138.


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

No test changes.

## Additional information / screenshots (optional)


https://user-images.githubusercontent.com/1910192/197706580-288054e7-6c31-4fa0-bb24-12e1d7803219.mov


