### PR TITLE
fix: filtering options for select columns

### DIFF
--- a/packages/nc-gui/utils/filterUtils.ts
+++ b/packages/nc-gui/utils/filterUtils.ts
@@ -41,13 +41,13 @@ export const comparisonOpList: {
     text: 'is empty',
     value: 'empty',
     ignoreVal: true,
-    excludedTypes: [UITypes.Checkbox, UITypes.Rating],
+    excludedTypes: [UITypes.Checkbox, UITypes.Rating, UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: 'is not empty',
     value: 'notempty',
     ignoreVal: true,
-    excludedTypes: [UITypes.Checkbox, UITypes.Rating],
+    excludedTypes: [UITypes.Checkbox, UITypes.Rating, UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: 'is null',
@@ -67,7 +67,7 @@ export const comparisonOpList: {
   {
     text: 'contains any of',
     value: 'anyof',
-    includedTypes: [UITypes.MultiSelect],
+    includedTypes: [UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: 'does not contain all of',
@@ -77,26 +77,26 @@ export const comparisonOpList: {
   {
     text: 'does not contain any of',
     value: 'nanyof',
-    includedTypes: [UITypes.MultiSelect],
+    includedTypes: [UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: '>',
     value: 'gt',
-    excludedTypes: [UITypes.Checkbox],
+    excludedTypes: [UITypes.Checkbox, UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: '<',
     value: 'lt',
-    excludedTypes: [UITypes.Checkbox],
+    excludedTypes: [UITypes.Checkbox, UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: '>=',
     value: 'gte',
-    excludedTypes: [UITypes.Checkbox],
+    excludedTypes: [UITypes.Checkbox, UITypes.MultiSelect, UITypes.SingleSelect],
   },
   {
     text: '<=',
     value: 'lte',
-    excludedTypes: [UITypes.Checkbox],
+    excludedTypes: [UITypes.Checkbox, UITypes.MultiSelect, UITypes.SingleSelect],
   },
 ]

--- a/packages/nc-gui/utils/filterUtils.ts
+++ b/packages/nc-gui/utils/filterUtils.ts
@@ -41,13 +41,13 @@ export const comparisonOpList: {
     text: 'is empty',
     value: 'empty',
     ignoreVal: true,
-    excludedTypes: [UITypes.Checkbox, UITypes.Rating, UITypes.MultiSelect, UITypes.SingleSelect],
+    excludedTypes: [UITypes.Checkbox, UITypes.Rating],
   },
   {
     text: 'is not empty',
     value: 'notempty',
     ignoreVal: true,
-    excludedTypes: [UITypes.Checkbox, UITypes.Rating, UITypes.MultiSelect, UITypes.SingleSelect],
+    excludedTypes: [UITypes.Checkbox, UITypes.Rating],
   },
   {
     text: 'is null',


### PR DESCRIPTION
## Change Summary

Re #4462
- Exclude incompatible options for select columns
- Add any of and not any of filtering for single select

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

