### PR TITLE
feat(gallery): skip empty value to be displayed in the gallery view

### DIFF
--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -214,24 +214,20 @@ watch(view, async (nextView) => {
                 </div>
 
                 <div class="flex flex-row w-full pb-3 pt-2 pl-2 items-center justify-start">
-                  <div v-if="isRowEmpty(record, col)" class="h-3 bg-gray-200 px-5 rounded-lg"></div>
+                  <LazySmartsheetVirtualCell
+                    v-if="isVirtualCol(col)"
+                    v-model="record.row[col.title]"
+                    :column="col"
+                    :row="record"
+                  />
 
-                  <template v-else>
-                    <LazySmartsheetVirtualCell
-                      v-if="isVirtualCol(col)"
-                      v-model="record.row[col.title]"
-                      :column="col"
-                      :row="record"
-                    />
-
-                    <LazySmartsheetCell
-                      v-else
-                      v-model="record.row[col.title]"
-                      :column="col"
-                      :edit-enabled="false"
-                      :read-only="true"
-                    />
-                  </template>
+                  <LazySmartsheetCell
+                    v-else
+                    v-model="record.row[col.title]"
+                    :column="col"
+                    :edit-enabled="false"
+                    :read-only="true"
+                  />
                 </div>
               </div>
             </div>

--- a/packages/nc-gui/components/smartsheet/Gallery.vue
+++ b/packages/nc-gui/components/smartsheet/Gallery.vue
@@ -203,38 +203,36 @@ watch(view, async (nextView) => {
               <MdiFileImageBox v-else class="w-full h-48 my-4 text-cool-gray-200" />
             </template>
 
-            <div
-              v-for="col in fieldsWithoutCover"
-              :key="`record-${record.row.id}-${col.id}`"
-              class="flex flex-col space-y-1 px-4 mb-6 bg-gray-50 rounded-lg w-full"
-            >
-              <div class="flex flex-row w-full justify-start border-b-1 border-gray-100 py-2.5">
-                <div class="w-full text-gray-600">
-                  <LazySmartsheetHeaderVirtualCell v-if="isVirtualCol(col)" :column="col" :hide-menu="true" />
+            <div v-for="col in fieldsWithoutCover" :key="`record-${record.row.id}-${col.id}`">
+              <div v-if="!isRowEmpty(record, col)" class="flex flex-col space-y-1 px-4 mb-6 bg-gray-50 rounded-lg w-full">
+                <div class="flex flex-row w-full justify-start border-b-1 border-gray-100 py-2.5">
+                  <div class="w-full text-gray-600">
+                    <LazySmartsheetHeaderVirtualCell v-if="isVirtualCol(col)" :column="col" :hide-menu="true" />
 
-                  <LazySmartsheetHeaderCell v-else :column="col" :hide-menu="true" />
+                    <LazySmartsheetHeaderCell v-else :column="col" :hide-menu="true" />
+                  </div>
                 </div>
-              </div>
 
-              <div class="flex flex-row w-full pb-3 pt-2 pl-2 items-center justify-start">
-                <div v-if="isRowEmpty(record, col)" class="h-3 bg-gray-200 px-5 rounded-lg"></div>
+                <div class="flex flex-row w-full pb-3 pt-2 pl-2 items-center justify-start">
+                  <div v-if="isRowEmpty(record, col)" class="h-3 bg-gray-200 px-5 rounded-lg"></div>
 
-                <template v-else>
-                  <LazySmartsheetVirtualCell
-                    v-if="isVirtualCol(col)"
-                    v-model="record.row[col.title]"
-                    :column="col"
-                    :row="record"
-                  />
+                  <template v-else>
+                    <LazySmartsheetVirtualCell
+                      v-if="isVirtualCol(col)"
+                      v-model="record.row[col.title]"
+                      :column="col"
+                      :row="record"
+                    />
 
-                  <LazySmartsheetCell
-                    v-else
-                    v-model="record.row[col.title]"
-                    :column="col"
-                    :edit-enabled="false"
-                    :read-only="true"
-                  />
-                </template>
+                    <LazySmartsheetCell
+                      v-else
+                      v-model="record.row[col.title]"
+                      :column="col"
+                      :edit-enabled="false"
+                      :read-only="true"
+                    />
+                  </template>
+                </div>
               </div>
             </div>
           </a-card>


### PR DESCRIPTION
## Change Summary

Do not display the fields with empty values in the gallery view.

ref: https://github.com/nocodb/nocodb/issues/4204

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Before:
<img width="1507" alt="Screenshot 2022-10-31 at 10 58 33 AM" src="https://user-images.githubusercontent.com/1910192/198951422-07d223db-29e3-46c6-9983-69ba6d8094b3.png">

After:
<img width="1507" alt="Screenshot 2022-10-31 at 10 58 53 AM" src="https://user-images.githubusercontent.com/1910192/198951447-047c5728-bc92-4d8e-a96f-177b6fbacece.png">
