### PR TITLE
Fix: Grid cell - avoid overwriting LTAR and Lookup cell on cell update

### DIFF
--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -21,7 +21,6 @@ import {
   onMounted,
   provide,
   ref,
-  useUIPermission,
   useViewData,
 } from '#imports'
 import type { Row as RowType } from '~/lib'

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -1,4 +1,4 @@
-import { ViewTypes, isVirtualCol, UITypes } from 'nocodb-sdk'
+import { UITypes, ViewTypes } from 'nocodb-sdk'
 import type { Api, ColumnType, FormType, GalleryType, PaginatedType, TableType, ViewType } from 'nocodb-sdk'
 import type { ComputedRef, Ref } from 'vue'
 import {
@@ -180,12 +180,12 @@ export function useViewData(
     if ((!project?.value?.id || !meta.value?.id || !viewMeta.value?.id) && !isPublic.value) return
     const response = !isPublic.value
       ? await api.dbViewRow.list('noco', project.value.id!, meta.value!.id!, viewMeta.value!.id!, {
-        ...queryParams.value,
-        ...params,
-        ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
-        ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
-        where: where?.value,
-      })
+          ...queryParams.value,
+          ...params,
+          ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
+          ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
+          where: where?.value,
+        })
       : await fetchSharedViewData({ sortsArr: sorts.value, filtersArr: nestedFilters.value })
     formattedData.value = formatData(response.list)
     paginationData.value = response.pageInfo
@@ -203,10 +203,7 @@ export function useViewData(
   async function insertRow(
     currentRow: Row,
     ltarState: Record<string, any> = {},
-    {
-      metaValue = meta.value,
-      viewMetaValue = viewMeta.value,
-    }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
+    { metaValue = meta.value, viewMetaValue = viewMeta.value }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
   ) {
     const row = currentRow.row
     if (currentRow.rowMeta) currentRow.rowMeta.saving = true
@@ -246,10 +243,7 @@ export function useViewData(
   async function updateRowProperty(
     toUpdate: Row,
     property: string,
-    {
-      metaValue = meta.value,
-      viewMetaValue = viewMeta.value,
-    }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
+    { metaValue = meta.value, viewMetaValue = viewMeta.value }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
   ) {
     if (toUpdate.rowMeta) toUpdate.rowMeta.saving = true
     try {
@@ -279,12 +273,13 @@ export function useViewData(
       })
 
       /** update row data(to sync formula and other related columns)
-       * update only virtual columns data to avoid overwriting any changes made by user
+       * update only formula, rollup and auto updated datetime columns data to avoid overwriting any changes made by user
        */
       Object.assign(
         toUpdate.row,
         metaValue!.columns!.reduce<Record<string, any>>((acc: Record<string, any>, col: ColumnType) => {
-          if (col.uidt === UITypes.Formula || col.uidt === UITypes.Rollup) acc[col.title!] = updatedRowData[col.title!]
+          if (col.uidt === UITypes.Formula || col.uidt === UITypes.Rollup || col.au || col.cdf?.includes(' on update '))
+            acc[col.title!] = updatedRowData[col.title!]
           return acc
         }, {} as Record<string, any>),
       )
@@ -323,7 +318,7 @@ export function useViewData(
 
   async function deleteRowById(id: string) {
     if (!id) {
-      throw new Error('Delete not allowed for table which doesn\'t have primary Key')
+      throw new Error("Delete not allowed for table which doesn't have primary Key")
     }
 
     const res: any = await $api.dbViewRow.delete(

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -1,4 +1,4 @@
-import { ViewTypes, isVirtualCol } from 'nocodb-sdk'
+import { ViewTypes, isVirtualCol, UITypes } from 'nocodb-sdk'
 import type { Api, ColumnType, FormType, GalleryType, PaginatedType, TableType, ViewType } from 'nocodb-sdk'
 import type { ComputedRef, Ref } from 'vue'
 import {
@@ -180,12 +180,12 @@ export function useViewData(
     if ((!project?.value?.id || !meta.value?.id || !viewMeta.value?.id) && !isPublic.value) return
     const response = !isPublic.value
       ? await api.dbViewRow.list('noco', project.value.id!, meta.value!.id!, viewMeta.value!.id!, {
-          ...queryParams.value,
-          ...params,
-          ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
-          ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
-          where: where?.value,
-        })
+        ...queryParams.value,
+        ...params,
+        ...(isUIAllowed('sortSync') ? {} : { sortArrJson: JSON.stringify(sorts.value) }),
+        ...(isUIAllowed('filterSync') ? {} : { filterArrJson: JSON.stringify(nestedFilters.value) }),
+        where: where?.value,
+      })
       : await fetchSharedViewData({ sortsArr: sorts.value, filtersArr: nestedFilters.value })
     formattedData.value = formatData(response.list)
     paginationData.value = response.pageInfo
@@ -203,7 +203,10 @@ export function useViewData(
   async function insertRow(
     currentRow: Row,
     ltarState: Record<string, any> = {},
-    { metaValue = meta.value, viewMetaValue = viewMeta.value }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
+    {
+      metaValue = meta.value,
+      viewMetaValue = viewMeta.value,
+    }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
   ) {
     const row = currentRow.row
     if (currentRow.rowMeta) currentRow.rowMeta.saving = true
@@ -243,7 +246,10 @@ export function useViewData(
   async function updateRowProperty(
     toUpdate: Row,
     property: string,
-    { metaValue = meta.value, viewMetaValue = viewMeta.value }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
+    {
+      metaValue = meta.value,
+      viewMetaValue = viewMeta.value,
+    }: { metaValue?: TableType; viewMetaValue?: ViewType } = {},
   ) {
     if (toUpdate.rowMeta) toUpdate.rowMeta.saving = true
     try {
@@ -278,7 +284,7 @@ export function useViewData(
       Object.assign(
         toUpdate.row,
         metaValue!.columns!.reduce<Record<string, any>>((acc: Record<string, any>, col: ColumnType) => {
-          if (isVirtualCol(col)) acc[col.title!] = updatedRowData[col.title!]
+          if (col.uidt === UITypes.Formula || col.uidt === UITypes.Rollup) acc[col.title!] = updatedRowData[col.title!]
           return acc
         }, {} as Record<string, any>),
       )
@@ -317,7 +323,7 @@ export function useViewData(
 
   async function deleteRowById(id: string) {
     if (!id) {
-      throw new Error("Delete not allowed for table which doesn't have primary Key")
+      throw new Error('Delete not allowed for table which doesn\'t have primary Key')
     }
 
     const res: any = await $api.dbViewRow.delete(


### PR DESCRIPTION
## Change Summary

Avoid overwriting LTAR and Lookup cell on cell update since it's not part of the update API response.

re #4220 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
