### PR TITLE
revert mssql and mysql in uffizzi previews

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -13,20 +13,6 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
       POSTGRES_DB: root_db
-  mssql:
-    image: "mcr.microsoft.com/mssql/server:2017-latest"
-    restart: always
-    environment: 
-      ACCEPT_EULA: "Y"
-      SA_PASSWORD: Password123.
-  mysql: 
-    environment: 
-      MYSQL_DATABASE: root_db
-      MYSQL_PASSWORD: password
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_USER: noco
-    image: "mysql:5.7"
-    restart: always
   nocodb:
     image: "${NOCODB_IMAGE}"
     ports:


### PR DESCRIPTION
## Change Summary

Revert MSSQL and MySQL changes in the uffizzi docker-compose as the preview doesn't seem to be working.

### More details

After increasing the memory on the container for both the dbs, the DBs came up but nocodb wasn't responding correctly. We will have to pursue another solution where the preview could be chosen from github action comments.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
