### PR TITLE
Update nuxt.config.ts

### DIFF
--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -135,6 +135,9 @@ export default defineNuxtConfig({
       }),
       monacoEditorPlugin({
         languageWorkers: ['json'],
+        customDistPath: (root: string, buildOutDir: string, base: string) => {
+          return buildOutDir + '/' + 'monacoeditorwork'
+        },
       }),
     ],
     define: {


### PR DESCRIPTION
fix build error in Windows

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [* ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Resolve build errors in Windows
```bash
 ERROR  [vite-plugin-moncao-editor] ENOENT: no such file or directory, mkdir 'D:\workspace\nocodb\packages\nc-gui\D:\workspace\nocodb\packages\nc-gui\.nuxt\dist\client\monacoeditorwork'   


 ERROR  ENOENT: no such file or directory, mkdir 'D:\workspace\nocodb\packages\nc-gui\D:\workspace\nocodb\packages\nc-gui\.nuxt\dist\client\monacoeditorwork'                     19:08:24  

  at Object.mkdirSync (node:fs:1386:3)
  at Object.writeBundle (node_modules\vite-plugin-monaco-editor\dist\index.js:99:20)
  at /D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/node_modules/rollup/dist/es/shared/rollup.js:22710:40
  at async Promise.all (index 0)
  at async PluginDriver.hookParallel (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/node_modules/rollup/dist/es/shared/rollup.js:22638:9)
  at async /D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/node_modules/rollup/dist/es/shared/rollup.js:23763:13
  at async catchUnfinishedHookActions (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/node_modules/rollup/dist/es/shared/rollup.js:23088:20)        
  at async doBuild (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/dist/node/chunks/dep-4da11a5e.js:45831:20)
  at async Module.build (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/node_modules/vite/dist/node/chunks/dep-4da11a5e.js:45662:16)
  at async buildClient (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/dist/shared/vite-builder.8e427c63.mjs:318:5)
  at async bundle (/D:/workspace/nocodb/packages/nc-gui/node_modules/@nuxt/vite-builder/dist/shared/vite-builder.8e427c63.mjs:853:3)
  at async build (/D:/workspace/nocodb/packages/nc-gui/node_modules/nuxt/dist/index.mjs:2084:5)
  at async Object.invoke (/D:/workspace/nocodb/packages/nc-gui/node_modules/nuxi/dist/chunks/build.mjs:51:5)
  at async _main (/D:/workspace/nocodb/packages/nc-gui/node_modules/nuxi/dist/cli.mjs:50:20)
```
## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
