### PR TITLE
fix(nocodb): MOD for postgres

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
@@ -148,6 +148,11 @@ const pg = {
       })${colAlias}`
     );
   },
+  MOD: ({ fn, knex, pt, colAlias }: MapFnArgs) => {
+    const x = fn(pt.arguments[0]);
+    const y = fn(pt.arguments[1]);
+    return knex.raw(`MOD((${x})::NUMERIC, (${y})::NUMERIC) ${colAlias}`);
+  },
 };
 
 export default pg;


### PR DESCRIPTION
## Change Summary

Formula like `MOD(10 / 2, 5)` would fail because fn(10 / 2) would return double precision.

ref: #4768

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
