### PR TITLE
fix(nocodb): convert attachment type in api response

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -99,9 +99,10 @@ class BaseModelSqlv2 {
 
     qb.where(_wherePk(this.model.primaryKeys, id));
 
-    const data = (await this.extractRawQueryAndExec(qb))?.[0];
+    let data = (await this.extractRawQueryAndExec(qb))?.[0];
 
     if (data) {
+      data = this.convertAttachmentType(data);
       const proto = await this.getProto();
       data.__proto__ = proto;
     }
@@ -251,7 +252,8 @@ class BaseModelSqlv2 {
 
     if (!ignoreViewFilterAndSort) applyPaginate(qb, rest);
     const proto = await this.getProto();
-    const data = await this.extractRawQueryAndExec(qb);
+    let data = await this.extractRawQueryAndExec(qb);
+    data = this.convertAttachmentType(data);
 
     return data?.map((d) => {
       d.__proto__ = proto;
@@ -423,7 +425,8 @@ class BaseModelSqlv2 {
           .as('list')
       );
 
-      const children = await this.extractRawQueryAndExec(childQb);
+      let children = await this.extractRawQueryAndExec(childQb);
+      children = this.convertAttachmentType(children);
       const proto = await (
         await Model.getBaseModelSQL({
           id: childTable.id,
@@ -550,7 +553,8 @@ class BaseModelSqlv2 {
 
       await childModel.selectObject({ qb });
 
-      const children = await this.extractRawQueryAndExec(qb);
+      let children = await this.extractRawQueryAndExec(qb);
+      children = this.convertAttachmentType(children);
 
       const proto = await (
         await Model.getBaseModelSQL({
@@ -668,6 +672,7 @@ class BaseModelSqlv2 {
     );
 
     let children = await this.extractRawQueryAndExec(finalQb);
+    children = this.convertAttachmentType(children);
     if (this.isMySQL) {
       children = children[0];
     }
@@ -735,7 +740,8 @@ class BaseModelSqlv2 {
     qb.limit(+rest?.limit || 25);
     qb.offset(+rest?.offset || 0);
 
-    const children = await this.extractRawQueryAndExec(qb);
+    let children = await this.extractRawQueryAndExec(qb);
+    children = this.convertAttachmentType(children);
     const proto = await (
       await Model.getBaseModelSQL({ id: rtnId, dbDriver: this.dbDriver })
     ).getProto();
@@ -1076,7 +1082,8 @@ class BaseModelSqlv2 {
     applyPaginate(qb, rest);
 
     const proto = await childModel.getProto();
-    const data = await this.extractRawQueryAndExec(qb);
+    let data = await this.extractRawQueryAndExec(qb);
+    data = this.convertAttachmentType(data);
 
     return data.map((c) => {
       c.__proto__ = proto;
@@ -1194,7 +1201,8 @@ class BaseModelSqlv2 {
     applyPaginate(qb, rest);
 
     const proto = await parentModel.getProto();
-    const data = await this.extractRawQueryAndExec(qb);
+    let data = await this.extractRawQueryAndExec(qb);
+    data = this.convertAttachmentType(data);
 
     return data.map((c) => {
       c.__proto__ = proto;
@@ -2725,6 +2733,30 @@ class BaseModelSqlv2 {
           this.dbDriver.raw(query).wrap('(', ') __nc_alias')
         )
       : await this.dbDriver.raw(query);
+  }
+
+  private convertAttachmentType(data) {
+    // attachment is stored in text and parse in UI
+    // convertAttachmentType is used to convert the response in string to array of object in API response
+    if (data) {
+      const attachmentColumns = this.model.columns.filter(
+        (c) => c.uidt === UITypes.Attachment
+      );
+      if (attachmentColumns.length) {
+        if (!Array.isArray(data)) {
+          data = [data];
+        }
+        data = data.map((d) => {
+          attachmentColumns.forEach((col) => {
+            if (d[col.column_name] && typeof d[col.column_name] === 'string') {
+              d[col.column_name] = JSON.parse(d[col.column_name]);
+            }
+          });
+          return d;
+        });
+      }
+    }
+    return data;
   }
 }
 

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -2748,8 +2748,8 @@ class BaseModelSqlv2 {
         }
         data = data.map((d) => {
           attachmentColumns.forEach((col) => {
-            if (d[col.column_name] && typeof d[col.column_name] === 'string') {
-              d[col.column_name] = JSON.parse(d[col.column_name]);
+            if (d[col.title] && typeof d[col.title] === 'string') {
+              d[col.title] = JSON.parse(d[col.title]);
             }
           });
           return d;


### PR DESCRIPTION
## Change Summary

ref: #4480

currently attachment data is stored in TEXT and parse to object in UI level. This PR is to convert it to array of objects so that users don't need to convert themselves while using our APIs.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

webhook response

```json
[
  {
    "Id": 10,
    "Title": "a2",
    "CreatedAt": "2022-11-25 12:30:23",
    "UpdatedAt": "2022-11-25 12:31:56",
    "title72": null,
    "nc_deak__Sheet-2_id": null,
    "title7": null,
    "title6": null,
    "title8": [
      {
        "url": "http://localhost:8080/download/noco/xcdb/Sheet-1/title8/iDii5f.jpeg",
        "title": "haha.jpeg",
        "mimetype": "image/jpeg",
        "size": 6494
      }
    ]
  }
]
```

list response

```
{
    ...
    "title8": [
        {
            "url": "http://localhost:8080/download/noco/xcdb/Sheet-1/title8/44Z_bA.jpeg",
            "title": "haha.jpeg",
            "mimetype": "image/jpeg",
            "size": 6494
        }
    ]
}
```

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
