### PR TITLE
fix(nocodb): fix invalid formula caused by STRING_AGG in postgres

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/CustomKnex.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/CustomKnex.ts
@@ -548,7 +548,7 @@ knex.QueryBuilder.extend(
 knex.QueryBuilder.extend('concat', function (cn: any) {
   switch (this?.client?.config?.client) {
     case 'pg':
-      this.select(this.client.raw(`STRING_AGG(?? , ',')`, [cn]));
+      this.select(this.client.raw(`STRING_AGG(??::character varying , ',')`, [cn]));
       break;
     case 'mysql':
     case 'mysql2':


### PR DESCRIPTION
## Change Summary

- in postgres, bigint is not supported in STRING_AGG because it only works for string value. Hence, this PR is to cast the data type of the input.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/215654898-9a43bbf0-fd71-4f11-8f66-cd437a974684.png)
