### PR TITLE
fix: injection warnings on shared view

### DIFF
--- a/packages/nc-gui/components/shared-view/Grid.vue
+++ b/packages/nc-gui/components/shared-view/Grid.vue
@@ -23,7 +23,7 @@ const { signedIn } = useGlobal()
 
 const { loadProject } = useProject()
 
-useProvideSmartsheetStore(sharedView, meta, true, sorts, nestedFilters)
+const { isLocked } = useProvideSmartsheetStore(sharedView, meta, true, sorts, nestedFilters)
 
 const reloadEventHook = createEventHook()
 
@@ -33,6 +33,7 @@ provide(MetaInj, meta)
 provide(ActiveViewInj, sharedView)
 provide(FieldsInj, ref(meta.value?.columns || []))
 provide(IsPublicInj, ref(true))
+provide(IsLockedInj, isLocked)
 
 if (signedIn.value) {
   try {

--- a/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
@@ -27,7 +27,7 @@ const activeView = inject(ActiveViewInj, ref())
 
 const reloadDataHook = inject(ReloadViewDataHookInj)!
 
-const reloadViewMetaHook = inject(ReloadViewMetaHookInj)!
+const reloadViewMetaHook = inject(ReloadViewMetaHookInj, undefined)!
 
 const rootFields = inject(FieldsInj)
 
@@ -108,7 +108,7 @@ const coverImageColumnId = computed({
         })
         ;(activeView.value.view as KanbanType).fk_cover_image_col_id = val
       }
-      reloadViewMetaHook.trigger()
+      reloadViewMetaHook?.trigger()
     }
   },
 })


### PR DESCRIPTION
## Change Summary

![image](https://user-images.githubusercontent.com/59797957/213254875-a0763bcc-4a23-4667-89d5-8bf1ea9356ed.png)

There was some warnings caused by injections
- Added default value for ReloadViewMetaHookInj
- Provided IsLockedInj from shared grid

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
