### PR TITLE
Remove outline of search input in single select

### DIFF
--- a/packages/nc-gui/assets/style.scss
+++ b/packages/nc-gui/assets/style.scss
@@ -287,7 +287,10 @@ a {
   @apply !top-[50px];
 }
 
-
 .ant-select-item-option-active:not(.ant-select-item-option-disabled) {
   @apply bg-primary bg-opacity-20;
+}
+
+.ant-select-selection-search-input:focus {
+  @apply !ring-0;
 }


### PR DESCRIPTION
## Change Summary

Remove the outline of the search input element which is shown when the element is focused.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

#### Before : 

<img width="290" alt="Screenshot 2022-12-02 at 10 19 38 AM" src="https://user-images.githubusercontent.com/61551451/205217225-6dcf6409-81d5-468c-b02b-2f5cab4260a4.png">
<img width="442" alt="Screenshot 2022-12-02 at 10 19 50 AM" src="https://user-images.githubusercontent.com/61551451/205217243-08db339a-91aa-4b95-89a1-1e9fdf071a4f.png">


#### After : 

<img width="370" alt="Screenshot 2022-12-02 at 10 10 44 AM" src="https://user-images.githubusercontent.com/61551451/205216690-d112f1b9-09c8-4c20-831d-f7a8e6b97880.png">
<img width="481" alt="Screenshot 2022-12-02 at 10 11 09 AM" src="https://user-images.githubusercontent.com/61551451/205216699-90348567-f444-413b-8c75-a4543eb0c981.png">

