### PR TITLE
fix: Populate unique fk constraint name 

### DIFF
--- a/packages/nc-gui/assets/style.scss
+++ b/packages/nc-gui/assets/style.scss
@@ -308,7 +308,7 @@ a {
 
 .ant-btn-loading-icon{
   & > span {
-    @apply block bg-red-500
+    @apply block;
   }
 }
 

--- a/packages/nocodb/src/lib/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/meta/api/columnApis.ts
@@ -52,6 +52,9 @@ export enum Altered {
 
 // generate unique foreign key constraint name for foreign key
 const generateFkConstraintName = (parent: TableType, child: TableType) => {
+  // generate a unique constraint name by taking first 10 chars of parent and child table name (by replacing all non word chars with _)
+  // and appending a random string of 15 chars maximum length.
+  // In database constraint name can be upto 64 chars and here we are generating a name of maximum 40 chars
   const constraintName = `fk_${parent.table_name
     .replace(/\W+/g, '_')
     .slice(0, 10)}_${child.table_name
@@ -326,7 +329,7 @@ export async function columnAdd(
                 onUpdate: 'NO ACTION',
                 type: 'real',
                 parentColumn: parent.primaryKey.column_name,
-                foreignKeyName: generateFkConstraintName(parent, child), //generateFkConstraintName()
+                foreignKeyName: generateFkConstraintName(parent, child),
               });
             }
 

--- a/packages/nocodb/src/lib/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/meta/api/columnApis.ts
@@ -50,6 +50,16 @@ export enum Altered {
   UPDATE_COLUMN = 8,
 }
 
+// generate unique foreign key constraint name for foreign key
+const generateFkConstraintName = (parent: TableType, child: TableType) => {
+  const constraintName = `fk_${parent.table_name
+    .replace(/\W+/g, '_')
+    .slice(0, 10)}_${child.table_name
+    .replace(/\W+/g, '_')
+    .slice(0, 10)}_${randomID(15)}`;
+  return constraintName;
+};
+
 async function createHmAndBtColumn(
   child: Model,
   parent: Model,
@@ -316,6 +326,7 @@ export async function columnAdd(
                 onUpdate: 'NO ACTION',
                 type: 'real',
                 parentColumn: parent.primaryKey.column_name,
+                foreignKeyName: generateFkConstraintName(parent, child), //generateFkConstraintName()
               });
             }
 
@@ -407,6 +418,7 @@ export async function columnAdd(
               parentTable: parent.table_name,
               parentColumn: parentPK.column_name,
               type: 'real',
+              foreignKeyName: generateFkConstraintName(parent, child),
             };
             const rel2Args = {
               ...req.body,
@@ -415,6 +427,7 @@ export async function columnAdd(
               parentTable: child.table_name,
               parentColumn: childPK.column_name,
               type: 'real',
+              foreignKeyName: generateFkConstraintName(parent, child),
             };
 
             await sqlMgr.sqlOpPlus(base, 'relationCreate', rel1Args);

--- a/packages/nocodb/src/lib/meta/api/helpers/index.ts
+++ b/packages/nocodb/src/lib/meta/api/helpers/index.ts
@@ -1,3 +1,3 @@
-import { populateMeta } from "./populateMeta";
+import { populateMeta } from './populateMeta';
 
-export { populateMeta }
+export { populateMeta };

--- a/packages/nocodb/src/lib/meta/api/helpers/populateMeta.ts
+++ b/packages/nocodb/src/lib/meta/api/helpers/populateMeta.ts
@@ -5,7 +5,9 @@ import NcHelp from '../../../utils/NcHelp';
 import Base from '../../../models/Base';
 import View from '../../../models/View';
 import NcConnectionMgrv2 from '../../../utils/common/NcConnectionMgrv2';
-import getTableNameAlias, { getColumnNameAlias } from '../../helpers/getTableName';
+import getTableNameAlias, {
+  getColumnNameAlias,
+} from '../../helpers/getTableName';
 import LinkToAnotherRecordColumn from '../../../models/LinkToAnotherRecordColumn';
 import getColumnUiType from '../../helpers/getColumnUiType';
 import mapDefaultPrimaryValue from '../../helpers/mapDefaultPrimaryValue';
@@ -179,7 +181,7 @@ export async function populateMeta(base: Base, project: Project): Promise<any> {
               // column_id,
               fk_child_column_id: rel_column_id,
               fk_parent_column_id: ref_rel_column_id,
-              fk_index_name: rel.fkn,
+              fk_index_name: rel.cstn,
               ur: rel.ur,
               dr: rel.dr,
               order: colOrder++,
@@ -259,7 +261,7 @@ export async function populateMeta(base: Base, project: Project): Promise<any> {
   const models = await Model.list({ project_id: project.id, base_id: base.id });
 
   for (const model of models) {
-    const views = await model.getViews()
+    const views = await model.getViews();
     for (const view of views) {
       if (view.type === ViewTypes.GRID) {
         await View.fixPVColumnForView(view.id);

--- a/packages/nocodb/src/lib/meta/api/metaDiffApis.ts
+++ b/packages/nocodb/src/lib/meta/api/metaDiffApis.ts
@@ -107,6 +107,7 @@ type MetaDiffChange = {
       cn?: string;
       rcn?: string;
       relationType: RelationTypes;
+      cstn?: string;
     }
 );
 
@@ -146,6 +147,7 @@ async function getMetaDiff(
     cn: string;
     rcn: string;
     found?: any;
+    cstn?: string;
   }> = (await sqlClient.relationListAll())?.data?.list;
 
   for (const table of tableList) {
@@ -394,6 +396,7 @@ async function getMetaDiff(
           rcn: relation.rcn,
           msg: `New relation added`,
           relationType: RelationTypes.BELONGS_TO,
+          cstn: relation.cstn,
         });
     }
     if (!relation?.found?.[RelationTypes.HAS_MANY]) {
@@ -736,6 +739,7 @@ export async function metaDiffSync(req, res) {
                     fk_parent_column_id: parentCol.id,
                     fk_child_column_id: childCol.id,
                     virtual: false,
+                    fk_index_name: change.cstn,
                   });
                 } else if (change.relationType === RelationTypes.HAS_MANY) {
                   const title = getUniqueColumnAliasName(
@@ -751,6 +755,7 @@ export async function metaDiffSync(req, res) {
                     fk_parent_column_id: parentCol.id,
                     fk_child_column_id: childCol.id,
                     virtual: false,
+                    fk_index_name: change.cstn,
                   });
                 }
               });

--- a/packages/nocodb/src/lib/models/GridViewColumn.ts
+++ b/packages/nocodb/src/lib/models/GridViewColumn.ts
@@ -108,7 +108,7 @@ export default class GridViewColumn implements GridColumnType {
         [column.fk_view_id],
         `${CacheScope.GRID_VIEW_COLUMN}:${id}`
       );
-    
+
     await View.fixPVColumnForView(column.fk_view_id, ncMeta);
 
     return this.get(id, ncMeta);

--- a/packages/nocodb/src/lib/models/Model.ts
+++ b/packages/nocodb/src/lib/models/Model.ts
@@ -606,11 +606,16 @@ export default class Model implements TableType {
       newPvCol.id
     );
 
-    const grid_views_with_column = await ncMeta.metaList2(null, null, MetaTable.GRID_VIEW_COLUMNS, {
-      condition: {
-        fk_column_id: newPvCol.id,
+    const grid_views_with_column = await ncMeta.metaList2(
+      null,
+      null,
+      MetaTable.GRID_VIEW_COLUMNS,
+      {
+        condition: {
+          fk_column_id: newPvCol.id,
+        },
       }
-    })
+    );
 
     if (grid_views_with_column.length) {
       for (const gv of grid_views_with_column) {

--- a/packages/nocodb/src/lib/models/View.ts
+++ b/packages/nocodb/src/lib/models/View.ts
@@ -633,16 +633,26 @@ export default class View implements ViewType {
 
     // keep primary_value_column always visible and first in grid view
     if (view.type === ViewTypes.GRID) {
-      const primary_value_column_meta = await ncMeta.metaGet2(null, null, MetaTable.COLUMNS, {
-        fk_model_id: view.fk_model_id,
-        pv: true,
-      });
+      const primary_value_column_meta = await ncMeta.metaGet2(
+        null,
+        null,
+        MetaTable.COLUMNS,
+        {
+          fk_model_id: view.fk_model_id,
+          pv: true,
+        }
+      );
 
-      const primary_value_column = await ncMeta.metaGet2(null, null, MetaTable.GRID_VIEW_COLUMNS, {
-        fk_view_id: view.id,
-        fk_column_id: primary_value_column_meta.id,
-      });
-      
+      const primary_value_column = await ncMeta.metaGet2(
+        null,
+        null,
+        MetaTable.GRID_VIEW_COLUMNS,
+        {
+          fk_view_id: view.id,
+          fk_column_id: primary_value_column_meta.id,
+        }
+      );
+
       if (primary_value_column && primary_value_column.id === colId) {
         updateObj.order = 1;
         updateObj.show = true;
@@ -1108,14 +1118,19 @@ export default class View implements ViewType {
     const scope = this.extractViewColumnsTableNameScope(view);
 
     if (view.type === ViewTypes.GRID) {
-      const primary_value_column = await ncMeta.metaGet2(null, null, MetaTable.COLUMNS, {
-        fk_model_id: view.fk_model_id,
-        pv: true,
-      })
+      const primary_value_column = await ncMeta.metaGet2(
+        null,
+        null,
+        MetaTable.COLUMNS,
+        {
+          fk_model_id: view.fk_model_id,
+          pv: true,
+        }
+      );
 
       // keep primary_value_column always visible
       if (primary_value_column) {
-        ignoreColdIds.push(primary_value_column.id)
+        ignoreColdIds.push(primary_value_column.id);
       }
     }
 
@@ -1179,27 +1194,41 @@ export default class View implements ViewType {
 
   static async fixPVColumnForView(viewId, ncMeta = Noco.ncMeta) {
     // get a list of view columns sorted by order
-    const view_columns = await ncMeta.metaList2(null, null, MetaTable.GRID_VIEW_COLUMNS, {
-      condition: {
-        fk_view_id: viewId,
-      },
-      orderBy: {
-        order: 'asc',
-      },
-    });
-    const view_columns_meta = []
+    const view_columns = await ncMeta.metaList2(
+      null,
+      null,
+      MetaTable.GRID_VIEW_COLUMNS,
+      {
+        condition: {
+          fk_view_id: viewId,
+        },
+        orderBy: {
+          order: 'asc',
+        },
+      }
+    );
+    const view_columns_meta = [];
 
     // get column meta for each view column
     for (const col of view_columns) {
-      const col_meta = await ncMeta.metaGet2(null, null, MetaTable.COLUMNS, col.fk_column_id);
+      const col_meta = await ncMeta.metaGet2(
+        null,
+        null,
+        MetaTable.COLUMNS,
+        col.fk_column_id
+      );
       view_columns_meta.push(col_meta);
     }
 
     const primary_value_column_meta = view_columns_meta.find((col) => col.pv);
 
     if (primary_value_column_meta) {
-      const primary_value_column = view_columns.find((col) => col.fk_column_id === primary_value_column_meta.id);
-      const primary_value_column_index = view_columns.findIndex((col) => col.fk_column_id === primary_value_column_meta.id);
+      const primary_value_column = view_columns.find(
+        (col) => col.fk_column_id === primary_value_column_meta.id
+      );
+      const primary_value_column_index = view_columns.findIndex(
+        (col) => col.fk_column_id === primary_value_column_meta.id
+      );
       const view_orders = view_columns.map((col) => col.order);
       const view_min_order = Math.min(...view_orders);
 
@@ -1210,7 +1239,7 @@ export default class View implements ViewType {
           null,
           MetaTable.GRID_VIEW_COLUMNS,
           { show: true },
-          primary_value_column.id,
+          primary_value_column.id
         );
         await NocoCache.set(
           `${CacheScope.GRID_VIEW_COLUMN}:${primary_value_column.id}`,
@@ -1218,7 +1247,10 @@ export default class View implements ViewType {
         );
       }
 
-      if (primary_value_column.order === view_min_order && view_orders.filter((o) => o === view_min_order).length === 1) {
+      if (
+        primary_value_column.order === view_min_order &&
+        view_orders.filter((o) => o === view_min_order).length === 1
+      ) {
         // if primary_value_column is in first order do nothing
         return;
       } else {
@@ -1245,14 +1277,19 @@ export default class View implements ViewType {
       }
     }
 
-    const views = await ncMeta.metaList2(null, null, MetaTable.GRID_VIEW_COLUMNS, {
-      condition: {
-        fk_view_id: viewId,
-      },
-      orderBy: {
-        order: 'asc',
-      },
-    });
+    const views = await ncMeta.metaList2(
+      null,
+      null,
+      MetaTable.GRID_VIEW_COLUMNS,
+      {
+        condition: {
+          fk_view_id: viewId,
+        },
+        orderBy: {
+          order: 'asc',
+        },
+      }
+    );
     await NocoCache.setList(CacheScope.GRID_VIEW_COLUMN, [viewId], views);
   }
 }


### PR DESCRIPTION
## Change Summary

Populate a unique foreign key constraint name rather than relying on knex generated name.

re #4615

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
