### PR TITLE
fix: app store plugin test

### DIFF
--- a/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
+++ b/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class Backblaze implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -121,7 +121,7 @@ export default class Backblaze implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/gcs/Gcs.ts
+++ b/packages/nocodb/src/lib/plugins/gcs/Gcs.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import { Storage, StorageOptions } from '@google-cloud/storage';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class Gcs implements IStorageAdapterV2 {
   private storageClient: Storage;
@@ -87,7 +87,7 @@ export default class Gcs implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/linode/LinodeObjectStorage.ts
+++ b/packages/nocodb/src/lib/plugins/linode/LinodeObjectStorage.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class LinodeObjectStorage implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -111,7 +111,7 @@ export default class LinodeObjectStorage implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/mino/Minio.ts
+++ b/packages/nocodb/src/lib/plugins/mino/Minio.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import { Client as MinioClient } from 'minio';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class Minio implements IStorageAdapterV2 {
   private minioClient: MinioClient;
@@ -75,7 +75,7 @@ export default class Minio implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/ovhCloud/OvhCloud.ts
+++ b/packages/nocodb/src/lib/plugins/ovhCloud/OvhCloud.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class OvhCloud implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -111,7 +111,7 @@ export default class OvhCloud implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/s3/S3.ts
+++ b/packages/nocodb/src/lib/plugins/s3/S3.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class S3 implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -114,7 +114,7 @@ export default class S3 implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/scaleway/ScalewayObjectStorage.ts
+++ b/packages/nocodb/src/lib/plugins/scaleway/ScalewayObjectStorage.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import AWS from 'aws-sdk';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class ScalewayObjectStorage implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -30,7 +31,7 @@ export default class ScalewayObjectStorage implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/spaces/Spaces.ts
+++ b/packages/nocodb/src/lib/plugins/spaces/Spaces.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class Spaces implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -119,7 +119,7 @@ export default class Spaces implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/upcloud/UpoCloud.ts
+++ b/packages/nocodb/src/lib/plugins/upcloud/UpoCloud.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class UpoCloud implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -109,7 +109,7 @@ export default class UpoCloud implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/plugins/vultr/Vultr.ts
+++ b/packages/nocodb/src/lib/plugins/vultr/Vultr.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 import path from 'path';
-
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
+import { waitForStreamClose } from '../../utils/pluginUtils';
 
 export default class Vultr implements IStorageAdapterV2 {
   private s3Client: AWS.S3;
@@ -111,7 +111,7 @@ export default class Vultr implements IStorageAdapterV2 {
     try {
       const tempFile = path.join(process.cwd(), 'temp.txt');
       const createStream = fs.createWriteStream(tempFile);
-      createStream.end();
+      await waitForStreamClose(createStream);
       await this.fileCreate('nc-test-file.txt', {
         path: tempFile,
         mimetype: '',

--- a/packages/nocodb/src/lib/utils/pluginUtils.ts
+++ b/packages/nocodb/src/lib/utils/pluginUtils.ts
@@ -3,10 +3,14 @@ import fs from 'fs';
 export async function waitForStreamClose(
   stream: fs.WriteStream
 ): Promise<void> {
-  stream.end();
-  return new Promise((resolve) => {
-    stream.once('finish', () => {
-      resolve();
-    });
+  return new Promise((resolve, reject) => {
+    stream
+      .once('finish', () => {
+        resolve();
+      })
+      .once('error', () => {
+        reject();
+      });
+    stream.end();
   });
 }

--- a/packages/nocodb/src/lib/utils/pluginUtils.ts
+++ b/packages/nocodb/src/lib/utils/pluginUtils.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+
+export async function waitForStreamClose(
+  stream: fs.WriteStream
+): Promise<void> {
+  stream.end();
+  return new Promise((resolve) => {
+    stream.once('finish', () => {
+      resolve();
+    });
+  });
+}

--- a/packages/nocodb/src/lib/utils/pluginUtils.ts
+++ b/packages/nocodb/src/lib/utils/pluginUtils.ts
@@ -8,8 +8,8 @@ export async function waitForStreamClose(
       .once('finish', () => {
         resolve();
       })
-      .once('error', () => {
-        reject();
+      .once('error', (err) => {
+        reject(err);
       });
     stream.end();
   });


### PR DESCRIPTION
## Change Summary

ref: #4213

Error `no such file or directory` shows sometimes when testing the plugin. The reason is the file `temp.txt` isn't ready when we need it. We should have waited for the stream emitting `finish` before the futher process.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/198507345-7a59f0b3-c570-476b-99c1-06992e0956b3.png)