### PR TITLE
Fix vue warning (remove unused class of Barcode Wrapper)

### DIFF
--- a/packages/nc-gui/components/virtual-cell/barcode/Barcode.vue
+++ b/packages/nc-gui/components/virtual-cell/barcode/Barcode.vue
@@ -46,7 +46,6 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning } = us
     v-if="showBarcode"
     :barcode-value="barcodeValue"
     :barcode-format="barcodeMeta.barcodeFormat"
-    class="nc-barcode-svg"
     @on-click-barcode="showBarcodeModal"
   >
     <template #barcodeRenderError>


### PR DESCRIPTION
## Change Summary

The BarcodeWrapper component's template has a fragment as root element (so no single parent HTML element). 
It was called though with a class property (which was actually dead code - not used anywhere) assigned to it which results in the Vue warning (see attached screenshot). 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

When adding barcodes to a table/grid view, the Vue warning shown in the attached screenshot should not appear anymore on this branch. 

## Additional information / screenshots (optional)

<img width="1348" alt="Screenshot 2022-12-29 at 21 29 22" src="https://user-images.githubusercontent.com/35769846/210008639-0f46b241-a7cb-451d-b683-82058c0388eb.png">

