### PR TITLE
fix: sqlite datetime diff

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
@@ -91,7 +91,7 @@ const pg = {
                     DATE_PART('year', AGE(${datetime_expr2}, '1900/01/01')) * 4) - 1)`;
         break;
       case 'year':
-        sql = `DATE_PART('year', age(${datetime_expr1}, ${datetime_expr2}))`;
+        sql = `DATE_PART('year', AGE(${datetime_expr1}, ${datetime_expr2}))`;
         break;
       case 'day':
         sql = `DATE_PART('day', ${datetime_expr1}::TIMESTAMP - ${datetime_expr2}::TIMESTAMP)`;

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
@@ -91,7 +91,7 @@ const pg = {
                     DATE_PART('year', AGE(${datetime_expr2}, '1900/01/01')) * 4) - 1)`;
         break;
       case 'year':
-        sql = `DATE_PART('year', ${datetime_expr1}::TIMESTAMP) - DATE_PART('year', ${datetime_expr2}::TIMESTAMP)`;
+        sql = `DATE_PART('year', age(${datetime_expr1}, ${datetime_expr2}))`;
         break;
       case 'day':
         sql = `DATE_PART('day', ${datetime_expr1}::TIMESTAMP - ${datetime_expr2}::TIMESTAMP)`;

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
@@ -130,7 +130,10 @@ const sqlite3 = {
         sql = `(strftime('%Y', ${datetime_expr1}) - strftime('%Y', ${datetime_expr2})) * 4 + (strftime('%m', ${datetime_expr1}) - strftime('%m', ${datetime_expr2})) / 3`;
         break;
       case 'years':
-        sql = `strftime('%Y', ${datetime_expr1}) - strftime('%Y', ${datetime_expr2})`;
+        sql = `CASE 
+                WHEN (JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) >= 0 THEN FLOOR(((JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) / 365.25))
+                ELSE CEILING(((JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) / 365.25))
+              END`;
         break;
       case 'days':
         sql = `JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})`;

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
@@ -139,6 +139,7 @@ const sqlite3 = {
                   AND strftime('%d', ${datetime_expr1}) < strftime('%d', ${datetime_expr2})))
                 )
                 WHEN (${datetime_expr2} > ${datetime_expr1}) THEN 
+                -1 * (
                   (strftime('%Y', ${datetime_expr2}) - strftime('%Y', ${datetime_expr1}))
                   - (strftime('%m', ${datetime_expr2}) < strftime('%m', ${datetime_expr1})
                   OR (strftime('%m', ${datetime_expr2}) = strftime('%m', ${datetime_expr1})

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/sqlite.ts
@@ -131,8 +131,20 @@ const sqlite3 = {
         break;
       case 'years':
         sql = `CASE 
-                WHEN (JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) >= 0 THEN FLOOR(((JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) / 365.25))
-                ELSE CEILING(((JULIANDAY(${datetime_expr1}) - JULIANDAY(${datetime_expr2})) / 365.25))
+                WHEN (${datetime_expr2} < ${datetime_expr1}) THEN 
+                (
+                  (strftime('%Y', ${datetime_expr1}) - strftime('%Y', ${datetime_expr2}))
+                  - (strftime('%m', ${datetime_expr1}) < strftime('%m', ${datetime_expr2})
+                  OR (strftime('%m', ${datetime_expr1}) = strftime('%m', ${datetime_expr2})
+                  AND strftime('%d', ${datetime_expr1}) < strftime('%d', ${datetime_expr2})))
+                )
+                WHEN (${datetime_expr2} > ${datetime_expr1}) THEN 
+                  (strftime('%Y', ${datetime_expr2}) - strftime('%Y', ${datetime_expr1}))
+                  - (strftime('%m', ${datetime_expr2}) < strftime('%m', ${datetime_expr1})
+                  OR (strftime('%m', ${datetime_expr2}) = strftime('%m', ${datetime_expr1})
+                  AND strftime('%d', ${datetime_expr2}) < strftime('%d', ${datetime_expr1})))
+                )
+                ELSE 0
               END`;
         break;
       case 'days':

--- a/tests/playwright/tests/columnFormula.spec.ts
+++ b/tests/playwright/tests/columnFormula.spec.ts
@@ -71,11 +71,11 @@ const formulaDataByDbType = (context: NcContext) => [
     result: ['-1', '-1', '-1', '-1', '-1'],
   },
   {
-    formula: `DATETIME_DIFF(NOW(), "2023/10/14", "y")`,
+    formula: `DATETIME_DIFF("2023/01/12", "2023/10/14", "y")`,
     result: ['0', '0', '0', '0', '0'],
   },
   {
-    formula: `DATETIME_DIFF("2023/10/14", NOW(), "y")`,
+    formula: `DATETIME_DIFF("2023/10/14", "2023/01/12", "y")`,
     result: ['0', '0', '0', '0', '0'],
   },
   {
@@ -95,7 +95,7 @@ const formulaDataByDbType = (context: NcContext) => [
     result: ['-365', '-365', '-365', '-365', '-365'],
   },
   {
-    formula: `DATETIME_DIFF("2022/10/14", NOW(), "d")`,
+    formula: `DATETIME_DIFF("2022/10/14", "2023/01/12", "d")`,
     result: ['-90', '-90', '-90', '-90', '-90'],
   },
   {

--- a/tests/playwright/tests/columnFormula.spec.ts
+++ b/tests/playwright/tests/columnFormula.spec.ts
@@ -39,6 +39,10 @@ const formulaDataByDbType = (context: NcContext) => [
     result: ['-1440', '-1440', '-1440', '-1440', '-1440'],
   },
   {
+    formula: `DATETIME_DIFF("2023/10/14", "2023/01/13", "minutes")`,
+    result: ['394560', '394560', '394560', '394560', '394560'],
+  },
+  {
     formula: `DATETIME_DIFF("2022/10/14", "2022/10/15", "seconds")`,
     result: ['-86400', '-86400', '-86400', '-86400', '-86400'],
   },
@@ -73,6 +77,18 @@ const formulaDataByDbType = (context: NcContext) => [
   {
     formula: `DATETIME_DIFF("2023/10/14", NOW(), "y")`,
     result: ['0', '0', '0', '0', '0'],
+  },
+  {
+    formula: `DATETIME_DIFF("2023-01-12", "2021-08-29", "y")`,
+    result: ['1', '1', '1', '1', '1'],
+  },
+  {
+    formula: `DATETIME_DIFF("2021-01-12", "2026-01-29", "y")`,
+    result: ['-5', '-5', '-5', '-5', '-5'],
+  },
+  {
+    formula: `DATETIME_DIFF("1990-01-12", "2046-12-29", "y")`,
+    result: ['-56', '-56', '-56', '-56', '-56'],
   },
   {
     formula: `DATETIME_DIFF("2022/10/14", "2023/10/14", "d")`,


### PR DESCRIPTION
## Change Summary

ref: #4816 

- revise DATETIME_DIFF sql for sqlite & pg
- add DATETIME_DIFF playwright tests

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

```
DATETIME_DIFF("2023-01-12", "2021-08-29", "years")
```

![image](https://user-images.githubusercontent.com/35857179/212239337-4a8b0b33-592e-4a81-9cf8-c72abe11e2c1.png)

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
