### PR TITLE
refactor(workflows): replace set-output with github env

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -60,10 +60,10 @@ jobs:
               DOCKER_REPOSITORY=${DOCKER_REPOSITORY}-timely
             fi
           fi
-          echo "::set-output name=DOCKER_REPOSITORY::${DOCKER_REPOSITORY}"
-          echo "::set-output name=DOCKER_BUILD_TAG::${DOCKER_BUILD_TAG}"
-          echo ${DOCKER_REPOSITORY}
-          echo ${DOCKER_BUILD_TAG}
+          echo "DOCKER_REPOSITORY=${DOCKER_REPOSITORY}" >> $GITHUB_OUTPUT
+          echo "DOCKER_BUILD_TAG=${DOCKER_BUILD_TAG}" >> $GITHUB_OUTPUT
+          echo DOCKER_REPOSITORY: ${DOCKER_REPOSITORY}
+          echo DOCKER_BUILD_TAG: ${DOCKER_BUILD_TAG}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -127,14 +127,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ env.working-directory }}
-          build-args: NC_VERSION=${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
+          build-args: NC_VERSION=${{ env.DOCKER_BUILD_TAG }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           push: true
           tags: |
-            nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
-            nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:latest
+            nocodb/${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_BUILD_TAG }}
+            nocodb/${{ env.DOCKER_REPOSITORY }}:latest
 
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -127,14 +127,14 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ${{ env.working-directory }}
-          build-args: NC_VERSION=${{ env.DOCKER_BUILD_TAG }}
+          build-args: NC_VERSION=${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           push: true
           tags: |
-            nocodb/${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_BUILD_TAG }}
-            nocodb/${{ env.DOCKER_REPOSITORY }}:latest
+            nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
+            nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:latest
 
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -53,7 +53,7 @@ jobs:
           if [[ ${{ github.event.inputs.tagHeadSHA || inputs.tagHeadSHA }} == "Y" ]]; then
             TARGET_SHA=$(git rev-list -n 1 HEAD | tail -1)
           fi
-          echo "::set-output name=TARGET_SHA::${TARGET_SHA}"
+          echo "TARGET_SHA=${TARGET_SHA}" >> $GITHUB_OUTPUT
           echo "Setting TARGET_SHA: ${TARGET_SHA}"
       - name: Create tag
         uses: actions/github-script@v3
@@ -66,7 +66,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/${{ github.event.inputs.tag || inputs.tag }}",
-              sha: "${{steps.get-sha.outputs.TARGET_SHA}}"
+              sha: "${{ env.TARGET_SHA }}"
             })
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -66,7 +66,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/${{ github.event.inputs.tag || inputs.tag }}",
-              sha: "${{ env.TARGET_SHA }}"
+              sha: "${{ steps.get-sha.outputs.TARGET_SHA }}"
             })
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -194,7 +194,7 @@ jobs:
           cp ./mac-dist/Noco-macos-x64 ./mac-dist/nocodb
           tar -czf ./mac-dist/nocodb.tar.gz ./mac-dist/nocodb
           rm ./mac-dist/nocodb
-          echo "::set-output name=CHECKSUM::$(shasum -a 256 ./mac-dist/nocodb.tar.gz | awk '{print $1}')"
+          echo "CHECKSUM=$(shasum -a 256 ./mac-dist/nocodb.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
         id: compress
 
 
@@ -240,7 +240,7 @@ jobs:
             desc "NocoDB : Opensource smart spreadsheet"
             homepage "https://github.com/nocodb/nocodb"
             url "https://github.com/nocodb/nocodb/releases/download/${{ github.event.inputs.tag || inputs.tag }}/nocodb.tar.gz"
-            sha256 "${{ steps.compress.outputs.CHECKSUM }}"
+            sha256 "${{ env.CHECKSUM }}"
             license "MIT"
             version "${{ github.event.inputs.tag || inputs.tag }}"
 

--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -240,7 +240,7 @@ jobs:
             desc "NocoDB : Opensource smart spreadsheet"
             homepage "https://github.com/nocodb/nocodb"
             url "https://github.com/nocodb/nocodb/releases/download/${{ github.event.inputs.tag || inputs.tag }}/nocodb.tar.gz"
-            sha256 "${{ env.CHECKSUM }}"
+            sha256 "${{ steps.compress.outputs.CHECKSUM }}"
             license "MIT"
             version "${{ github.event.inputs.tag || inputs.tag }}"
 

--- a/.github/workflows/release-nightly-dev.yml
+++ b/.github/workflows/release-nightly-dev.yml
@@ -26,24 +26,19 @@ jobs:
           if [[ ${{ github.event_name }} == 'workflow_dispatch' ]]; then
             IS_DAILY='N'
           fi
