### PR TITLE
fix: remove relations in a logical order from meta on base delete

### DIFF
--- a/packages/nocodb/src/lib/models/Base.ts
+++ b/packages/nocodb/src/lib/models/Base.ts
@@ -7,7 +7,7 @@ import {
   MetaTable,
 } from '../utils/globals';
 import Model from './Model';
-import { BaseType } from 'nocodb-sdk';
+import { BaseType, UITypes } from 'nocodb-sdk';
 import NocoCache from '../cache/NocoCache';
 import CryptoJS from 'crypto-js';
 import { extractProps } from '../meta/helpers/extractProps';
@@ -277,6 +277,55 @@ export default class Base implements BaseType {
       },
       ncMeta
     );
+
+    const relColumns = [];
+    const relRank = {
+      [UITypes.Lookup]: 1,
+      [UITypes.Rollup]: 2,
+      [UITypes.ForeignKey]: 3,
+      [UITypes.LinkToAnotherRecord]: 4,
+    }
+
+    for (const model of models) {
+      for (const col of await model.getColumns(ncMeta)) {
+        let colOptionTableName = null;
+        let cacheScopeName = null;
+        switch (col.uidt) {
+          case UITypes.Rollup:
+            colOptionTableName = MetaTable.COL_ROLLUP;
+            cacheScopeName = CacheScope.COL_ROLLUP;
+            break;
+          case UITypes.Lookup:
+            colOptionTableName = MetaTable.COL_LOOKUP;
+            cacheScopeName = CacheScope.COL_LOOKUP;
+            break;
+          case UITypes.ForeignKey:
+          case UITypes.LinkToAnotherRecord:
+            colOptionTableName = MetaTable.COL_RELATIONS;
+            cacheScopeName = CacheScope.COL_RELATION;
+            break;
+        }
+        if (colOptionTableName && cacheScopeName) {
+          relColumns.push({ col, colOptionTableName, cacheScopeName });
+        }
+      }
+    }
+
+    relColumns.sort((a, b) => {
+      return relRank[a.col.uidt] - relRank[b.col.uidt];
+    });
+
+    for (const relCol of relColumns) {
+      await ncMeta.metaDelete(null, null, relCol.colOptionTableName, {
+        fk_column_id: relCol.col.id,
+      });
+      await NocoCache.deepDel(
+        relCol.cacheScopeName,
+        `${relCol.cacheScopeName}:${relCol.col.id}`,
+        CacheDelDirection.CHILD_TO_PARENT
+      );
+    }
+
     for (const model of models) {
       await model.delete(ncMeta, true);
     }


### PR DESCRIPTION
## Change Summary

Re #4871
The issue was reproducible when there is a lookup / roll up on one of the sheet after link column
( Sheet-1 has a belongs to column, Sheet-2 has a has many + lookup/roll up in that case base delete was failing because it was trying to remove belongs to before removing depending lookup / roll up columns)
- While removing a base, delete relational columns in order (Lookup -> Roll up -> FK -> LTAR)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

