### PR TITLE
improve like operator

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
@@ -285,7 +285,7 @@ const parseConditionV2 = async (
               [field, val] = [val, field];
               val = `%${val}%`.replace(/^%'([\s\S]*)'%$/, '%$1%');
             } else {
-              val = `%${val}%`;
+              val = val.startsWith('%') || val.endsWith('%') ? val : `%${val}%`;
             }
             if (qb?.client?.config?.client === 'pg') {
               qb = qb.whereRaw('??::text ilike ?', [field, val]);
@@ -298,7 +298,7 @@ const parseConditionV2 = async (
               [field, val] = [val, field];
               val = `%${val}%`.replace(/^%'([\s\S]*)'%$/, '%$1%');
             } else {
-              val = `%${val}%`;
+              val = val.startsWith('%') || val.endsWith('%') ? val : `%${val}%`;
             }
             qb = qb.whereNot(
               field,


### PR DESCRIPTION
Signed-off-by: Vijay Kumar Rathore <professional.vijay8492@gmail.com>

## Change Summary

Improvement in how like operator works, make is similar to the standard.
Currently, if you send filter value as (column,like,abc%) it will return all results where abc is there in the string regardless of its position of it. But the correct response would be to return all the results which start with abc.
The reason for this bug was, that Noco is making abc% to %abc%% by adding % at the start and end. I have corrected this behaviour in this PR

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
