### PR TITLE
fix(test): Maximum timeout for each instance is 30 minutes and improved quick test CI configuration

### DIFF
--- a/.github/workflows/playwright-test-workflow.yml
+++ b/.github/workflows/playwright-test-workflow.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   playwright:
     runs-on: ubuntu-20.04
+    timeout-minutes: 20
     steps:
       # Reference: https://github.com/pierotofy/set-swap-space/blob/master/action.yml
       - name: Set 5gb swap
@@ -102,17 +103,28 @@ jobs:
         run: |
           kill -9 $(lsof -t -i:8080)
           npm run watch:run:playwright:pg:cyquick &
-          cd ../nc-gui/tests/playwright
-          npm run test:quick
       - name: Run quick server and tests (sqlite)
         if: ${{ inputs.db == 'sqlite' && inputs.shard == '2' }}
         working-directory: ./packages/nocodb
         run: | 
           kill -9 $(lsof -t -i:8080)
           npm run watch:run:playwright:quick &
-          cd ../nc-gui/tests/playwright
-          npm run test:quick
-
+      - name: Wait for backend & run quick tests
+        if: ${{ inputs.db == 'sqlite' }}
+        working-directory: ./packages/nc-gui/tests/playwright
+        run: |
+          while ! curl --output /dev/null --silent --head --fail http://localhost:8080; do
+            printf '.'
+            sleep 2
+          done
+          PLAYWRIGHT_HTML_REPORT=playwright-report-quick npm run test:quick
+      - uses: actions/upload-artifact@v3
+        if: ${{ inputs.db == 'sqlite' }}
+        with:
+          name: playwright-report-quick-${{ inputs.shard }}
+          path: ./packages/nc-gui/tests/playwright/playwright-report-quick/
+          retention-days: 2
+          
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.github/workflows/playwright-test-workflow.yml
+++ b/.github/workflows/playwright-test-workflow.yml
@@ -70,14 +70,16 @@ jobs:
         run: npm run ci:run
       - name: Run backend
         working-directory: ./packages/nocodb
-        run: npm run ci:run &
+        run: |
+          npm install
+          npm run watch:run:playwright & > ${{ inputs.db }}_${{ inputs.shard }}_test_backend.log
       - name: Cache playwright npm modules
         uses: actions/cache@v3
         id: playwright-cache
         with:
           path: |
-            **/playwright/node_modules
-          key: cache-nc-playwright-${{ hashFiles('**/playwright/package-lock.json') }}
+            **/nocodb/packages/nc-gui/tests/playwright/node_modules
+          key: cache-nc-playwright-${{ hashFiles('**/nocodb/packages/nc-gui/tests/playwright/package-lock.json') }}
       - name: Install dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./packages/nc-gui/tests/playwright
@@ -108,7 +110,7 @@ jobs:
         working-directory: ./packages/nocodb
         run: | 
           kill -9 $(lsof -t -i:8080)
-          npm run watch:run:playwright:quick &
+          npm run watch:run:playwright:quick & > quick_${{ inputs.shard }}_test_backend.log
       - name: Wait for backend & run quick tests
         if: ${{ inputs.db == 'sqlite' }}
         working-directory: ./packages/nc-gui/tests/playwright
@@ -118,6 +120,12 @@ jobs:
             sleep 2
           done
           PLAYWRIGHT_HTML_REPORT=playwright-report-quick npm run test:quick
+      - uses: actions/upload-artifact@v3
+        if: ${{ inputs.db == 'sqlite' }}
+        with:
+          name: quick-backend-log-${{ inputs.shard }}
+          path: ./packages/nocodb/quick_${{ inputs.shard }}_test_backend.log
+          retention-days: 2
       - uses: actions/upload-artifact@v3
         if: ${{ inputs.db == 'sqlite' }}
         with:
@@ -135,5 +143,5 @@ jobs:
         if: always()
         with:
           name: backend-logs-${{ inputs.db }}-${{ inputs.shard }}
-          path: ./packages/nocodb/mysql_test_backend.log
+          path: ./packages/nocodb/${{ inputs.db }}_${{ inputs.shard }}_test_backend.log
           retention-days: 2

