### PR TITLE
test: UT for filter APIs

### DIFF
--- a/packages/nocodb/tests/unit/factory/row.ts
+++ b/packages/nocodb/tests/unit/factory/row.ts
@@ -128,6 +128,31 @@ const rowMixedValue = (column: ColumnType, index: number) => {
     null,
   ];
 
+  const singleSelect = [
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'may',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'oct',
+    'nov',
+    'dec',
+    null,
+  ];
+
+  const multiSelect = [
+    'jan,feb,mar',
+    'apr,may,jun',
+    'jul,aug,sep',
+    'oct,nov,dec',
+    'jan,feb,mar',
+    null,
+  ];
+
   switch (column.uidt) {
     case UITypes.Number:
     case UITypes.Percent:
@@ -151,6 +176,10 @@ const rowMixedValue = (column: ColumnType, index: number) => {
       return '2020-01-01';
     case UITypes.URL:
       return urls[index % urls.length];
+    case UITypes.SingleSelect:
+      return singleSelect[index % singleSelect.length];
+    case UITypes.MultiSelect:
+      return multiSelect[index % multiSelect.length];
     default:
       return `test-${index}`;
   }

--- a/packages/nocodb/tests/unit/factory/row.ts
+++ b/packages/nocodb/tests/unit/factory/row.ts
@@ -24,13 +24,124 @@ const rowValue = (column: ColumnType, index: number) => {
   }
 };
 