-          echo "::set-output name=NIGHTLY_BUILD_TAG::${TAG_NAME}"
-          echo "::set-output name=IS_DAILY::${IS_DAILY}"
-          echo "::set-output name=CURRENT_VERSION::${CURRENT_VERSION}"
-      - name: verify-tag
-        run: |
-          echo ${{ steps.tag-step.outputs.NIGHTLY_BUILD_TAG }}
-          echo ${{ steps.tag-step.outputs.IS_DAILY }}
-          echo ${{ steps.tag-step.outputs.CURRENT_VERSION }}
-    outputs:
-      nightly_build_tag: ${{ steps.tag-step.outputs.NIGHTLY_BUILD_TAG }}
-      is_daily: ${{ steps.tag-step.outputs.IS_DAILY }}
-      current_version: ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+          echo "NIGHTLY_BUILD_TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "IS_DAILY=${IS_DAILY}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+          # verify
+          echo NIGHTLY_BUILD_TAG: ${{ env.NIGHTLY_BUILD_TAG }}
+          echo IS_DAILY: ${{ env.IS_DAILY }}
+          echo CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
   # Build frontend and backend and publish to npm
   release-npm:
     needs: set-tag
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ needs.set-tag.outputs.nightly_build_tag }}
+      tag: ${{ env.NIGHTLY_BUILD_TAG }}
       targetEnv: 'DEV'
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -53,7 +48,7 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-timely-executables.yml
     with:
-      tag: ${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.nightly_build_tag }}
+      tag: ${{ env.CURRENT_VERSION }}-${{ env.NIGHTLY_BUILD_TAG }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -62,10 +57,10 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-docker.yml
     with:
-      currentVersion: ${{ needs.set-tag.outputs.current_version }}
-      tag: ${{ needs.set-tag.outputs.nightly_build_tag }}
+      currentVersion: ${{ env.CURRENT_VERSION }}
+      tag: ${{ env.NIGHTLY_BUILD_TAG }}
       targetEnv: 'DEV'
-      isDaily: ${{ needs.set-tag.outputs.is_daily }}
+      isDaily: ${{ env.IS_DAILY }}
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
       DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"

--- a/.github/workflows/release-nightly-dev.yml
+++ b/.github/workflows/release-nightly-dev.yml
@@ -29,16 +29,21 @@ jobs:
           echo "NIGHTLY_BUILD_TAG=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "IS_DAILY=${IS_DAILY}" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-          # verify
-          echo NIGHTLY_BUILD_TAG: ${{ env.NIGHTLY_BUILD_TAG }}
-          echo IS_DAILY: ${{ env.IS_DAILY }}
-          echo CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
+      - name: verify-tag
+        run: |
+          echo ${{ steps.tag-step.outputs.NIGHTLY_BUILD_TAG }}
+          echo ${{ steps.tag-step.outputs.IS_DAILY }}
+          echo ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+    outputs:
+      nightly_build_tag: ${{ steps.tag-step.outputs.NIGHTLY_BUILD_TAG }}
+      is_daily: ${{ steps.tag-step.outputs.IS_DAILY }}
+      current_version: ${{ steps.tag-step.outputs.CURRENT_VERSION }}
   # Build frontend and backend and publish to npm
   release-npm:
     needs: set-tag
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ env.NIGHTLY_BUILD_TAG }}
+      tag: ${{ needs.set-tag.outputs.nightly_build_tag }}
       targetEnv: 'DEV'
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -48,7 +53,7 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-timely-executables.yml
     with:
-      tag: ${{ env.CURRENT_VERSION }}-${{ env.NIGHTLY_BUILD_TAG }}
+      tag: ${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.nightly_build_tag }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -57,10 +62,10 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-docker.yml
     with:
-      currentVersion: ${{ env.CURRENT_VERSION }}
-      tag: ${{ env.NIGHTLY_BUILD_TAG }}
+      currentVersion: ${{ needs.set-tag.outputs.current_version }}
+      tag: ${{ needs.set-tag.outputs.nightly_build_tag }}
       targetEnv: 'DEV'
-      isDaily: ${{ env.IS_DAILY }}
+      isDaily: ${{ needs.set-tag.outputs.is_daily }}
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
       DOCKERHUB_TOKEN: "${{ secrets.DOCKERHUB_TOKEN }}"

--- a/.github/workflows/release-nocodb.yml
+++ b/.github/workflows/release-nocodb.yml
@@ -25,6 +25,9 @@ jobs:
   process-input:
     runs-on: ubuntu-latest
     needs: validate-branch
