### PR TITLE
fix(nocodb): argument of OR/AND must be type boolean, not type integer

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/functionMappings/pg.ts
@@ -123,7 +123,7 @@ const pg = {
             .join(' AND ')}`
         )
         .wrap('(', ')')
-        .toQuery()} THEN 1 ELSE 0 END ${args.colAlias}`
+        .toQuery()} THEN TRUE ELSE FALSE END ${args.colAlias}`
     );
   },
   OR: (args: MapFnArgs) => {
@@ -135,7 +135,7 @@ const pg = {
             .join(' OR ')}`
         )
         .wrap('(', ')')
-        .toQuery()} THEN 1 ELSE 0 END ${args.colAlias}`
+        .toQuery()} THEN TRUE ELSE FALSE END ${args.colAlias}`
     );
   },
   SUBSTR: ({ fn, knex, pt, colAlias }: MapFnArgs) => {


### PR DESCRIPTION
## Change Summary

ref: #4920

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/214760143-6241647a-251d-4a09-8212-eaa0e506c23d.png)

- f0:  `AND(true, AND(true, false))`
- f1: `AND(true, OR(true, false))`
- f2: `OR(true, AND(true, false))`
- f3: `OR(true, OR(true, false))`
- f4: `OR(OR(true, OR(true, false)), OR(true, false))`
