### PR TITLE
fix(nc-gui): Fixed column icon for LTAR, rollup

### DIFF
--- a/packages/nc-gui/windi.config.ts
+++ b/packages/nc-gui/windi.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   },
 
   darkMode: 'class',
-
+  safelist: ['text-yellow-500', 'text-sky-500', 'text-red-500'],
   plugins: [
     scrollbar,
     animations,


### PR DESCRIPTION
Ref: #4501 

The windy css class names were getting removed, so added them to `safeList`