### PR TITLE
fix(nc-gui): cater new attachments in gallery view

### DIFF
--- a/packages/nc-gui/composables/useKanbanViewStore.ts
+++ b/packages/nc-gui/composables/useKanbanViewStore.ts
@@ -71,7 +71,9 @@ const [useProvideKanbanViewStore, useKanbanViewStore] = useInjectionState(
 
     const { sqlUis } = useProject()
 
-    const sqlUi = ref(meta.value?.base_id ? sqlUis.value[meta.value?.base_id] : Object.values(sqlUis.value)[0])
+    const sqlUi = ref(
+      (meta.value as TableType)?.base_id ? sqlUis.value[(meta.value as TableType)?.base_id!] : Object.values(sqlUis.value)[0],
+    )
 
     const xWhere = computed(() => {
       let where

--- a/packages/nc-gui/composables/useKanbanViewStore.ts
+++ b/packages/nc-gui/composables/useKanbanViewStore.ts
@@ -198,6 +198,8 @@ const [useProvideKanbanViewStore, useKanbanViewStore] = useInjectionState(
         // See /packages/nocodb/src/lib/version-upgrader/ncAttachmentUpgrader.ts for the details
         for (const record of data.value.list) {
           for (const attachmentColumn of attachmentColumns.value) {
+            // attachment column can be hidden
+            if (!record[attachmentColumn!]) continue
             const oldAttachment = JSON.parse(record[attachmentColumn!])
             const newAttachment = []
             for (const attachmentObj of oldAttachment) {

--- a/packages/nc-gui/composables/useSmartsheetStore.ts
+++ b/packages/nc-gui/composables/useSmartsheetStore.ts
@@ -13,9 +13,12 @@ const [useProvideSmartsheetStore, useSmartsheetStore] = useInjectionState(
     initialFilters?: Ref<FilterType[]>,
   ) => {
     const { $api } = useNuxtApp()
+
     const { sqlUis } = useProject()
 
-    const sqlUi = ref(meta.value?.base_id ? sqlUis.value[meta.value?.base_id] : Object.values(sqlUis.value)[0])
+    const sqlUi = ref(
+      (meta.value as TableType)?.base_id ? sqlUis.value[(meta.value as TableType)?.base_id!] : Object.values(sqlUis.value)[0],
+    )
 
     const cellRefs = ref<HTMLTableDataCellElement[]>([])
 

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -1,5 +1,15 @@
 import { UITypes, ViewTypes } from 'nocodb-sdk'
-import type { Api, ColumnType, FormColumnType, FormType, GalleryType, PaginatedType, TableType, ViewType } from 'nocodb-sdk'
+import type {
+  Api,
+  AttachmentType,
+  ColumnType,
+  FormColumnType,
+  FormType,
+  GalleryType,
+  PaginatedType,
+  TableType,
+  ViewType,
+} from 'nocodb-sdk'
 import type { ComputedRef, Ref } from 'vue'
 import {
   IsPublicInj,
@@ -80,6 +90,10 @@ export function useViewData(
   const { sorts, nestedFilters } = useSmartsheetStoreOrThrow()
 
   const { isUIAllowed } = useUIPermission()
+
+  const attachmentColumns = computed(() =>
+    (meta.value?.columns as ColumnType[])?.filter((c) => c.uidt === UITypes.Attachment).map((c) => c.title),
+  )
 
   const routeQuery = $computed(() => route.query as Record<string, string>)
 
@@ -187,6 +201,28 @@ export function useViewData(
     }
   }
 
+  // TODO: refactor
+  async function getAttachmentUrl(item: AttachmentType) {
+    const path = item?.path
+    // if path doesn't exist, use `item.url`
+    if (path) {
+      // try ${appInfo.value.ncSiteUrl}/${item.path} first
+      const url = `${appInfo.ncSiteUrl}/${item.path}`
+      try {
+        const res = await fetch(url)
+        if (res.ok) {
+          // use `url` if it is accessible
+          return Promise.resolve(url)
+        }
+      } catch {
+        // for some cases, `url` is not accessible as expected
+        // do nothing here
+      }
+    }
+    // if it fails, use the original url
+    return Promise.resolve(item.url)
+  }
+
   async function loadData(params: Parameters<Api<any>['dbViewRow']['list']>[4] = {}) {
     if ((!project?.value?.id || !meta.value?.id || !viewMeta.value?.id) && !isPublic.value) return
     const response = !isPublic.value
@@ -198,7 +234,25 @@ export function useViewData(
           where: where?.value,
         })
       : await fetchSharedViewData({ sortsArr: sorts.value, filtersArr: nestedFilters.value })
-    formattedData.value = formatData(response.list)
+    // reconstruct the url
+    // See /packages/nocodb/src/lib/version-upgrader/ncAttachmentUpgrader.ts for the details
+    const records = []
+    for (const record of response.list) {
+      for (const attachmentColumn of attachmentColumns.value) {
+        const oldAttachment =
+          typeof record[attachmentColumn!] === 'string' ? JSON.parse(record[attachmentColumn!]) : record[attachmentColumn!]
+        const newAttachment = []
+        for (const attachmentObj of oldAttachment) {
+          newAttachment.push({
+            ...attachmentObj,
+            url: await getAttachmentUrl(attachmentObj),
+          })
+        }
+        record[attachmentColumn!] = newAttachment
+      }
+      records.push(record)
+    }
+    formattedData.value = formatData(records)
     paginationData.value = response.pageInfo
 
     // to cater the case like when querying with a non-zero offset

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -239,6 +239,8 @@ export function useViewData(
     const records = []
     for (const record of response.list) {
       for (const attachmentColumn of attachmentColumns.value) {
+        // attachment column can be hidden
+        if (!record[attachmentColumn!]) continue
         const oldAttachment =
           typeof record[attachmentColumn!] === 'string' ? JSON.parse(record[attachmentColumn!]) : record[attachmentColumn!]
         const newAttachment = []

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -511,7 +511,7 @@ export function useViewData(
           order: (fieldById[c.id] && fieldById[c.id].order) || order++,
           id: fieldById[c.id] && fieldById[c.id].id,
         }))
-        .sort((a: Record<string, any>, b: Record<string, any>) => a.order - b.order) as Record<string, any>
+        .sort((a: Record<string, any>, b: Record<string, any>) => a.order - b.order) as Record<string, any>[]
     } catch (e: any) {
       return message.error(`${t('msg.error.setFormDataFailed')}: ${await extractSdkResponseErrorMsg(e)}`)
     }

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -105,7 +105,7 @@ export async function uploadViaURL(req: Request, res: Response) {
 
       let attachmentPath;
 
-      // if `url` is null, then it is local attachment
+      // if `attachmentUrl` is null, then it is local attachment
       if (!attachmentUrl) {
         // then store the attachement path only
         // url will be constructued in `useAttachmentCell`

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -113,7 +113,7 @@ export async function uploadViaURL(req: Request, res: Response) {
       }
 
       return {
-        ...(url ? { url: attachmentUrl } : {}),
+        ...(attachmentUrl ? { url: attachmentUrl } : {}),
         ...(attachmentPath ? { path: attachmentPath } : {}),
         title: fileName,
         mimetype: urlMeta.mimetype,

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -103,14 +103,18 @@ export async function uploadViaURL(req: Request, res: Response) {
         url
       );
 
+      let attachmentPath;
+
+      // if `url` is null, then it is local attachment
       if (!attachmentUrl) {
-        attachmentUrl = `${(req as any).ncSiteUrl}/download/${filePath.join(
-          '/'
-        )}/${fileName}`;
+        // then store the attachement path only
+        // url will be constructued in `useAttachmentCell`
+        attachmentPath = `download/${filePath.join('/')}/${fileName}`;
       }
 
       return {
-        url: attachmentUrl,
+        ...(url ? { url: attachmentUrl } : {}),
+        ...(attachmentPath ? { path: attachmentPath } : {}),
         title: fileName,
         mimetype: urlMeta.mimetype,
         size: urlMeta.size,

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -96,7 +96,7 @@ export async function uploadViaURL(req: Request, res: Response) {
     req.body?.map?.(async (urlMeta) => {
       const { url, fileName: _fileName } = urlMeta;
 
-      const fileName = `${nanoid(6)}${_fileName || url.split('/').pop()}`;
+      const fileName = `${nanoid(18)}${_fileName || url.split('/').pop()}`;
 
       let attachmentUrl = await (storageAdapter as any).fileCreateByUrl(
         slash(path.join(destPath, fileName)),


### PR DESCRIPTION
## Change Summary

ref: #4958

- gallery view doesn't use attachment cells. hence, patch `url` after getting the data. 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/215264041-b24c9e8c-78d7-4eb6-9acf-e9bc3662b4c4.png)
