### PR TITLE
fix: formula division for mysql

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/formulaQueryBuilderFromString.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/formulaQueryBuilderFromString.ts
@@ -136,6 +136,11 @@ export default function formulaQueryBuilder(
           type: 'CallExpression',
           arguments: [pt.left],
         };
+        pt.right = {
+          callee: { name: 'FLOAT' },
+          type: 'CallExpression',
+          arguments: [pt.right],
+        };
       }
 
       const query = knex.raw(

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/formulav2/formulaQueryBuilderv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/formulav2/formulaQueryBuilderv2.ts
@@ -646,6 +646,11 @@ export default async function formulaQueryBuilderv2(
           type: 'CallExpression',
           arguments: [pt.left],
         };
+        pt.right = {
+          callee: { name: 'FLOAT' },
+          type: 'CallExpression',
+          arguments: [pt.right],
+        };
       }
       pt.left.fnName = pt.left.fnName || 'ARITH';
       pt.right.fnName = pt.right.fnName || 'ARITH';

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/mysql.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/mysql.ts
@@ -36,7 +36,7 @@ const mysql2 = {
   MID: 'SUBSTR',
   FLOAT: (args: MapFnArgs) => {
     return args.knex
-      .raw(`CAST(${args.fn(args.pt.arguments[0])} as DOUBLE)${args.colAlias}`)
+      .raw(`CAST(CAST(${args.fn(args.pt.arguments[0])} as CHAR) AS DOUBLE)${args.colAlias}`)
       .wrap('(', ')');
   },
   DATEADD: ({ fn, knex, pt, colAlias }: MapFnArgs) => {


### PR DESCRIPTION
## Change Summary

ref: #4527 

- mark CallExpression on pt.right for division
- cast char first before casting as double for FLOAT

For select option, the data type would be `enum` . The existing SQL would produce the wrong result.

```sql
-- existing
(CAST(`t1` as DOUBLE)) / `t2`

-- PR
CAST(CAST(`t1` as CHAR) AS DOUBLE) / CAST(CAST(`t2` as CHAR) AS DOUBLE)
```

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/204747232-017eb848-5ce6-411d-a35c-d1c245de0d4b.png)