-const getRow = async (context, {project, table, id}) => {
+const rowMixedValue = (column: ColumnType, index: number) => {
+  console.log(column.uidt, index);
+
+  // Array of country names
+  const countries = [
+    'Afghanistan',
+    'Albania',
+    '',
+    'Andorra',
+    'Angola',
+    'Antigua and Barbuda',
+    'Argentina',
+    null,
+    'Armenia',
+    'Australia',
+    'Austria',
+    '',
+    null,
+  ];
+
+  // Array of sample random paragraphs (comma separated list of cities and countries). Not more than 200 characters
+  const longText = [
+    'Aberdeen, United Kingdom',
+    'Abidjan, Côte d’Ivoire',
+    'Abuja, Nigeria',
+    '',
+    'Addis Ababa, Ethiopia',
+    'Adelaide, Australia',
+    'Ahmedabad, India',
+    'Albuquerque, United States',
+    null,
+    'Alexandria, Egypt',
+    'Algiers, Algeria',
+    'Allahabad, India',
+    '',
+    null,
+  ];
+
+  // Array of random integers, not more than 10000
+  const numbers = [33, 456, 54, 267, 34, 8754, 3234, 44, 33, null];
+
+  // Array of random sample email strings (not more than 100 characters)
+  const emails = [
+    'jbutt@gmail.com',
+    'josephine_darakjy@darakjy.org',
+    'art@venere.org',
+    '',
+    null,
+    'donette.foller@cox.net',
+    'simona@morasca.com',
+    'mitsue_tollner@yahoo.com',
+    'leota@hotmail.com',
+    'sage_wieser@cox.net',
+    '',
+    null,
+  ];
+
+  // Array of random sample phone numbers
+  const phoneNumbers = [
+    '1-541-754-3010',
+    '504-621-8927',
+    '810-292-9388',
+    '856-636-8749',
+    '907-385-4412',
+    '513-570-1893',
+    '419-503-2484',
+    '773-573-6914',
+    '',
+    null,
+  ];
+
+  // Array of random sample URLs
+  const urls = [
+    'https://www.google.com',
+    'https://www.facebook.com',
+    'https://www.youtube.com',
+    'https://www.amazon.com',
+    'https://www.wikipedia.org',
+    'https://www.twitter.com',
+    'https://www.instagram.com',
+    'https://www.linkedin.com',
+    'https://www.reddit.com',
+    'https://www.tiktok.com',
+    'https://www.pinterest.com',
+    'https://www.netflix.com',
+    'https://www.microsoft.com',
+    'https://www.apple.com',
+    '',
+    null,
+  ];
+
+  switch (column.uidt) {
+    case UITypes.Number:
+      return numbers[index % numbers.length];
+    case UITypes.SingleLineText:
+      return countries[index % countries.length];
+    case UITypes.Email:
+      return emails[index % emails.length];
+    case UITypes.PhoneNumber:
+      return phoneNumbers[index % phoneNumbers.length];
+    case UITypes.LongText:
+      return longText[index % longText.length];
+    case UITypes.Date:
+      return '2020-01-01';
+    case UITypes.URL:
+      return urls[index % urls.length];
+    default:
+      return `test-${index}`;
+  }
+};
+
+const getRow = async (context, { project, table, id }) => {
   const response = await request(context.app)
     .get(`/api/v1/db/data/noco/${project.id}/${table.id}/${id}`)
     .set('xc-auth', context.token);
 
-  if(response.status !== 200) {
-    return undefined
+  if (response.status !== 200) {
+    return undefined;
   }
 
   return response.body;
@@ -119,18 +230,19 @@ const createBulkRows = async (
   {
     project,
     table,
-    values
+    values,
   }: {
     project: Project;
     table: Model;
     values: any[];
-  }) => {
-    await request(context.app)
-      .post(`/api/v1/db/data/bulk/noco/${project.id}/${table.id}`)
-      .set('xc-auth', context.token)
-      .send(values)
-      .expect(200);
   }
+) => {
+  await request(context.app)
+    .post(`/api/v1/db/data/bulk/noco/${project.id}/${table.id}`)
+    .set('xc-auth', context.token)
+    .send(values)
+    .expect(200);
+};
 
 // Links 2 table rows together. Will create rows if ids are not provided
 const createChildRow = async (
@@ -174,6 +286,26 @@ const createChildRow = async (
   return row;
 };
 
+// Mixed row attributes
+const generateMixedRowAttributes = ({
+  columns,
+  index = 0,
+}: {
+  columns: ColumnType[];
+  index?: number;
+}) =>
+  columns.reduce((acc, column) => {
+    if (
+      column.uidt === UITypes.LinkToAnotherRecord ||
+      column.uidt === UITypes.ForeignKey ||
+      column.uidt === UITypes.ID
+    ) {
+      return acc;
+    }
+    acc[column.title!] = rowMixedValue(column, index);
+    return acc;
+  }, {});
+
 export {
   createRow,
   getRow,
@@ -181,5 +313,7 @@ export {
   getOneRow,
   listRow,
   generateDefaultRowAttributes,
-  createBulkRows
+  generateMixedRowAttributes,
+  createBulkRows,
+  rowMixedValue,
 };

--- a/packages/nocodb/tests/unit/factory/row.ts
+++ b/packages/nocodb/tests/unit/factory/row.ts
@@ -61,7 +61,22 @@ const rowMixedValue = (column: ColumnType, index: number) => {
   ];
 
   // Array of random integers, not more than 10000
-  const numbers = [33, 456, 54, 267, 34, 8754, 3234, 44, 33, null];
+  const numbers = [33, null, 456, 333, 267, 34, 8754, 3234, 44, 33, null];
+  const decimals = [
+    33.3,
+    456.34,
+    333.3,
+    null,
+    267.5674,
+    34.0,
+    8754.0,
+    3234.547,
+    44.2647,
+    33.98,
+    null,
+  ];
+  const duration = [10, 20, 30, 40, 50, 60, null, 70, 80, 90, null];
+  const rating = [0, 1, 2, 3, null, 0, 4, 5, 0, 1, null];
 
   // Array of random sample email strings (not more than 100 characters)
   const emails = [
@@ -115,7 +130,15 @@ const rowMixedValue = (column: ColumnType, index: number) => {
 
   switch (column.uidt) {
     case UITypes.Number:
+    case UITypes.Percent:
       return numbers[index % numbers.length];
+    case UITypes.Decimal:
+    case UITypes.Currency:
+      return decimals[index % decimals.length];
+    case UITypes.Duration:
+      return duration[index % duration.length];
+    case UITypes.Rating:
+      return rating[index % rating.length];
     case UITypes.SingleLineText:
       return countries[index % countries.length];
     case UITypes.Email:

--- a/packages/nocodb/tests/unit/factory/row.ts
+++ b/packages/nocodb/tests/unit/factory/row.ts
@@ -25,8 +25,6 @@ const rowValue = (column: ColumnType, index: number) => {
 };
 
 const rowMixedValue = (column: ColumnType, index: number) => {
-  console.log(column.uidt, index);
-
   // Array of country names
   const countries = [
     'Afghanistan',

--- a/packages/nocodb/tests/unit/rest/index.test.ts
+++ b/packages/nocodb/tests/unit/rest/index.test.ts
@@ -7,6 +7,7 @@ import tableTests from './tests/table.test';
 import tableRowTests from './tests/tableRow.test';
 import viewRowTests from './tests/viewRow.test';
 import attachmentTests from './tests/attachment.test';
+import filterTest from './tests/filter.test';
 
 function restTests() {
   authTests();
@@ -17,6 +18,7 @@ function restTests() {
   viewRowTests();
   columnTypeSpecificTests();
   attachmentTests();
+  filterTest();
 }
 
 export default function () {

--- a/packages/nocodb/tests/unit/rest/tests/filter.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/filter.test.ts
@@ -1,0 +1,97 @@
+import 'mocha';
+import init from '../../init';
+import { createProject } from '../../factory/project';
+import Project from '../../../../src/lib/models/Project';
+import { createTable } from '../../factory/table';
+import { isSqlite } from '../../init/db';
+import { UITypes } from 'nocodb-sdk';
+import {
+  createBulkRows,
+  generateDefaultRowAttributes,
+  generateMixedRowAttributes,
+  rowMixedValue,
+  listRow,
+} from '../../factory/row';
+import Model from '../../../../src/lib/models/Model';
+import { expect } from 'chai';
+
+// Test case list
+
+function filterTests() {
+  let context;
+  let project: Project;
+  let table: Model;
+  let unfilteredRecords: any[] = [];
+
+  // prepare data for test cases
+  beforeEach(async function () {
+    context = await init();
+    project = await createProject(context);
+    table = await createTable(context, project, {
+      table_name: 'textBased',
+      title: 'TextBased',
+      columns: [
+        {
+          column_name: 'Id',
+          title: 'Id',
+          uidt: UITypes.ID,
+        },
+        {
+          column_name: 'SingleLineText',
+          title: 'SingleLineText',
+          uidt: UITypes.SingleLineText,
+        },
+        {
+          column_name: 'MultiLineText',
+          title: 'MultiLineText',
+          uidt: UITypes.LongText,
+        },
+        {
+          column_name: 'Email',
+          title: 'Email',
+          uidt: UITypes.Email,
+        },
+        {
+          column_name: 'Phone',
+          title: 'Phone',
+          uidt: UITypes.PhoneNumber,
+        },
+        {
+          column_name: 'Url',
+          title: 'Url',
+          uidt: UITypes.URL,
+        },
+      ],
+    });
+
+    const columns = await table.getColumns();
+
+    let rowAttributes = [];
+    for (let i = 0; i < 400; i++) {
+      let row = {
+        SingleLineText: rowMixedValue(columns[1], i),
+        MultiLineText: rowMixedValue(columns[2], i),
+        Email: rowMixedValue(columns[3], i),
+        Phone: rowMixedValue(columns[4], i),
+        Url: rowMixedValue(columns[5], i),
+      };
+      rowAttributes.push(row);
+    }
+
+    await createBulkRows(context, {
+      project,
+      table,
+      values: rowAttributes,
+    });
+    unfilteredRecords = await listRow({ project, table });
+
+    // verify length of unfiltered records to be 400
+    expect(unfilteredRecords.length).to.equal(400);
+  });
+
+  it('Type: Single Line Text', async () => {});
+}
+
+export default function () {
+  describe('Filters', filterTests);
+}

--- a/packages/nocodb/tests/unit/rest/tests/filter.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/filter.test.ts
@@ -16,14 +16,66 @@ import Model from '../../../../src/lib/models/Model';
 import { expect } from 'chai';
 import request from 'supertest';
 
+const debugMode = true;
+
 // Test case list
 
-function filterTests() {
-  let context;
-  let project: Project;
-  let table: Model;
-  let columns: any[];
-  let unfilteredRecords: any[] = [];
+async function retrieveRecordsAndValidate(
+  filter: {
+    comparison_op: string;
+    value: string;
+    fk_column_id: any;
+    status: string;
+    logical_op: string;
+  },
+  expectedRecords: any[],
+  title: string
+) {
+  // retrieve filtered records
+  const response = await request(context.app)
+    .get(`/api/v1/db/data/noco/${project.id}/${table.id}`)
+    .set('xc-auth', context.token)
+    .query({
+      filterArrJson: JSON.stringify([filter]),
+    })
+    .expect(200);
+
+  // validate
+  if (debugMode) {
+    if (response.body.pageInfo.totalRows !== expectedRecords.length) {
+      console.log(`Failed for filter: ${JSON.stringify(filter)}`);
+      console.log(`Expected: ${expectedRecords.length}`);
+      console.log(`Actual: ${response.body.pageInfo.totalRows}`);
+      throw new Error('fix me!');
+    }
+    response.body.list.forEach((row, index) => {
+      if (row[title] !== expectedRecords[index][title]) {
+        console.log(`Failed for filter: ${JSON.stringify(filter)}`);
+        console.log(`Expected: ${expectedRecords[index][title]}`);
+        console.log(`Actual: ${row[title]}`);
+        throw new Error('fix me!');
+      }
+    });
+  } else {
+    expect(response.body.pageInfo.totalRows).to.equal(expectedRecords.length);
+    response.body.list.forEach((row, index) => {
+      expect(row[title] !== expectedRecords[index][title]);
+    });
+  }
+}
+
+let context;
+let project: Project;
+let table: Model;
+let columns: any[];
+let unfilteredRecords: any[] = [];
+
+function filterTextBased() {
+  // let context;
+  // let project: Project;
+  // let table: Model;
+  // let columns: any[];
+  // let unfilteredRecords: any[] = [];
 
   // prepare data for test cases
   beforeEach(async function () {
@@ -91,35 +143,54 @@ function filterTests() {
     expect(unfilteredRecords.length).to.equal(400);
   });
 
-  async function retrieveRecordsAndValidate(
-    filter: {
-      comparison_op: string;
-      value: string;
-      fk_column_id: any;
-      status: string;
-      logical_op: string;
-    },
-    expectedRecords: any[]
-  ) {
-    // retrieve filtered records
-    const response = await request(context.app)
-      .get(`/api/v1/db/data/noco/${project.id}/${table.id}`)
-      .set('xc-auth', context.token)
-      .query({
-        filterArrJson: JSON.stringify([filter]),
-      })
-      .expect(200);
-
-    // validate
-    expect(response.body.pageInfo.totalRows).to.equal(expectedRecords.length);
-    response.body.list.forEach((row, index) => {
-      expect(row[columns[1].title] !== expectedRecords[index].SingleLineText);
-    });
-  }
+  // async function retrieveRecordsAndValidate(
+  //   filter: {
+  //     comparison_op: string;
+  //     value: string;
+  //     fk_column_id: any;
+  //     status: string;
+  //     logical_op: string;
+  //   },
+  //   expectedRecords: any[]
+  // ) {
+  //   // retrieve filtered records
+  //   const response = await request(context.app)
+  //     .get(`/api/v1/db/data/noco/${project.id}/${table.id}`)
+  //     .set('xc-auth', context.token)
+  //     .query({
+  //       filterArrJson: JSON.stringify([filter]),
+  //     })
+  //     .expect(200);
+  //
+  //   // validate
+  //   if (debugMode) {
+  //     if (response.body.pageInfo.totalRows !== expectedRecords.length) {
+  //       console.log(`Failed for filter: ${JSON.stringify(filter)}`);
+  //       console.log(`Expected: ${expectedRecords.length}`);
+  //       console.log(`Actual: ${response.body.pageInfo.totalRows}`);
+  //       throw new Error('fix me!');
+  //     }
+  //     response.body.list.forEach((row, index) => {
+  //       if (row[columns[1].title] !== expectedRecords[index].SingleLineText) {
+  //         console.log(`Failed for filter: ${JSON.stringify(filter)}`);
+  //         console.log(`Expected: ${expectedRecords[index].SingleLineText}`);
+  //         console.log(`Actual: ${row[columns[1].title]}`);
+  //         throw new Error('fix me!');
+  //       }
+  //     });
+  //   } else {
+  //     expect(response.body.pageInfo.totalRows).to.equal(expectedRecords.length);
+  //     response.body.list.forEach((row, index) => {
+  //       expect(row[columns[1].title] !== expectedRecords[index].SingleLineText);
+  //     });
+  //   }
+  // }
 
   it('Type: Single Line Text', async () => {
     // filter types to be verified
     // eq, neq, null, notnull, empty, notempty, like, nlike
+
+    const dataType = 'SingleLineText';
 
     const filter = {
       fk_column_id: columns[1].id,
@@ -130,63 +201,780 @@ function filterTests() {
     };
 
     let expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText === 'Afghanistan'
+      (record) => record[dataType] === 'Afghanistan'
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: neq
     filter.comparison_op = 'neq';
     expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText !== 'Afghanistan'
+      (record) => record[dataType] !== 'Afghanistan'
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: null
     filter.comparison_op = 'null';
     expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText === null
+      (record) => record[dataType] === null
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: notnull
     filter.comparison_op = 'notnull';
     expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText !== null
+      (record) => record[dataType] !== null
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: empty
     filter.comparison_op = 'empty';
     expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText === ''
+      (record) => record[dataType] === ''
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: notempty
     filter.comparison_op = 'notempty';
     expectedRecords = unfilteredRecords.filter(
-      (record) => record.SingleLineText !== ''
+      (record) => record[dataType] !== ''
     );
-    //TBD await retrieveRecordsAndValidate(filter, expectedRecords);
+    //TBD await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: like
     filter.comparison_op = 'like';
     filter.value = 'Au';
     expectedRecords = unfilteredRecords.filter((record) =>
-      record.SingleLineText?.includes('Au')
+      record[dataType]?.includes('Au')
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
 
     // filter: nlike
     filter.comparison_op = 'nlike';
     filter.value = 'Au';
     expectedRecords = unfilteredRecords.filter(
-      (record) => !record.SingleLineText?.includes('Au')
+      (record) => !record[dataType]?.includes('Au')
     );
-    await retrieveRecordsAndValidate(filter, expectedRecords);
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: LongText', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, empty, notempty, like, nlike
+
+    const dataType = 'MultiLineText';
+
+    const filter = {
+      fk_column_id: columns[2].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: 'Aberdeen, United Kingdom',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 'Aberdeen, United Kingdom'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 'Aberdeen, United Kingdom'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: empty
+    filter.comparison_op = 'empty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === ''
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notempty
+    filter.comparison_op = 'notempty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== ''
+    );
+    //TBD await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: like
+    filter.comparison_op = 'like';
+    filter.value = 'abad';
+    expectedRecords = unfilteredRecords.filter((record) =>
+      record[dataType]?.includes('abad')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: nlike
+    filter.comparison_op = 'nlike';
+    filter.value = 'abad';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => !record[dataType]?.includes('abad')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Email', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, empty, notempty, like, nlike
+
+    const dataType = 'Email';
+
+    const filter = {
+      fk_column_id: columns[3].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: 'leota@hotmail.com',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 'leota@hotmail.com'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 'leota@hotmail.com'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: empty
+    filter.comparison_op = 'empty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === ''
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notempty
+    filter.comparison_op = 'notempty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== ''
+    );
+    //TBD await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: like
+    filter.comparison_op = 'like';
+    filter.value = 'cox.net';
+    expectedRecords = unfilteredRecords.filter((record) =>
+      record[dataType]?.includes('cox.net')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: nlike
+    filter.comparison_op = 'nlike';
+    filter.value = 'cox.net';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => !record[dataType]?.includes('cox.net')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Phone', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, empty, notempty, like, nlike
+
+    const dataType = 'Phone';
+
+    const filter = {
+      fk_column_id: columns[4].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '504-621-8927',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === '504-621-8927'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== '504-621-8927'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: empty
+    filter.comparison_op = 'empty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === ''
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notempty
+    filter.comparison_op = 'notempty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== ''
+    );
+    //TBD await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: like
+    filter.comparison_op = 'like';
+    filter.value = '504';
+    expectedRecords = unfilteredRecords.filter((record) =>
+      record[dataType]?.includes('504')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: nlike
+    filter.comparison_op = 'nlike';
+    filter.value = '504';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => !record[dataType]?.includes('504')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: URL', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, empty, notempty, like, nlike
+
+    const dataType = 'Url';
+
+    const filter = {
+      fk_column_id: columns[5].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: 'https://www.youtube.com',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 'https://www.youtube.com'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 'https://www.youtube.com'
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: empty
+    filter.comparison_op = 'empty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === ''
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notempty
+    filter.comparison_op = 'notempty';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== ''
+    );
+    //TBD await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: like
+    filter.comparison_op = 'like';
+    filter.value = 'e.com';
+    expectedRecords = unfilteredRecords.filter((record) =>
+      record[dataType]?.includes('e.com')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: nlike
+    filter.comparison_op = 'nlike';
+    filter.value = 'e.com';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => !record[dataType]?.includes('e.com')
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+}
+
+function filterNumberBased() {
+  // prepare data for test cases
+  beforeEach(async function () {
+    context = await init();
+    project = await createProject(context);
+    table = await createTable(context, project, {
+      table_name: 'numberBased',
+      title: 'numberBased',
+      columns: [
+        {
+          column_name: 'Id',
+          title: 'Id',
+          uidt: UITypes.ID,
+        },
+        {
+          column_name: 'Number',
+          title: 'Number',
+          uidt: UITypes.Number,
+        },
+        {
+          column_name: 'Decimal',
+          title: 'Decimal',
+          uidt: UITypes.Decimal,
+        },
+        {
+          column_name: 'Currency',
+          title: 'Currency',
+          uidt: UITypes.Currency,
+        },
+        {
+          column_name: 'Percent',
+          title: 'Percent',
+          uidt: UITypes.Percent,
+        },
+        {
+          column_name: 'Duration',
+          title: 'Duration',
+          uidt: UITypes.Duration,
+        },
+        {
+          column_name: 'Rating',
+          title: 'Rating',
+          uidt: UITypes.Rating,
+        },
+      ],
+    });
+
+    columns = await table.getColumns();
+
+    let rowAttributes = [];
+    for (let i = 0; i < 400; i++) {
+      let row = {
+        Number: rowMixedValue(columns[1], i),
+        Decimal: rowMixedValue(columns[2], i),
+        Currency: rowMixedValue(columns[3], i),
+        Percent: rowMixedValue(columns[4], i),
+        Duration: rowMixedValue(columns[5], i),
+        Rating: rowMixedValue(columns[6], i),
+      };
+      rowAttributes.push(row);
+    }
+
+    await createBulkRows(context, {
+      project,
+      table,
+      values: rowAttributes,
+    });
+    unfilteredRecords = await listRow({ project, table });
+
+    // verify length of unfiltered records to be 400
+    expect(unfilteredRecords.length).to.equal(400);
+  });
+
+  it('Type: Number', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, like, nlike, >, >=, <, <=
+
+    const dataType = 'Number';
+
+    const filter = {
+      fk_column_id: columns[1].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '33',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 33
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 33
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >
+    filter.comparison_op = 'gt';
+    filter.value = '44';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] > 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >=
+    filter.comparison_op = 'gte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] >= 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <
+    filter.comparison_op = 'lt';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] < 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <=
+    filter.comparison_op = 'lte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] <= 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Decimal', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, like, nlike, >, >=, <, <=
+
+    const dataType = 'Decimal';
+
+    const filter = {
+      fk_column_id: columns[2].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '33.3',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => parseFloat(record[dataType]) === 33.3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => parseFloat(record[dataType]) !== 33.3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >
+    filter.comparison_op = 'gt';
+    filter.value = '44.26';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) > 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >=
+    filter.comparison_op = 'gte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) >= 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <
+    filter.comparison_op = 'lt';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) < 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <=
+    filter.comparison_op = 'lte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) <= 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Currency', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, like, nlike, >, >=, <, <=
+
+    const dataType = 'Currency';
+
+    const filter = {
+      fk_column_id: columns[3].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '33.3',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => parseFloat(record[dataType]) === 33.3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => parseFloat(record[dataType]) !== 33.3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >
+    filter.comparison_op = 'gt';
+    filter.value = '44.26';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) > 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >=
+    filter.comparison_op = 'gte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) >= 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <
+    filter.comparison_op = 'lt';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) < 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <=
+    filter.comparison_op = 'lte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) =>
+        parseFloat(record[dataType]) <= 44.26 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Percent', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, like, nlike, >, >=, <, <=
+
+    const dataType = 'Percent';
+
+    const filter = {
+      fk_column_id: columns[4].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '33',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 33
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 33
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >
+    filter.comparison_op = 'gt';
+    filter.value = '44';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] > 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >=
+    filter.comparison_op = 'gte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] >= 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <
+    filter.comparison_op = 'lt';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] < 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <=
+    filter.comparison_op = 'lte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] <= 44 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+  });
+
+  it('Type: Rating', async () => {
+    // filter types to be verified
+    // eq, neq, null, notnull, like, nlike, >, >=, <, <=
+
+    const dataType = 'Rating';
+
+    const filter = {
+      fk_column_id: columns[6].id,
+      status: 'create',
+      logical_op: 'and',
+      comparison_op: 'eq',
+      value: '3',
+    };
+
+    let expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === 3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: neq
+    filter.comparison_op = 'neq';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== 3
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: null
+    filter.comparison_op = 'null';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] === null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: notnull
+    filter.comparison_op = 'notnull';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >
+    filter.comparison_op = 'gt';
+    filter.value = '2';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] > 2 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: >=
+    filter.comparison_op = 'gte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] >= 2 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <
+    filter.comparison_op = 'lt';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] < 2 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
+
+    // filter: <=
+    filter.comparison_op = 'lte';
+    expectedRecords = unfilteredRecords.filter(
+      (record) => record[dataType] <= 2 && record[dataType] !== null
+    );
+    await retrieveRecordsAndValidate(filter, expectedRecords, dataType);
   });
 }
 
 export default function () {
-  describe('Filters', filterTests);
+  describe('Filter: Text based', filterTextBased);
+  describe('Filter: Numerical', filterNumberBased);
 }

--- a/packages/nocodb/tests/unit/rest/tests/filter.test.ts
+++ b/packages/nocodb/tests/unit/rest/tests/filter.test.ts
@@ -25,7 +25,11 @@ async function retrieveRecordsAndValidate(
 ) {
   let expectedRecords = [];
   let toFloat = false;
-  if (['Number', 'Decimal', 'Currency', 'Percent', 'Rating'].includes(title)) {
+  if (
+    ['Number', 'Decimal', 'Currency', 'Percent', 'Duration', 'Rating'].includes(
+      title
+    )
+  ) {
     toFloat = true;
   }
 
@@ -429,6 +433,20 @@ function filterNumberBased() {
       { comparison_op: 'lte', value: '44' },
     ];
     await verifyFilters('Percent', columns[4].id, filterList);
+  });
+
+  it('Type: Duration', async () => {
+    let filterList = [
+      { comparison_op: 'eq', value: '10' },
+      { comparison_op: 'neq', value: '10' },
+      { comparison_op: 'null', value: '' },
+      { comparison_op: 'notnull', value: '' },
+      { comparison_op: 'gt', value: '50' },
+      { comparison_op: 'gte', value: '50' },
+      { comparison_op: 'lt', value: '50' },
+      { comparison_op: 'lte', value: '50' },
+    ];
+    await verifyFilters('Duration', columns[5].id, filterList);
   });
 
   it('Type: Rating', async () => {


### PR DESCRIPTION
## Change Summary
- Xcdb project: hence even data is generated locally for required datatypes, instead of using sakila
- Covered so far
  - Text based : single line, long text, phone number, email, url
  - Numerical : number, decimal, percent, currency, rating, duration
  - Select based : single & multi select
 
## Change type
- [x] test: (adding missing tests, refactoring tests; no production code change)

## Test/ Verification
Locally verified

## Additional information / screenshots (optional)
Anything for maintainers to be made aware of