--- a/.github/workflows/playwright-test-workflow.yml
+++ b/.github/workflows/playwright-test-workflow.yml
@@ -78,8 +78,8 @@ jobs:
         id: playwright-cache
         with:
           path: |
-            **/nocodb/packages/nc-gui/tests/playwright/node_modules
-          key: cache-nc-playwright-${{ hashFiles('**/nocodb/packages/nc-gui/tests/playwright/package-lock.json') }}
+            **/packages/nc-gui/tests/playwright/node_modules
+          key: cache-nc-playwright-${{ hashFiles('**/packages/nc-gui/tests/playwright/package-lock.json') }}
       - name: Install dependencies
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: ./packages/nc-gui/tests/playwright

--- a/.github/workflows/playwright-test-workflow.yml
+++ b/.github/workflows/playwright-test-workflow.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: ./packages/nocodb
         run: |
           npm install
-          npm run watch:run:playwright & > ${{ inputs.db }}_${{ inputs.shard }}_test_backend.log
+          npm run watch:run:playwright > ${{ inputs.db }}_${{ inputs.shard }}_test_backend.log &
       - name: Cache playwright npm modules
         uses: actions/cache@v3
         id: playwright-cache
@@ -110,7 +110,7 @@ jobs:
         working-directory: ./packages/nocodb
         run: | 
           kill -9 $(lsof -t -i:8080)
-          npm run watch:run:playwright:quick & > quick_${{ inputs.shard }}_test_backend.log
+          npm run watch:run:playwright:quick > quick_${{ inputs.shard }}_test_backend.log &
       - name: Wait for backend & run quick tests
         if: ${{ inputs.db == 'sqlite' }}
         working-directory: ./packages/nc-gui/tests/playwright

--- a/.github/workflows/playwright-test-workflow.yml
+++ b/.github/workflows/playwright-test-workflow.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   playwright:
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       # Reference: https://github.com/pierotofy/set-swap-space/blob/master/action.yml
       - name: Set 5gb swap

--- a/packages/nc-gui/tests/playwright/.gitignore
+++ b/packages/nc-gui/tests/playwright/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright-report copy/
+/playwright-report-quick/
 /playwright/.cache/
 .env
 output

--- a/packages/nc-gui/tests/playwright/README.md
+++ b/packages/nc-gui/tests/playwright/README.md
@@ -77,3 +77,4 @@ Page objects should be in `packages/nc-gui/tests/playwright/pages` folder.
 ### Verify if tests are not flaky
 
 Add `.only` to the added test and run `npm run test:repeat`. This will run the test multiple times and should show if the test is flaky.
+

--- a/packages/nc-gui/tests/playwright/README.md
+++ b/packages/nc-gui/tests/playwright/README.md
@@ -77,4 +77,3 @@ Page objects should be in `packages/nc-gui/tests/playwright/pages` folder.
 ### Verify if tests are not flaky
 
 Add `.only` to the added test and run `npm run test:repeat`. This will run the test multiple times and should show if the test is flaky.
-

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -46,8 +46,7 @@
     "watch:run:pg": "cross-env  NC_DISABLE_TELE=true EE=true nodemon -e ts,js -w ./src -x \"ts-node src/run/dockerRunPG --log-error --project tsconfig.json\"",
     "run": "ts-node src/run/docker",
     "watch:try": "nodemon -e ts,js -w ./src -x \"ts-node src/run/try --log-error --project tsconfig.json\"",
-    "example:docker": "ts-node src/run/docker.ts",
-    "ci:run": "npm install; npm run watch:run:playwright > mysql_test_backend.log"
+    "example:docker": "ts-node src/run/docker.ts"
   },
   "engines": {
     "node": ">=8.9"


### PR DESCRIPTION
-  Made maximum timeout to 30 minutes for a CI instance
- Quick test's backend is now waited on till its ready
- Handling playwright report of quick test as a different report. Quick tests playwright reports were overwriting the actual tests report.
- Added backend log of quick test server as GH artifact