### PR TITLE
chore: bumb mysql container image version to 8.0.32

### DIFF
--- a/.github/uffizzi/docker-compose.uffizzi.yml
+++ b/.github/uffizzi/docker-compose.uffizzi.yml
@@ -31,7 +31,7 @@ services:
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: password
       MYSQL_USER: noco
-    image: "mysql:5.7"
+    image: "mysql:8.0.32"
     deploy:
       resources:
         limits:

--- a/docker-compose/mysql/docker-compose.yml
+++ b/docker-compose/mysql/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         - "-h"
         - localhost
       timeout: 20s
-    image: "mysql:5.7"
+    image: "mysql:8.0.32"
     restart: always
     volumes: 
       - "db_data:/var/lib/mysql"

--- a/docker-compose/nginx-proxy-manager/docker-compose.yml
+++ b/docker-compose/nginx-proxy-manager/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         - "-h"
         - localhost
       timeout: 20s
-    image: "mysql:5.7"
+    image: "mysql:8.0.32"
     networks: 
       - default
     restart: always

--- a/packages/nocodb/docker-compose.yml
+++ b/packages/nocodb/docker-compose.yml
@@ -19,28 +19,32 @@ services:
     #     - 3356:3306
     #   volumes:
     #     - ./mysql-sakila-db:/docker-entrypoint-initdb.d
-    db57:
-      image: mysql:5.7
-      restart: always
-      environment:
-        MYSQL_ROOT_PASSWORD: password
-      ports:
-       - 3357:3306
-      volumes:
-       - ./tests/mysql-sakila-db:/docker-entrypoint-initdb.d
-      healthcheck:
-         test: "/etc/init.d/mysql status"
-         interval: 1s
-         retries: 240
-    # db80:
-    #   image: mysql:8.0
+    # db57:
+    #   image: mysql:5.7
     #   restart: always
     #   environment:
     #     MYSQL_ROOT_PASSWORD: password
     #   ports:
-    #     - 3380:3306
+    #    - 3357:3306
     #   volumes:
-    #     - ./mysql-sakila-db:/docker-entrypoint-initdb.d
+    #    - ./tests/mysql-sakila-db:/docker-entrypoint-initdb.d
+      # healthcheck:
+      #    test: "/etc/init.d/mysql status"
+      #    interval: 1s
+      #    retries: 240
+    db8032:
+      image: mysql:8.0.32
+      restart: always
+      environment:
+        MYSQL_ROOT_PASSWORD: password
+      ports:
+        - 3380:3306
+      volumes:
+        - ./mysql-sakila-db:/docker-entrypoint-initdb.d
+      healthcheck:
+         test: "/etc/init.d/mysql status"
+         interval: 1s
+         retries: 240
     # maria102:
     #   image: mariadb:10.2
     #   restart: always

--- a/packages/nocodb/docker-compose.yml
+++ b/packages/nocodb/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       ports:
         - 3380:3306
       volumes:
-        - ./mysql-sakila-db:/docker-entrypoint-initdb.d
+        - ./tests/mysql-sakila-db:/docker-entrypoint-initdb.d
       healthcheck:
          test: "/etc/init.d/mysql status"
          interval: 1s


### PR DESCRIPTION
## Change Summary

- GA on 2015
- end of life on Oct this year
- we're using at least 8.0 to develop / test (playwright)
- some of existing sql may not work in 5.x  (#4929)

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

<img width="458" alt="image" src="https://user-images.githubusercontent.com/35857179/214800288-fdbd85c7-e683-4c11-8590-da8fafb27cbe.png">
