### PR TITLE
add project Id with filterparent requests

### DIFF
--- a/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
+++ b/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
@@ -75,6 +75,9 @@ export default async (req, res, next) => {
     } else if (params.filterId) {
       const filter = await Filter.get(params.filterId);
       req.ncProjectId = filter?.project_id;
+    } else if (params.filterParentId) {
+      const filter = await Filter.get(params.filterParentId);
+      req.ncProjectId = filter?.project_id;
     } else if (params.sortId) {
       const sort = await Sort.get(params.sortId);
       req.ncProjectId = sort?.project_id;


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

If user try to update child filters, it's getting error as user not allowed. This PR fixes this issue.
![image](https://user-images.githubusercontent.com/17380265/200560791-261e591f-5ef1-4841-9084-21f25adc8b7c.png)


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.
The error is happening when filterParentId is sent in request parameter. In backend projectId is not searched with filter parent and noco backend consider all these requests as unauthorized as authorization is project based.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
