### PR TITLE
fix: correct api sample template strings

### DIFF
--- a/packages/nc-gui/components/smartsheet/ApiSnippet.vue
+++ b/packages/nc-gui/components/smartsheet/ApiSnippet.vue
@@ -103,9 +103,9 @@ const activeLang = $computed(() => langs.find((lang) => lang.name === selectedLa
 
 const code = $computed(() => {
   if (activeLang?.name === 'nocodb-sdk') {
-    return `${selectedClient === 'node' ? 'const { Api } require("nocodb-sdk");' : 'import { Api } from "nocodb-sdk";'}
+    return `${selectedClient === 'node' ? 'const { Api } = require("nocodb-sdk");' : 'import { Api } from "nocodb-sdk";'}
 const api = new Api({
-  baseURL: ${JSON.stringify(apiUrl)},
+  baseURL: "${(appInfo && appInfo.ncSiteUrl) || '/'}",
   headers: {
     "xc-auth": ${JSON.stringify(token as string)}
   }


### PR DESCRIPTION
## Change Summary

The API snippet template string were wrong for the nocodb-sdk tab. This PR fixes them. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

* Create a test Project and Table
* Go to "Get API Snippet" 
* Go to Tabl `nocodb-sdk`
* Try out the snippets in a simple Node project

## Additional information / screenshots (optional)

<img alt="image" src="https://user-images.githubusercontent.com/249210/202430577-cf245a58-40c1-43c4-a4e6-3e6ae63070cc.png">

<img alt="image" src="https://user-images.githubusercontent.com/249210/202430526-2ca53152-c8c7-4e91-ae04-77b2cf4b48ca.png">
