### PR TITLE
fix: filters logic

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -236,7 +236,7 @@ defineExpose({
               :key="`${i}_7`"
               v-model:value="filter.value"
               class="nc-filter-value-select"
-              :disabled="filter.readOnly"
+              :disabled="filter.readOnly || !filter.fk_column_id"
               @click.stop
               @input="saveOrUpdate(filter, i)"
             />

--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -104,7 +104,7 @@ export default class Noco {
   constructor() {
     process.env.PORT = process.env.PORT || '8080';
     // todo: move
-    process.env.NC_VERSION = '0098005';
+    process.env.NC_VERSION = '0100002';
 
     // if env variable NC_MINIMAL_DBS is set, then disable project creation with external sources
     if (process.env.NC_MINIMAL_DBS) {

--- a/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
+++ b/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
@@ -73,9 +73,14 @@ export default async (req, res, next) => {
       const column = await Column.get({ colId: params.columnId });
       req.ncProjectId = column?.project_id;
     } else if (params.filterId) {
-      const filter = await Filter.get(params.filterId).then((f) =>
-        f?.getColumn()
-      );
+      const filter = await Filter.get(params.filterId).then(async (f) => {
+        if (f.fk_view_id) {
+          return await View.get(f.fk_view_id);
+        } else if (f.fk_hook_id) {
+          return await Hook.get(f.fk_hook_id);
+        }
+        return await Column.get({ colId: filter.fk_column_id });
+      });
       req.ncProjectId = filter?.project_id;
     } else if (params.filterParentId) {
       const filter = await Filter.get(params.filterParentId);

--- a/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
+++ b/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
@@ -73,7 +73,9 @@ export default async (req, res, next) => {
       const column = await Column.get({ colId: params.columnId });
       req.ncProjectId = column?.project_id;
     } else if (params.filterId) {
-      const filter = await Filter.get(params.filterId);
+      const filter = await Filter.get(params.filterId).then((f) =>
+        f?.getColumn()
+      );
       req.ncProjectId = filter?.project_id;
     } else if (params.filterParentId) {
       const filter = await Filter.get(params.filterParentId);

--- a/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
+++ b/packages/nocodb/src/lib/meta/helpers/extractProjectIdAndAuthenticate.ts
@@ -73,14 +73,7 @@ export default async (req, res, next) => {
       const column = await Column.get({ colId: params.columnId });
       req.ncProjectId = column?.project_id;
     } else if (params.filterId) {
-      const filter = await Filter.get(params.filterId).then(async (f) => {
-        if (f.fk_view_id) {
-          return await View.get(f.fk_view_id);
-        } else if (f.fk_hook_id) {
-          return await Hook.get(f.fk_hook_id);
-        }
-        return await Column.get({ colId: filter.fk_column_id });
-      });
+      const filter = await Filter.get(params.filterId);
       req.ncProjectId = filter?.project_id;
     } else if (params.filterParentId) {
       const filter = await Filter.get(params.filterParentId);

--- a/packages/nocodb/src/lib/models/Filter.ts
+++ b/packages/nocodb/src/lib/models/Filter.ts
@@ -10,6 +10,7 @@ import {
 import View from './View';
 import { FilterType, UITypes } from 'nocodb-sdk';
 import NocoCache from '../cache/NocoCache';
+import { NcError } from '../meta/helpers/catchError';
 
 export default class Filter {
   id: string;
@@ -69,6 +70,9 @@ export default class Filter {
     filter: Partial<FilterType>,
     ncMeta = Noco.ncMeta
   ) {
+    if (!filter.fk_column_id) {
+      NcError.badRequest('fk_column_id is required');
+    }
     const insertObj = {
       id: filter.id,
       fk_view_id: filter.fk_view_id,

--- a/packages/nocodb/src/lib/version-upgrader/NcUpgrader.ts
+++ b/packages/nocodb/src/lib/version-upgrader/NcUpgrader.ts
@@ -8,6 +8,7 @@ import ncProjectEnvUpgrader0011045 from './ncProjectEnvUpgrader0011045';
 import ncProjectUpgraderV2_0090000 from './ncProjectUpgraderV2_0090000';
 import ncDataTypesUpgrader from './ncDataTypesUpgrader';
 import ncProjectRolesUpgrader from './ncProjectRolesUpgrader';
+import ncFilterUpgrader from './ncFilterUpgrader';
 
 const log = debug('nc:version-upgrader');
 import boxen from 'boxen';
@@ -35,6 +36,7 @@ export default class NcUpgrader {
         { name: '0090000', handler: ncProjectUpgraderV2_0090000 },
         { name: '0098004', handler: ncDataTypesUpgrader },
         { name: '0098005', handler: ncProjectRolesUpgrader },
+        { name: '0100002', handler: ncFilterUpgrader },
       ];
       if (!(await ctx.ncMeta.knexConnection?.schema?.hasTable?.('nc_store'))) {
         return;

--- a/packages/nocodb/src/lib/version-upgrader/ncFilterUpgrader.ts
+++ b/packages/nocodb/src/lib/version-upgrader/ncFilterUpgrader.ts
@@ -26,7 +26,7 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
         null,
         null,
         MetaTable.FILTER_EXP,
-        { project_id: model.project_id },
+        { base_id: model.base_id, project_id: model.project_id },
         filter.id
       );
     }

--- a/packages/nocodb/src/lib/version-upgrader/ncFilterUpgrader.ts
+++ b/packages/nocodb/src/lib/version-upgrader/ncFilterUpgrader.ts
@@ -1,0 +1,34 @@
+import { NcUpgraderCtx } from './NcUpgrader';
+import { MetaTable } from '../utils/globals';
+import View from '../models/View';
+import Hook from '../models/Hook';
+import Column from '../models/Column';
+
+// before 0.101.0, an incorrect project_id was inserted when
+// a filter is created without specifying the column
+// this upgrader is to retrieve the correct project id from either view, hook, or column
+// and update the project id
+export default async function ({ ncMeta }: NcUpgraderCtx) {
+  const filters = await ncMeta.metaList2(null, null, MetaTable.FILTER_EXP);
+  for (const filter of filters) {
+    let model: { project_id?: string; base_id?: string };
+    if (filter.fk_view_id) {
+      model = await View.get(filter.fk_view_id, ncMeta);
+    } else if (filter.fk_hook_id) {
+      model = await Hook.get(filter.fk_hook_id, ncMeta);
+    } else if (filter.fk_column_id) {
+      model = await Column.get({ colId: filter.fk_column_id }, ncMeta);
+    } else {
+      continue;
+    }
+    if (filter.project_id != model.project_id) {
+      await ncMeta.metaUpdate(
+        null,
+        null,
+        MetaTable.FILTER_EXP,
+        { project_id: model.project_id },
+        filter.id
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Change Summary

ref: #4793 

`project_id` in `nc_filter_exp_v2` is incorrect if users input the filter value first (since `fk_column_id` is missing which causes picking the first project id). This PR does the following changes

- upgrader to correct the `project_id` based on either `fk_view_id`, `fk_hook_id` or `fk_column_id` so that users can update / delete the problematic filters.
- disable filter value input if filter field is not chosen (in frontend)
- if `fk_column_id` is not provided, `project_id` should be retrieved from either `fk_view_id` or `fk_hook_id` (in backend).

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

the first 3 filters can be updated / deleted successfully

![image](https://user-images.githubusercontent.com/35857179/211546791-9f66233d-714d-4e0f-a179-ad6e1f1c6b03.png)
