### PR TITLE
fix: css for fixed row height

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import type { ColumnType, GridType } from 'nocodb-sdk'
+import type { ColumnType } from 'nocodb-sdk'
 import { isSystemColumn } from 'nocodb-sdk'
 import {
   ActiveCellInj,
-  ActiveViewInj,
   ColumnInj,
   EditModeInj,
   IsFormInj,
@@ -60,8 +59,6 @@ interface Props {
 const props = defineProps<Props>()
 
 const emit = defineEmits(['update:modelValue', 'save', 'navigate', 'update:editEnabled'])
-
-const view = inject(ActiveViewInj, ref())
 
 const column = toRef(props, 'column')
 
@@ -127,23 +124,6 @@ const syncAndNavigate = (dir: NavigateDir, e: KeyboardEvent) => {
 
   if (!isForm.value) e.stopImmediatePropagation()
 }
-
-const rowHeight = computed(() => {
-  if ((view.value?.view as GridType)?.row_height !== undefined) {
-    switch ((view.value?.view as GridType)?.row_height) {
-      case 0:
-        return 1
-      case 1:
-        return 2
-      case 2:
-        return 4
-      case 3:
-        return 6
-      default:
-        return 1
-    }
-  }
-})
 </script>
 
 <template>
@@ -152,8 +132,6 @@ const rowHeight = computed(() => {
     :class="[
       `nc-cell-${(column?.uidt || 'default').toLowerCase()}`,
       { 'text-blue-600': isPrimary(column) && !props.virtual && !isForm },
-      { 'm-y-auto !h-auto': !rowHeight || rowHeight === 1 },
-      { '!h-full': rowHeight && rowHeight !== 1 },
     ]"
     @keydown.enter.exact="syncAndNavigate(NavigateDir.NEXT, $event)"
     @keydown.shift.enter.exact="syncAndNavigate(NavigateDir.PREV, $event)"

--- a/packages/nc-gui/components/smartsheet/Grid.vue
+++ b/packages/nc-gui/components/smartsheet/Grid.vue
@@ -830,6 +830,8 @@ const rowHeight = computed(() => {
                     :class="{
                       'active': hasEditPermission && isCellSelected(rowIndex, colIndex),
                       'nc-required-cell': isColumnRequiredAndNull(columnObj, row.row),
+                      'align-middle': !rowHeight || rowHeight === 1,
+                      'align-top': rowHeight && rowHeight !== 1,
                     }"
                     :data-testid="`cell-${columnObj.title}-${rowIndex}`"
                     :data-key="rowIndex + columnObj.id"
@@ -982,7 +984,7 @@ const rowHeight = computed(() => {
 
   td:not(:first-child) > div {
     overflow: hidden;
-    @apply flex px-1;
+    @apply flex px-1 h-auto;
   }
 
   table,


### PR DESCRIPTION
## Change Summary

Re #4952
- Change the way fixed row height css handled so it is compatible with other browsers (tested with Chrome, Firefox, Safari)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/59797957/215332272-a9d89be8-0c73-4537-962c-757f15f5b54b.png">

<img width="1134" alt="image" src="https://user-images.githubusercontent.com/59797957/215332297-9f7f9fbd-101b-4f26-8e3a-1c5c9fc6bc11.png">

