### PR TITLE
fix(nc-gui): use the default base id if baseId is not provided

### DIFF
--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -501,12 +501,16 @@ async function importTemplate() {
             }
           }
         }
-        const createdTable = await $api.base.tableCreate(project?.value?.id as string, baseId as string, {
-          table_name: table.table_name,
-          // leave title empty to get a generated one based on table_name
-          title: '',
-          columns: table.columns || [],
-        })
+        const createdTable = await $api.base.tableCreate(
+          project?.value?.id as string,
+          (baseId || project?.value?.bases?.[0].id)!,
+          {
+            table_name: table.table_name,
+            // leave title empty to get a generated one based on table_name
+            title: '',
+            columns: table.columns || [],
+          },
+        )
         table.id = createdTable.id
         table.title = createdTable.title
 

--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -502,8 +502,8 @@ async function importTemplate() {
           }
         }
         const createdTable = await $api.base.tableCreate(
-          project?.value?.id as string,
-          (baseId || project?.value?.bases?.[0].id)!,
+          project.value?.id as string,
+          (baseId || project.value?.bases?.[0].id)!,
           {
             table_name: table.table_name,
             // leave title empty to get a generated one based on table_name

--- a/packages/nc-gui/composables/useTable.ts
+++ b/packages/nc-gui/composables/useTable.ts
@@ -49,7 +49,7 @@ export function useTable(onTableCreate?: (tableMeta: TableType) => void, baseId?
     })
 
     try {
-      const tableMeta = await $api.base.tableCreate(project?.value?.id as string, baseId as string, {
+      const tableMeta = await $api.base.tableCreate(project?.value?.id as string, (baseId || project?.value?.bases?.[0].id)!, {
         ...table,
         columns,
       })


### PR DESCRIPTION
## Change Summary

- for import on the landing page, `baseId` is not provided which causes the issue. This PR is to add the default base id if it is not provided.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Use the csv provided by user in the issue.

![image](https://user-images.githubusercontent.com/35857179/216748018-aca6b9ec-b5a9-4d2e-b267-85b05be2dcc0.png)

