### PR TITLE
Undo select option removal

### DIFF
--- a/packages/nc-gui/components.d.ts
+++ b/packages/nc-gui/components.d.ts
@@ -124,6 +124,7 @@ declare module '@vue/runtime-core' {
     MdiArrowDownDropCircleOutline: typeof import('~icons/mdi/arrow-down-drop-circle-outline')['default']
     MdiArrowExpand: typeof import('~icons/mdi/arrow-expand')['default']
     MdiArrowLeftBold: typeof import('~icons/mdi/arrow-left-bold')['default']
+    MdiArrowULeftBottom: typeof import('~icons/mdi/arrow-u-left-bottom')['default']
     MdiAt: typeof import('~icons/mdi/at')['default']
     MdiBackburger: typeof import('~icons/mdi/backburger')['default']
     MdiBookOpenOutline: typeof import('~icons/mdi/book-open-outline')['default']

--- a/tests/playwright/pages/Dashboard/Grid/Column/SelectOptionColumn.ts
+++ b/tests/playwright/pages/Dashboard/Grid/Column/SelectOptionColumn.ts
@@ -1,5 +1,6 @@
 import { ColumnPageObject } from '.';
 import BasePage from '../../../Base';
+import { expect } from '@playwright/test';
 
 export class SelectOptionColumnPageObject extends BasePage {
   readonly column: ColumnPageObject;
@@ -48,6 +49,22 @@ export class SelectOptionColumnPageObject extends BasePage {
     await this.column.openEdit({ title: columnTitle });
 
     await this.column.get().locator(`svg[data-testid="select-column-option-remove-${index}"]`).click();
+
+    await expect(this.column.get().getByTestId(`select-column-option-${index}`)).toHaveClass(/removed/);
+
+    await this.column.save({ isUpdated: true });
+  }
+
+  async deleteOptionWithUndo({ columnTitle, index }: { index: number; columnTitle: string }) {
+    await this.column.openEdit({ title: columnTitle });
+
+    await this.column.get().locator(`svg[data-testid="select-column-option-remove-${index}"]`).click();
+
+    await expect(this.column.get().getByTestId(`select-column-option-${index}`)).toHaveClass(/removed/);
+
+    await this.column.get().locator(`svg[data-testid="select-column-option-remove-undo-${index}"]`).click();
+
+    await expect(this.column.get().getByTestId(`select-column-option-${index}`)).not.toHaveClass(/removed/);
 
     await this.column.save({ isUpdated: true });
   }

--- a/tests/playwright/tests/columnSingleSelect.spec.ts
+++ b/tests/playwright/tests/columnSingleSelect.spec.ts
@@ -53,6 +53,13 @@ test.describe('Single select', () => {
     await grid.cell.selectOption.select({ index: 0, columnHeader: 'SingleSelect', option: 'Option 3' });
     await grid.cell.selectOption.verify({ index: 0, columnHeader: 'SingleSelect', option: 'Option 3' });
 
+    await grid.column.selectOption.deleteOptionWithUndo({ index: 0, columnTitle: 'SingleSelect' });
+    await grid.cell.selectOption.verifyOptions({
+      index: 0,
+      columnHeader: 'SingleSelect',
+      options: ['Option 1', 'Option 2', 'Option 3'],
+    });
+
     await grid.column.selectOption.deleteOption({ index: 2, columnTitle: 'SingleSelect' });
     await grid.cell.selectOption.verifyNoOptionsSelected({ index: 0, columnHeader: 'SingleSelect' });
 


### PR DESCRIPTION
## Change Summary

Since option removal is a destructive operation in can be a good idea to warn a user beforehead

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of

<img width="565" alt="image" src="https://user-images.githubusercontent.com/31967149/211217977-77fa8fe4-9b18-49ca-ac04-3064bce08efb.png">
