### PR TITLE
fix: backblaze region format

### DIFF
--- a/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
+++ b/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
@@ -77,7 +77,7 @@ export default class Backblaze implements IStorageAdapterV2 {
     // in v0.0.1, we constructed the endpoint with `region = s3.us-west-001`
     // in v0.0.2, `region` would be `us-west-001`
     // as backblaze states Region is the 2nd part of your S3 Endpoint in documentation
-    if (region.slice(0, 3) === 's3.') {
+    if (region.startsWith('s3.')) {
       region = region.slice(3);
     }
     return region;

--- a/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
+++ b/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
@@ -73,6 +73,16 @@ export default class Backblaze implements IStorageAdapterV2 {
     });
   }
 
+  patchRegion(region: string): string {
+    // in v0.0.1, we constructed the endpoint with `region = s3.us-west-001`
+    // in v0.0.2, `region` would be `us-west-001`
+    // as backblaze states Region is the 2nd part of your S3 Endpoint in documentation
+    if (region.slice(0, 3) === 's3.') {
+      region = region.slice(3);
+    }
+    return region;
+  }
+
   public async fileDelete(_path: string): Promise<any> {
     return Promise.resolve(undefined);
   }
@@ -94,14 +104,14 @@ export default class Backblaze implements IStorageAdapterV2 {
   public async init(): Promise<any> {
     const s3Options: any = {
       params: { Bucket: this.input.bucket },
-      region: this.input.region,
+      region: this.patchRegion(this.input.region),
     };
 
     s3Options.accessKeyId = this.input.access_key;
     s3Options.secretAccessKey = this.input.access_secret;
 
     s3Options.endpoint = new AWS.Endpoint(
-      `${this.input.region}.backblazeb2.com`
+      `s3.${s3Options.region}.backblazeb2.com`
     );
 
     this.s3Client = new AWS.S3(s3Options);

--- a/packages/nocodb/src/lib/plugins/backblaze/index.ts
+++ b/packages/nocodb/src/lib/plugins/backblaze/index.ts
@@ -6,7 +6,7 @@ import BackblazePlugin from './BackblazePlugin';
 const config: XcPluginConfig = {
   builder: BackblazePlugin,
   title: 'Backblaze B2',
-  version: '0.0.1',
+  version: '0.0.2',
   logo: 'plugins/backblaze.jpeg',
   tags: 'Storage',
   description:
@@ -24,21 +24,21 @@ const config: XcPluginConfig = {
       {
         key: 'region',
         label: 'Region',
-        placeholder: 'Region',
+        placeholder: 'e.g. us-west-001',
         type: XcType.SingleLineText,
         required: true,
       },
       {
         key: 'access_key',
         label: 'Access Key',
-        placeholder: 'Access Key',
+        placeholder: 'i.e. keyID in App Keys',
         type: XcType.SingleLineText,
         required: true,
       },
       {
         key: 'access_secret',
         label: 'Access Secret',
-        placeholder: 'Access Secret',
+        placeholder: 'i.e. applicationKey in App Keys',
         type: XcType.Password,
         required: true,
       },


### PR DESCRIPTION
## Change Summary

ref: #4188

- fix region format (previously it requires `s3.` at the beginning while backblaze states region is the 2nd part of url.
- revise placeholders to give more hints

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/198194444-39a0faca-7b01-4860-9abb-6c2a418db677.png)

![image](https://user-images.githubusercontent.com/35857179/198199070-75b76687-c3a7-4d6d-a506-fb14b6aad5c7.png)

