### PR TITLE
fix: add useNullAsDefault flag for sqlite on root level

### DIFF
--- a/packages/nocodb/src/lib/db/sql-client/lib/sqlite/SqliteClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/sqlite/SqliteClient.ts
@@ -19,6 +19,8 @@ class SqliteClient extends KnexClient {
   private _version: any;
 
   constructor(connectionConfig) {
+    // sqlite does not support inserting default values and knex fires a warning without this flag
+    connectionConfig.connection.useNullAsDefault = true;
     super(connectionConfig);
     this.sqlClient = knex(connectionConfig.connection);
     this.queries = queries;

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/CustomKnex.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/CustomKnex.ts
@@ -988,6 +988,11 @@ function parseNestedCondition(obj, qb, pKey?, table?, tableAlias?) {
 type CustomKnex = Knex;
 
 function CustomKnex(arg: string | Knex.Config<any> | any): CustomKnex {
+  // sqlite does not support inserting default values and knex fires a warning without this flag
+  if (arg?.client === 'sqlite3') {
+    arg.useNullAsDefault = true;
+  }
+
   const kn: any = knex(arg);
 
   const knexRaw = kn.raw;

--- a/packages/nocodb/src/lib/meta/MetaAPILogger.ts
+++ b/packages/nocodb/src/lib/meta/MetaAPILogger.ts
@@ -11,7 +11,6 @@ export default class MetaAPILogger {
       connection: {
         filename: 'noco_log.db',
       },
-      useNullAsDefault: true,
     });
   }
 

--- a/packages/nocodb/src/lib/meta/NcMetaIOImpl.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaIOImpl.ts
@@ -77,10 +77,6 @@ export default class NcMetaIOImpl extends NcMetaIO {
   constructor(app: Noco, config: NcConfig, trx = null) {
     super(app, config);
 
-    if (this.config?.meta?.db?.client === 'sqlite3') {
-      this.config.meta.db.useNullAsDefault = true;
-    }
-
     if (this.config?.meta?.db) {
       this.connection = trx || XKnex(this.config?.meta?.db);
     } else {

--- a/packages/nocodb/src/lib/meta/api/projectApis.ts
+++ b/packages/nocodb/src/lib/meta/api/projectApis.ts
@@ -138,7 +138,6 @@ async function projectCreate(req: Request<any, any>, res) {
               connection: {
                 filename: `${toolDir}/nc_minimal_dbs/${projectTitle}_${dbId}.db`,
               },
-              useNullAsDefault: true,
             },
           },
           inflection_column: 'camelize',

--- a/packages/nocodb/src/lib/utils/NcConfigFactory.ts
+++ b/packages/nocodb/src/lib/utils/NcConfigFactory.ts
@@ -200,7 +200,6 @@ export default class NcConfigFactory implements NcConfig {
           },
           database:
             url.searchParams.get('d') || url.searchParams.get('database'),
-          useNullAsDefault: true,
         },
       } as any;
     } else {
@@ -496,7 +495,6 @@ export default class NcConfigFactory implements NcConfig {
         connection: {
           ...dbConnectionConfig,
           database: dbConnectionConfig.connection.filename,
-          useNullAsDefault: true,
         },
       };
     }


### PR DESCRIPTION
## Change Summary

- sqlite3 requires us to pass useNullAsDefault in order to surpass warning, we were passing that in various places, implemented that to root so we don't need to add it everywhere
- removed no more required flag from various places

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
