### PR TITLE
refactor: 'Link To Another Record' instead of 'Child Table'

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/LookupOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/LookupOptions.vue
@@ -56,7 +56,7 @@ const columns = $computed<ColumnType[]>(() => {
 <template>
   <div class="p-6 w-full flex flex-col border-2 mb-2 mt-4">
     <div class="w-full flex flex-row space-x-2">
-      <a-form-item class="flex w-1/2 pb-2" :label="$t('labels.childTable')" v-bind="validateInfos.fk_relation_column_id">
+      <a-form-item class="flex w-1/2 pb-2" :label="$t('labels.linkToAnotherRecord')" v-bind="validateInfos.fk_relation_column_id">
         <a-select
           v-model:value="vModel.fk_relation_column_id"
           dropdown-class-name="!w-64 nc-dropdown-relation-table"

--- a/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
@@ -76,7 +76,7 @@ const columns = $computed(() => {
 <template>
   <div class="p-6 w-full flex flex-col border-2 mb-2 mt-4">
     <div class="w-full flex flex-row space-x-2">
-      <a-form-item class="flex w-1/2 pb-2" :label="$t('labels.childTable')" v-bind="validateInfos.fk_relation_column_id">
+      <a-form-item class="flex w-1/2 pb-2" :label="$t('labels.linkToAnotherRecord')" v-bind="validateInfos.fk_relation_column_id">
         <a-select
           v-model:value="vModel.fk_relation_column_id"
           dropdown-class-name="!w-64 nc-dropdown-relation-table"

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -277,6 +277,7 @@
     "selectUserRole": "Select User Role",
     "childTable": "Child table",
     "childColumn": "Child column",
+    "linkToAnotherRecord": "Link to another record",
     "onUpdate": "On Update",
     "onDelete": "On Delete",
     "account": "Account",


### PR DESCRIPTION
Signed-off-by: Raju Udava <86527202+dstala@users.noreply.github.com>

## Change Summary
Use "Link to another record" instead of "Child table"

## Change type
- [x] refactor: (refactoring production code, eg. renaming a variable)

## Test/ Verification
Locally verified
