### PR TITLE
hide project actions from non owners

### DIFF
--- a/packages/nc-gui/pages/index/index/index.vue
+++ b/packages/nc-gui/pages/index/index/index.vue
@@ -121,6 +121,10 @@ const getProjectPrimary = (project: ProjectType) => {
   return meta.theme?.primaryColor || themeV2Colors['royal-blue'].DEFAULT
 }
 
+const hasAccessToProjectActions = (project: ProjectType) => {
+  return project.roles && (project.roles.match('owner') || project.roles.match('creator'))
+}
+
 const customRow = (record: ProjectType) => ({
   onClick: async () => {
     await navigateTo(`/nc/${record.id}`)
@@ -281,7 +285,7 @@ const copyProjectMeta = async () => {
 
         <a-table-column key="id" :title="$t('labels.actions')" data-index="id">
           <template #default="{ text, record }">
-            <div class="flex items-center gap-2">
+            <div v-if="hasAccessToProjectActions(record)" class="flex items-center gap-2">
               <MdiEditOutline v-e="['c:project:edit:rename']" class="nc-action-btn" @click.stop="navigateTo(`/${text}`)" />
 
               <MdiDeleteOutline class="nc-action-btn" @click.stop="deleteProject(record)" />

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -67,6 +67,7 @@ export interface ProjectType {
   created_at?: any;
   updated_at?: any;
   slug?: string;
+  roles?: string;
 }
 
 export interface ProjectListType {
@@ -252,12 +253,12 @@ export interface ColumnType {
   system?: number | boolean;
   meta?: any;
   colOptions?:
-    | LinkToAnotherRecordType
-    | FormulaType
-    | RollupType
-    | LookupType
-    | SelectOptionsType
-    | object;
+  | LinkToAnotherRecordType
+  | FormulaType
+  | RollupType
+  | LookupType
+  | SelectOptionsType
+  | object;
 }
 
 export interface ColumnListType {
@@ -571,89 +572,89 @@ export interface HookLogType {
 
 export type ColumnReqType =
   | {
-      uidt?:
-        | 'ID'
-        | 'SingleLineText'
-        | 'LongText'
-        | 'Attachment'
-        | 'Checkbox'
-        | 'MultiSelect'
-        | 'SingleSelect'
-        | 'Collaborator'
-        | 'Date'
-        | 'Year'
-        | 'Time'
-        | 'PhoneNumber'
-        | 'Email'
-        | 'URL'
-        | 'Number'
-        | 'Decimal'
-        | 'Currency'
-        | 'Percent'
-        | 'Duration'
-        | 'Rating'
-        | 'Count'
-        | 'DateTime'
-        | 'CreateTime'
-        | 'LastModifiedTime'
-        | 'AutoNumber'
-        | 'Geometry'
-        | 'JSON'
-        | 'SpecificDBType'
-        | 'Barcode'
-        | 'Button';
-      id?: string;
-      base_id?: string;
-      fk_model_id?: string;
-      title?: string;
-      dt?: string;
-      np?: string;
-      ns?: string;
-      clen?: string | number;
-      cop?: string;
-      pk?: boolean;
-      pv?: boolean;
-      rqd?: boolean;
-      column_name?: string;
-      un?: boolean;
-      ct?: string;
-      ai?: boolean;
-      unique?: boolean;
-      cdf?: string;
-      cc?: string;
-      csn?: string;
-      dtx?: string;
-      dtxp?: string;
-      dtxs?: string;
-      au?: boolean;
-      ''?: string;
-    }
+    uidt?:
+    | 'ID'
+    | 'SingleLineText'
+    | 'LongText'
+    | 'Attachment'
+    | 'Checkbox'
+    | 'MultiSelect'
+    | 'SingleSelect'
+    | 'Collaborator'
+    | 'Date'
+    | 'Year'
+    | 'Time'
+    | 'PhoneNumber'
+    | 'Email'
+    | 'URL'
+    | 'Number'
+    | 'Decimal'
+    | 'Currency'
+    | 'Percent'
+    | 'Duration'
+    | 'Rating'
+    | 'Count'
+    | 'DateTime'
+    | 'CreateTime'
+    | 'LastModifiedTime'
+    | 'AutoNumber'
+    | 'Geometry'
+    | 'JSON'
+    | 'SpecificDBType'
+    | 'Barcode'
+    | 'Button';
+    id?: string;
+    base_id?: string;
+    fk_model_id?: string;
+    title?: string;
+    dt?: string;
+    np?: string;
+    ns?: string;
+    clen?: string | number;
+    cop?: string;
+    pk?: boolean;
+    pv?: boolean;
+    rqd?: boolean;
+    column_name?: string;
+    un?: boolean;
+    ct?: string;
+    ai?: boolean;
+    unique?: boolean;
+    cdf?: string;
+    cc?: string;
+    csn?: string;
+    dtx?: string;
+    dtxp?: string;
+    dtxs?: string;
+    au?: boolean;
+    ''?: string;
+  }
   | {
-      uidt: 'LinkToAnotherRecord';
-      title: string;
-      parentId: string;
-      childId: string;
-      type: 'hm' | 'bt' | 'mm';
-    }
+    uidt: 'LinkToAnotherRecord';
+    title: string;
+    parentId: string;
+    childId: string;
+    type: 'hm' | 'bt' | 'mm';
+  }
   | {
-      uidt?: 'Rollup';
-      title?: string;
-      fk_relation_column_id?: string;
-      fk_rollup_column_id?: string;
-      rollup_function?: string;
-    }
+    uidt?: 'Rollup';
+    title?: string;
+    fk_relation_column_id?: string;
+    fk_rollup_column_id?: string;
+    rollup_function?: string;
+  }
   | {
-      uidt?: 'Lookup';
-      title?: string;
-      fk_relation_column_id?: string;
-      fk_lookup_column_id?: string;
-    }
+    uidt?: 'Lookup';
+    title?: string;
+    fk_relation_column_id?: string;
+    fk_lookup_column_id?: string;
+  }
   | {
-      uidt?: string;
-      formula_raw?: string;
-      formula?: string;
-      title?: string;
-    };
+    uidt?: string;
+    formula_raw?: string;
+    formula?: string;
+    title?: string;
+  };
 
 export interface UserInfoType {
   id?: string;
@@ -3500,7 +3501,7 @@ export class Api<
           relatedMetas?: any;
           client?: string;
           columns?: (GridColumnType | FormColumnType | GalleryColumnType) &
-            ColumnType;
+          ColumnType;
           model?: TableType;
         } & {
           view?: FormType | GridType | GalleryType;

--- a/packages/nocodb/src/lib/meta/api/projectApis.ts
+++ b/packages/nocodb/src/lib/meta/api/projectApis.ts
@@ -75,7 +75,7 @@ export async function projectList(
   next
 ) {
   try {
-    const projects = await Project.list(req.query);
+    const projects = await Project.list(req.query, (req as any)?.user?.id);
 
     res // todo: pagination
       .json(

--- a/packages/nocodb/src/lib/models/ProjectUser.ts
+++ b/packages/nocodb/src/lib/models/ProjectUser.ts
@@ -183,4 +183,21 @@ export default class ProjectUser {
       project_id: projectId,
     });
   }
+
+  /**
+   * Lists all projects users
+   */
+  static async list(ncMeta = Noco.ncMeta) {
+    let projectUsersList = await NocoCache.getList(CacheScope.PROJECT_USER, []);
+    if (!projectUsersList.length) {
+      projectUsersList = await ncMeta.metaList2(
+        null,
+        null,
+        MetaTable.PROJECT_USERS,
+        {}
+      );
+      await NocoCache.setList(CacheScope.PROJECT_USER, [], projectUsersList);
+    }
+    return projectUsersList;
+  }
 }


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

Project EDIT and DELETE buttons are shown to all the users on the project List string.
This PR hides actions from noneligible users.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
User 1
<img width="767" alt="Screenshot 2022-11-01 at 19 05 50" src="https://user-images.githubusercontent.com/17380265/199246169-1dde70cb-84f6-4564-8cc5-7b9a84aa4070.png">

User 2
<img width="775" alt="Screenshot 2022-11-01 at 19 06 20" src="https://user-images.githubusercontent.com/17380265/199246246-f7757c2f-8d21-4cc9-88f5-75220b578b70.png">
