### PR TITLE
refactor(gui): remove dropdown for create project from project list page

### DIFF
--- a/packages/nc-gui/pages/index/index/index.vue
+++ b/packages/nc-gui/pages/index/index/index.vue
@@ -174,42 +174,42 @@ const copyProjectMeta = async () => {
 
       <div class="flex-1" />
 
-      <a-dropdown v-if="isUIAllowed('projectCreate', true)" :trigger="['click']" overlay-class-name="nc-dropdown-create-project">
-        <button class="nc-new-project-menu mt-4 md:mt-0">
-          <span class="flex items-center w-full">
-            {{ $t('title.newProj') }}
-            <MdiMenuDown class="menu-icon" />
-          </span>
-        </button>
+      <!--      <a-dropdown v-if="isUIAllowed('projectCreate', true)" :trigger="['click']" overlay-class-name="nc-dropdown-create-project"> -->
+      <button v-if="isUIAllowed('projectCreate', true)" class="nc-new-project-menu mt-4 md:mt-0" @click="navigateTo('/create')">
+        <span class="flex items-center w-full">
+          {{ $t('title.newProj') }}
+          <!--          <MdiMenuDown class="menu-icon" /> -->
+        </span>
+      </button>
 
-        <template #overlay>
-          <a-menu class="!py-0 rounded">
-            <a-menu-item>
-              <div
-                v-e="['c:project:create:xcdb']"
-                class="nc-project-menu-item group nc-create-xc-db-project"
-                @click="navigateTo('/create')"
-              >
-                <MdiPlusOutline class="group-hover:text-accent" />
+      <!--        <template #overlay> -->
+      <!--          <a-menu class="!py-0 rounded"> -->
+      <!--            <a-menu-item> -->
+      <!--              <div -->
+      <!--                v-e="['c:project:create:xcdb']" -->
+      <!--                class="nc-project-menu-item group nc-create-xc-db-project" -->
+      <!--                @click="navigateTo('/create')" -->
+      <!--              > -->
+      <!--                <MdiPlusOutline class="group-hover:text-accent" /> -->
 
-                <div>{{ $t('activity.createProject') }}</div>
-              </div>
-            </a-menu-item>
+      <!--                <div>{{ $t('activity.createProject') }}</div> -->
+      <!--              </div> -->
+      <!--            </a-menu-item> -->
 
-            <a-menu-item v-if="appInfo.connectToExternalDB">
-              <div
-                v-e="['c:project:create:extdb']"
-                class="nc-project-menu-item group nc-create-external-db-project"
-                @click="navigateTo('/create-external')"
-              >
-                <MdiDatabaseOutline class="group-hover:text-accent" />
+      <!--            <a-menu-item v-if="appInfo.connectToExternalDB"> -->
+      <!--              <div -->
+      <!--                v-e="['c:project:create:extdb']" -->
+      <!--                class="nc-project-menu-item group nc-create-external-db-project" -->
+      <!--                @click="navigateTo('/create-external')" -->
+      <!--              > -->
+      <!--                <MdiDatabaseOutline class="group-hover:text-accent" /> -->
 
-                <div v-html="$t('activity.createProjectExtended.extDB')" />
-              </div>
-            </a-menu-item>
-          </a-menu>
-        </template>
-      </a-dropdown>
+      <!--                <div v-html="$t('activity.createProjectExtended.extDB')" /> -->
+      <!--              </div> -->
+      <!--            </a-menu-item> -->
+      <!--          </a-menu> -->
+      <!--        </template> -->
+      <!--      </a-dropdown> -->
     </div>
 
     <!--

--- a/packages/nc-gui/pages/index/index/index.vue
+++ b/packages/nc-gui/pages/index/index/index.vue
@@ -174,42 +174,11 @@ const copyProjectMeta = async () => {
 
       <div class="flex-1" />
 
-      <!--      <a-dropdown v-if="isUIAllowed('projectCreate', true)" :trigger="['click']" overlay-class-name="nc-dropdown-create-project"> -->
       <button v-if="isUIAllowed('projectCreate', true)" class="nc-new-project-menu mt-4 md:mt-0" @click="navigateTo('/create')">
         <span class="flex items-center w-full">
           {{ $t('title.newProj') }}
-          <!--          <MdiMenuDown class="menu-icon" /> -->
         </span>
       </button>
-
-      <!--        <template #overlay> -->
-      <!--          <a-menu class="!py-0 rounded"> -->
-      <!--            <a-menu-item> -->
-      <!--              <div -->
-      <!--                v-e="['c:project:create:xcdb']" -->
-      <!--                class="nc-project-menu-item group nc-create-xc-db-project" -->
-      <!--                @click="navigateTo('/create')" -->
-      <!--              > -->
-      <!--                <MdiPlusOutline class="group-hover:text-accent" /> -->
-
-      <!--                <div>{{ $t('activity.createProject') }}</div> -->
-      <!--              </div> -->
-      <!--            </a-menu-item> -->
-
-      <!--            <a-menu-item v-if="appInfo.connectToExternalDB"> -->
-      <!--              <div -->
-      <!--                v-e="['c:project:create:extdb']" -->
-      <!--                class="nc-project-menu-item group nc-create-external-db-project" -->
-      <!--                @click="navigateTo('/create-external')" -->
-      <!--              > -->
-      <!--                <MdiDatabaseOutline class="group-hover:text-accent" /> -->
-
-      <!--                <div v-html="$t('activity.createProjectExtended.extDB')" /> -->
-      <!--              </div> -->
-      <!--            </a-menu-item> -->
-      <!--          </a-menu> -->
-      <!--        </template> -->
-      <!--      </a-dropdown> -->
     </div>
 
     <!--

--- a/tests/playwright/pages/ProjectsPage/index.ts
+++ b/tests/playwright/pages/ProjectsPage/index.ts
@@ -28,15 +28,16 @@ export class ProjectsPage extends BasePage {
   }) {
     if (!withoutPrefix) name = this.prefixTitle(name);
 
+    // Click "New Project" button
     await this.get().locator('.nc-new-project-menu').click();
 
-    const createProjectMenu = await this.rootPage.locator('.nc-dropdown-create-project');
-
-    if (type === 'xcdb') {
-      await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(0).click();
-    } else {
-      await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(1).click();
-    }
+    // const createProjectMenu = await this.rootPage.locator('.nc-dropdown-create-project');
+    //
+    // if (type === 'xcdb') {
+    //   await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(0).click();
+    // } else {
+    //   await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(1).click();
+    // }
 
     await this.rootPage.locator(`.nc-metadb-project-name`).waitFor();
     await this.rootPage.locator(`input.nc-metadb-project-name`).fill(name);

--- a/tests/playwright/pages/ProjectsPage/index.ts
+++ b/tests/playwright/pages/ProjectsPage/index.ts
@@ -17,27 +17,11 @@ export class ProjectsPage extends BasePage {
   }
 
   // create project
-  async createProject({
-    name = 'sample',
-    type = 'xcdb',
-    withoutPrefix,
-  }: {
-    name?: string;
-    type?: string;
-    withoutPrefix?: boolean;
-  }) {
+  async createProject({ name = 'sample', withoutPrefix }: { name?: string; type?: string; withoutPrefix?: boolean }) {
     if (!withoutPrefix) name = this.prefixTitle(name);
 
     // Click "New Project" button
     await this.get().locator('.nc-new-project-menu').click();
-
-    // const createProjectMenu = await this.rootPage.locator('.nc-dropdown-create-project');
-    //
-    // if (type === 'xcdb') {
-    //   await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(0).click();
-    // } else {
-    //   await createProjectMenu.locator(`.ant-dropdown-menu-title-content`).nth(1).click();
-    // }
 
     await this.rootPage.locator(`.nc-metadb-project-name`).waitFor();
     await this.rootPage.locator(`input.nc-metadb-project-name`).fill(name);

--- a/tests/playwright/tests/projectOperations.spec.ts
+++ b/tests/playwright/tests/projectOperations.spec.ts
@@ -19,7 +19,7 @@ test.describe('Project operations', () => {
 
   test('rename, delete', async () => {
     await dashboard.clickHome();
-    await projectPage.createProject({ name: 'project-1', type: 'xcdb' });
+    await projectPage.createProject({ name: 'project-1' });
     await dashboard.clickHome();
     await projectPage.renameProject({
       title: 'project-1',


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
- Connect to external DB option removed from project list page
- External datasource can be added after creating a default root DB project

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