+    outputs:
+      target_tag: ${{ steps.process-input.outputs.target_tag }}
+      prev_tag: ${{ steps.process-input.outputs.prev_tag }}
     steps:
       - id: process-input
         name: process-input
@@ -42,17 +45,19 @@ jobs:
             TARGET_TAG=$(echo ${PREV_TAG} | awk -F. -v OFS=. '{$NF += 1 ; print}')
           fi
 
-          echo target version: ${TARGET_TAG}
-          echo previous version: ${PREV_TAG}
           echo "TARGET_TAG=${TARGET_TAG}" >> $GITHUB_OUTPUT
           echo "PREV_TAG=${PREV_TAG}" >> $GITHUB_OUTPUT
+      - name: Verify
+        run : |
+          echo TARGET_TAG: ${{ steps.process-input.outputs.target_tag }}
+          echo PREV_TAG: ${{ steps.process-input.outputs.prev_tag }}
 
   # Merge develop to master
   pr-to-master:
     needs: process-input
     uses: ./.github/workflows/pr-to-master.yml
     with:
-      tag: ${{ env.TARGET_TAG }}
+      tag: ${{ needs.process-input.outputs.target_tag }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
 
   # Build, install, publish frontend and backend to npm
@@ -60,7 +65,7 @@ jobs:
     needs: [pr-to-master, process-input]
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ env.TARGET_TAG }}
+      tag: ${{ needs.process-input.outputs.target_tag }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -70,8 +75,8 @@ jobs:
     needs: [release-npm, process-input]
     uses: ./.github/workflows/release-draft.yml
     with:
-      tag: ${{ env.TARGET_TAG }}
-      prev_tag: ${{ env.PREV_TAG }}
+      tag: ${{ needs.process-input.outputs.target_tag }}
+      prev_tag: ${{ needs.process-input.outputs.prev_tag }}
       tagHeadSHA: 'N'
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
@@ -82,7 +87,7 @@ jobs:
     uses: ./.github/workflows/release-docker.yml
     with:
       currentVersion: 'N/A'
-      tag: ${{ env.TARGET_TAG }}
+      tag: ${{ needs.process-input.outputs.target_tag }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
@@ -93,7 +98,7 @@ jobs:
     needs: [release-draft-note, process-input]
     uses: ./.github/workflows/release-executables.yml
     with:
-      tag: ${{ env.TARGET_TAG }}
+      tag: ${{ needs.process-input.outputs.target_tag }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -103,7 +108,7 @@ jobs:
     uses: ./.github/workflows/release-close-issue.yml
     with:
       issue_label: '🚀 Status: Ready for Next Release'
-      version: ${{ env.TARGET_TAG }}
+      version: ${{ needs.process-input.outputs.target_tag }}
 
   # Publish Docs
   publish-docs:

--- a/.github/workflows/release-nocodb.yml
+++ b/.github/workflows/release-nocodb.yml
@@ -25,9 +25,6 @@ jobs:
   process-input:
     runs-on: ubuntu-latest
     needs: validate-branch
-    outputs:
-      target_tag: ${{ steps.process-input.outputs.target_tag }}
-      prev_tag: ${{ steps.process-input.outputs.prev_tag }}
     steps:
       - id: process-input
         name: process-input
@@ -47,18 +44,15 @@ jobs:
 
           echo target version: ${TARGET_TAG}
           echo previous version: ${PREV_TAG}
-          echo "::set-output name=target_tag::${TARGET_TAG}"
-          echo "::set-output name=prev_tag::${PREV_TAG}"
-      - name: Verify
-        run : |
-          echo ${{ steps.process-input.outputs.target_tag }}
+          echo "TARGET_TAG=${TARGET_TAG}" >> $GITHUB_OUTPUT
+          echo "PREV_TAG=${PREV_TAG}" >> $GITHUB_OUTPUT
 
   # Merge develop to master
   pr-to-master:
     needs: process-input
     uses: ./.github/workflows/pr-to-master.yml
     with:
-      tag: ${{ needs.process-input.outputs.target_tag }}
+      tag: ${{ env.TARGET_TAG }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
 
   # Build, install, publish frontend and backend to npm
@@ -66,7 +60,7 @@ jobs:
     needs: [pr-to-master, process-input]
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ needs.process-input.outputs.target_tag }}
+      tag: ${{ env.TARGET_TAG }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -76,8 +70,8 @@ jobs:
     needs: [release-npm, process-input]
     uses: ./.github/workflows/release-draft.yml
     with:
-      tag: ${{ needs.process-input.outputs.target_tag }}
-      prev_tag: ${{ needs.process-input.outputs.prev_tag }}
+      tag: ${{ env.TARGET_TAG }}
+      prev_tag: ${{ env.PREV_TAG }}
       tagHeadSHA: 'N'
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
@@ -88,7 +82,7 @@ jobs:
     uses: ./.github/workflows/release-docker.yml
     with:
       currentVersion: 'N/A'
-      tag: ${{ needs.process-input.outputs.target_tag }}
+      tag: ${{ env.TARGET_TAG }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
     secrets:
       DOCKERHUB_USERNAME: "${{ secrets.DOCKERHUB_USERNAME }}"
@@ -99,7 +93,7 @@ jobs:
     needs: [release-draft-note, process-input]
     uses: ./.github/workflows/release-executables.yml
     with:
-      tag: ${{ needs.process-input.outputs.target_tag }}
+      tag: ${{ env.TARGET_TAG }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -109,7 +103,7 @@ jobs:
     uses: ./.github/workflows/release-close-issue.yml
     with:
       issue_label: '🚀 Status: Ready for Next Release'
-      version: ${{ needs.process-input.outputs.target_tag }}
+      version: ${{ env.TARGET_TAG }}
 
   # Publish Docs
   publish-docs:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -35,15 +35,11 @@ jobs:
           CURRENT_VERSION=$(basename $(curl -fs -o/dev/null -w %{redirect_url} https://github.com/nocodb/nocodb/releases/latest))
           # Construct tag name
           TAG_NAME=pr-${PR_NUMBER}-${CURRENT_DATE}-${CURRENT_TIME}
-          echo "::set-output name=TARGET_TAG::${TAG_NAME}"
-          echo "::set-output name=CURRENT_VERSION::${CURRENT_VERSION}"
-      - name: verify-tag
-        run: |
-          echo ${{ steps.tag-step.outputs.TARGET_TAG }}
-          echo ${{ steps.tag-step.outputs.CURRENT_VERSION }}
-    outputs:
-      target_tag: ${{ steps.tag-step.outputs.TARGET_TAG }}
-      current_version: ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+          # Verify
+          echo env.TARGET_TAG: ${{ env.TARGET_TAG }}
+          echo env.CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
 
   # Build, install, publish frontend and backend to npm
   release-npm:
@@ -51,7 +47,7 @@ jobs:
     needs: [set-tag]
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ needs.set-tag.outputs.target_tag }}
+      tag: ${{ env.TARGET_TAG }}
       targetEnv: 'DEV'
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -62,8 +58,8 @@ jobs:
     needs: [release-npm, set-tag]
     uses: ./.github/workflows/release-docker.yml
     with:
-      currentVersion: ${{ needs.set-tag.outputs.current_version }}
-      tag: ${{ needs.set-tag.outputs.target_tag }}
+      currentVersion: ${{ env.CURRENT_VERSION }}
+      tag: ${{ env.TARGET_TAG }}
       targetEnv: 'DEV'
       isDaily: 'N'
     secrets:
@@ -76,7 +72,7 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-timely-executables.yml
     with:
-      tag: ${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}
+      tag: ${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -91,7 +87,7 @@ jobs:
           body: |
             The PR changes have been deployed. Please run the following command to verify:
             ```
-            docker run -d -p 8888:8080 nocodb/nocodb-timely:${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}
+            docker run -d -p 8888:8080 nocodb/nocodb-timely:${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}
             ```
 
   # Add a comment for PR executable build
@@ -108,24 +104,24 @@ jobs:
             #### MacOS
 
             ```bash
-            mkdir -p ./${{ needs.set-tag.outputs.current_version }}/${{ needs.set-tag.outputs.target_tag }} && cd "$_" \
-                && curl http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-macos-arm64 -o noco -L \
+            mkdir -p ./${{ env.CURRENT_VERSION }}/${{ env.TARGET_TAG }} && cd "$_" \
+                && curl http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-macos-arm64 -o noco -L \
                 && chmod +x noco \
                 && ./noco
             ```
             #### Linux
 
             ```bash
-            mkdir -p ./${{ needs.set-tag.outputs.current_version }}/${{ needs.set-tag.outputs.target_tag }} && cd "$_" \
-               && curl http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-linux-x64 -o noco -L \
+            mkdir -p ./${{ env.CURRENT_VERSION }}/${{ env.TARGET_TAG }} && cd "$_" \
+               && curl http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-linux-x64 -o noco -L \
                && chmod +x noco \
                && ./noco
             ```
             #### Windows
 
             ```bash
-            iwr http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
+            iwr http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-win-arm64.exe
             .\Noco-win-arm64.exe
             ```
 
-            For executables visit [here](https://github.com/nocodb/nocodb-timely/releases/tag/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }})
+            For executables visit [here](https://github.com/nocodb/nocodb-timely/releases/tag/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }})

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -37,9 +37,13 @@ jobs:
           TAG_NAME=pr-${PR_NUMBER}-${CURRENT_DATE}-${CURRENT_TIME}
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
-          # Verify
-          echo env.TARGET_TAG: ${{ env.TARGET_TAG }}
-          echo env.CURRENT_VERSION: ${{ env.CURRENT_VERSION }}
+      - name: verify-tag
+        run: |
+          echo ${{ steps.tag-step.outputs.TARGET_TAG }}
+          echo ${{ steps.tag-step.outputs.CURRENT_VERSION }}
+    outputs:
+      target_tag: ${{ steps.tag-step.outputs.TARGET_TAG }}
+      current_version: ${{ steps.tag-step.outputs.CURRENT_VERSION }}
 
   # Build, install, publish frontend and backend to npm
   release-npm:
@@ -47,7 +51,7 @@ jobs:
     needs: [set-tag]
     uses: ./.github/workflows/release-npm.yml
     with:
-      tag: ${{ env.TARGET_TAG }}
+      tag: ${{ needs.set-tag.outputs.target_tag }}
       targetEnv: 'DEV'
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
@@ -58,8 +62,8 @@ jobs:
     needs: [release-npm, set-tag]
     uses: ./.github/workflows/release-docker.yml
     with:
-      currentVersion: ${{ env.CURRENT_VERSION }}
-      tag: ${{ env.TARGET_TAG }}
+      currentVersion: ${{ needs.set-tag.outputs.current_version }}
+      tag: ${{ needs.set-tag.outputs.target_tag }}
       targetEnv: 'DEV'
       isDaily: 'N'
     secrets:
@@ -72,7 +76,7 @@ jobs:
     needs: [set-tag, release-npm]
     uses: ./.github/workflows/release-timely-executables.yml
     with:
-      tag: ${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}
+      tag: ${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}
     secrets:
       NC_GITHUB_TOKEN: "${{ secrets.NC_GITHUB_TOKEN }}"
 
@@ -87,7 +91,7 @@ jobs:
           body: |
             The PR changes have been deployed. Please run the following command to verify:
             ```
-            docker run -d -p 8888:8080 nocodb/nocodb-timely:${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}
+            docker run -d -p 8888:8080 nocodb/nocodb-timely:${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}
             ```
 
   # Add a comment for PR executable build
@@ -104,24 +108,24 @@ jobs:
             #### MacOS
 
             ```bash
-            mkdir -p ./${{ env.CURRENT_VERSION }}/${{ env.TARGET_TAG }} && cd "$_" \
-                && curl http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-macos-arm64 -o noco -L \
+            mkdir -p ./${{ needs.set-tag.outputs.current_version }}/${{ needs.set-tag.outputs.target_tag }} && cd "$_" \
+                && curl http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-macos-arm64 -o noco -L \
                 && chmod +x noco \
                 && ./noco
             ```
             #### Linux
 
             ```bash
-            mkdir -p ./${{ env.CURRENT_VERSION }}/${{ env.TARGET_TAG }} && cd "$_" \
-               && curl http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-linux-x64 -o noco -L \
+            mkdir -p ./${{ needs.set-tag.outputs.current_version }}/${{ needs.set-tag.outputs.target_tag }} && cd "$_" \
+               && curl http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-linux-x64 -o noco -L \
                && chmod +x noco \
                && ./noco
             ```
             #### Windows
 
             ```bash
-            iwr http://dl.nocodb.com/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }}/Noco-win-arm64.exe
+            iwr http://dl.nocodb.com/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }}/Noco-win-arm64.exe
             .\Noco-win-arm64.exe
             ```
 
-            For executables visit [here](https://github.com/nocodb/nocodb-timely/releases/tag/${{ env.CURRENT_VERSION }}-${{ env.TARGET_TAG }})
+            For executables visit [here](https://github.com/nocodb/nocodb-timely/releases/tag/${{ needs.set-tag.outputs.current_version }}-${{ needs.set-tag.outputs.target_tag }})


### PR DESCRIPTION
## Change Summary

As titled, GitHub Actions is deprecating save-state and set-output commands. This PR is to remove all `set-ouput` commands and replaced by Github ENV.

ref: #4171

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
