### PR TITLE
fix: avoid synchronous calls on various places

### DIFF
--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -180,7 +180,7 @@ export default class Noco {
     log('Initializing app');
 
     // create tool directory if missing
-    mkdirp.sync(this.config.toolDir);
+    await mkdirp(this.config.toolDir);
 
     this.initSentry();
     NocoCache.init();

--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import fs from 'fs';
 import path from 'path';
+import { promisify } from 'util';
 
 import * as Sentry from '@sentry/node';
 import bodyParser from 'body-parser';
@@ -459,7 +460,7 @@ export default class Noco {
             connectionConfig.meta.dbAlias,
             'migrations'
           );
-          if (!fs.existsSync(migrationFolder)) {
+          if (!await promisify(fs.exists)(migrationFolder)) {
             await migrator.init({
               folder: this.config?.toolDir,
               env: this.env,

--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -114,32 +114,6 @@ export default class Noco {
     this.router = express.Router();
     this.projectRouter = express.Router();
 
-    /* prepare config */
-    Noco.config = this.config = NcConfigFactory.make();
-
-    /******************* setup : start *******************/
-    this.env = '_noco'; //process.env['NODE_ENV'] || this.config.workingEnv || 'dev';
-    this.config.workingEnv = this.env;
-
-    this.config.type = 'docker';
-    if (!this.config.toolDir) {
-      this.config.toolDir = process.cwd();
-    }
-
-    // this.ncToolApi = new NcToolGui(this.config);
-    // if (server) {
-    //   server.set('view engine', 'ejs');
-    // }
-
-    const NcMetaImpl = process.env.EE ? NcMetaImplEE : NcMetaImplCE;
-    // const NcMetaMgr = process.env.EE ? NcMetaMgrEE : NcMetaMgrCE;
-
-    Noco._ncMeta = new NcMetaImpl(this, this.config);
-    // this.metaMgr = new NcMetaMgr(this, this.config, Noco._ncMeta);
-    // this.metaMgrv2 = new NcMetaMgrv2(this, this.config, Noco._ncMeta);
-
-    /******************* setup : end *******************/
-
     /******************* prints : start *******************/
     // this.sumTable = new Table({
     //   head: ['#DBs', '#Tables',
@@ -169,6 +143,32 @@ export default class Noco {
     server?: http.Server,
     _app?: express.Express
   ) {
+    /* prepare config */
+    Noco.config = this.config = await NcConfigFactory.make();
+
+    /******************* setup : start *******************/
+    this.env = '_noco'; //process.env['NODE_ENV'] || this.config.workingEnv || 'dev';
+    this.config.workingEnv = this.env;
+
+    this.config.type = 'docker';
+    if (!this.config.toolDir) {
+      this.config.toolDir = process.cwd();
+    }
+
+    // this.ncToolApi = new NcToolGui(this.config);
+    // if (server) {
+    //   server.set('view engine', 'ejs');
+    // }
+
+    const NcMetaImpl = process.env.EE ? NcMetaImplEE : NcMetaImplCE;
+    // const NcMetaMgr = process.env.EE ? NcMetaMgrEE : NcMetaMgrCE;
+
+    Noco._ncMeta = new NcMetaImpl(this, this.config);
+    // this.metaMgr = new NcMetaMgr(this, this.config, Noco._ncMeta);
+    // this.metaMgrv2 = new NcMetaMgrv2(this, this.config, Noco._ncMeta);
+
+    /******************* setup : end *******************/
+
     // @ts-ignore
     const {
       progressCallback,
@@ -278,6 +278,7 @@ export default class Noco {
       instance: getInstance,
     });
     Tele.emit('evt_app_started', await User.count());
+    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
     weAreHiring();
     return this.router;
   }

--- a/packages/nocodb/src/lib/db/sql-client/lib/KnexClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/KnexClient.ts
@@ -586,27 +586,6 @@ class KnexClient extends SqlClient {
     if (connectionConfig.knex) {
       this.sqlClient = connectionConfig.knex;
     } else {
-      // console.log('KnexClient',this.connectionConfig);
-      if (
-        this.connectionConfig.connection.ssl &&
-        typeof this.connectionConfig.connection.ssl === 'object'
-      ) {
-        if (this.connectionConfig.connection.ssl.caFilePath) {
-          this.connectionConfig.connection.ssl.ca = fs
-            .readFileSync(this.connectionConfig.connection.ssl.caFilePath)
-            .toString();
-        }
-        if (this.connectionConfig.connection.ssl.keyFilePath) {
-          this.connectionConfig.connection.ssl.key = fs
-            .readFileSync(this.connectionConfig.connection.ssl.keyFilePath)
-            .toString();
-        }
-        if (this.connectionConfig.connection.ssl.certFilePath) {
-          this.connectionConfig.connection.ssl.cert = fs
-            .readFileSync(this.connectionConfig.connection.ssl.certFilePath)
-            .toString();
-        }
-      }
       const tmpConnectionConfig =
         connectionConfig.client === 'sqlite3'
           ? connectionConfig.connection
@@ -620,10 +599,10 @@ class KnexClient extends SqlClient {
     this.evt = new Emit();
   }
 
-  _validateInput() {
+  async _validateInput() {
     try {
       const packageJson = JSON.parse(
-        fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+        await promisify(fs.readFile)(path.join(process.cwd(), 'package.json'), 'utf8')
       );
       return (
         packageJson.name === 'nocodb' || 'nocodb' in packageJson.dependencies
@@ -632,10 +611,10 @@ class KnexClient extends SqlClient {
     return true;
   }
 
-  validateInput() {
+  async validateInput() {
     try {
       if (!('___ext' in KnexClient)) {
-        KnexClient.___ext = this._validateInput();
+        KnexClient.___ext = await this._validateInput();
       }
       if (!KnexClient.___ext) {
         Tele.emit('evt', {

--- a/packages/nocodb/src/lib/db/sql-client/lib/KnexClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/KnexClient.ts
@@ -2838,7 +2838,7 @@ class KnexClient extends SqlClient {
     console.log('in knex SeedInit');
 
     try {
-      mkdirp.sync(args.seedsFolder);
+      await mkdirp(args.seedsFolder);
     } catch (e) {
       log.ppe(e, _func);
       throw e;

--- a/packages/nocodb/src/lib/db/sql-client/lib/SqlClientFactory.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/SqlClientFactory.ts
@@ -9,6 +9,11 @@ import YugabyteClient from './pg/YugabyteClient';
 import TidbClient from './mysql/TidbClient';
 import VitessClient from './mysql/VitessClient';
 
+import fs from 'fs';
+import { promisify } from 'util';
+
+const readFileAsync = promisify(fs.readFile);
+
 export class SqlClientFactory {
   static create(connectionConfig) {
     connectionConfig.meta = connectionConfig.meta || {};
@@ -40,7 +45,28 @@ export class SqlClientFactory {
 }
 
 export default class {
-  static create(connectionConfig) {
+  static async create(connectionConfig) {
+    if (
+      connectionConfig.connection.ssl &&
+      typeof connectionConfig.connection.ssl === 'object'
+    ) {
+      if (connectionConfig.connection.ssl.caFilePath) {
+        connectionConfig.connection.ssl.ca = await readFileAsync(
+          connectionConfig.connection.ssl.caFilePath
+        ).toString();
+      }
+      if (connectionConfig.connection.ssl.keyFilePath) {
+        connectionConfig.connection.ssl.key = await readFileAsync(
+          connectionConfig.connection.ssl.keyFilePath
+        ).toString();
+      }
+      if (connectionConfig.connection.ssl.certFilePath) {
+        connectionConfig.connection.ssl.cert = await readFileAsync(
+          connectionConfig.connection.ssl.certFilePath
+        ).toString();
+      }
+    }
+
     if (Noco.isEE()) {
       return SqlClientFactoryEE.create(connectionConfig);
     }

--- a/packages/nocodb/src/lib/db/sql-client/lib/SqlClientFactory.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/SqlClientFactory.ts
@@ -12,8 +12,6 @@ import VitessClient from './mysql/VitessClient';
 import fs from 'fs';
 import { promisify } from 'util';
 
-const readFileAsync = promisify(fs.readFile);
-
 export class SqlClientFactory {
   static create(connectionConfig) {
     connectionConfig.meta = connectionConfig.meta || {};
@@ -51,17 +49,17 @@ export default class {
       typeof connectionConfig.connection.ssl === 'object'
     ) {
       if (connectionConfig.connection.ssl.caFilePath) {
-        connectionConfig.connection.ssl.ca = await readFileAsync(
+        connectionConfig.connection.ssl.ca = await promisify(fs.readFile)(
           connectionConfig.connection.ssl.caFilePath
         ).toString();
       }
       if (connectionConfig.connection.ssl.keyFilePath) {
-        connectionConfig.connection.ssl.key = await readFileAsync(
+        connectionConfig.connection.ssl.key = await promisify(fs.readFile)(
           connectionConfig.connection.ssl.keyFilePath
         ).toString();
       }
       if (connectionConfig.connection.ssl.certFilePath) {
-        connectionConfig.connection.ssl.cert = await readFileAsync(
+        connectionConfig.connection.ssl.cert = await promisify(fs.readFile)(
           connectionConfig.connection.ssl.certFilePath
         ).toString();
       }

--- a/packages/nocodb/src/lib/db/sql-client/lib/mysql/MysqlClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/mysql/MysqlClient.ts
@@ -1930,7 +1930,7 @@ class MysqlClient extends KnexClient {
     console.log('in mysql SeedInit');
 
     try {
-      mkdirp.sync(args.seedsFolder);
+      await mkdirp(args.seedsFolder);
 
       const seedSettings = path.join(args.seedsFolder, '__xseeds.json');
       await promisify(jsonfile.writeFile)(

--- a/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
@@ -152,7 +152,7 @@ export default class SqlMgr {
   //   return this._project;
   // }
   public async testConnection(args = {}) {
-    const client = SqlClientFactory.create(args);
+    const client = await SqlClientFactory.create(args);
     return client.testConnection();
   }
 
@@ -301,7 +301,7 @@ export default class SqlMgr {
           const connectionKey = `${env}_${this.currentProjectJson.envs[env].db[i].meta.dbAlias}`;
 
           this.currentProjectConnections[connectionKey] =
-            SqlClientFactory.create({
+            await SqlClientFactory.create({
               ...connectionConfig,
               knex: await NcConnectionMgr.get({
                 dbAlias: this.currentProjectJson.envs[env].db[i].meta.dbAlias,
@@ -361,7 +361,7 @@ export default class SqlMgr {
     }
 
     if ('client' in connectionConfig) {
-      const data = SqlClientFactory.create(connectionConfig);
+      const data = await SqlClientFactory.create(connectionConfig);
       this.currentProjectConnections[connectionKey] = data;
       // console.log(data);
       return data;

--- a/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
@@ -299,7 +299,7 @@ export default class SqlMgr {
           this.currentProjectConnections[connectionKey] =
             SqlClientFactory.create({
               ...connectionConfig,
-              knex: NcConnectionMgr.get({
+              knex: await NcConnectionMgr.get({
                 dbAlias: this.currentProjectJson.envs[env].db[i].meta.dbAlias,
                 env: env,
                 config: args,

--- a/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
+import { promisify } from 'util';
 
 import fsExtra from 'fs-extra';
 import importFresh from 'import-fresh';
@@ -18,6 +19,9 @@ import Debug from '../util/Debug';
 import Result from '../util/Result';
 const randomID = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz_', 20);
 const log = new Debug('SqlMgr');
+
+const writeFileAsync = promisify(fs.writeFile);
+const readFileAsync = promisify(fs.readFile);
 
 const ToolOps = {
   DB_TABLE_LIST: 'tableList',
@@ -1098,13 +1102,13 @@ export default class SqlMgr {
   public async projectChangeEnv(args) {
     try {
       const xcConfig = JSON.parse(
-        fs.readFileSync(
+        await readFileAsync(
           path.join(this.currentProjectFolder, 'config.xc.json'),
           'utf8'
         )
       );
       xcConfig.workingEnv = args.env;
-      fs.writeFileSync(
+      await writeFileAsync(
         path.join(this.currentProjectFolder, 'config.xc.json'),
         JSON.stringify(xcConfig, null, 2)
       );
@@ -1357,7 +1361,7 @@ export default class SqlMgr {
           break;
         case ToolOps.WRITE_FILE:
           console.log('Within WRITE_FILE handler', args);
-          result = fs.writeFileSync(args.args.path, args.args.data);
+          result = await writeFileAsync(args.args.path, args.args.data);
           break;
 
         case ToolOps.REST_API_CALL:

--- a/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/SqlMgr.ts
@@ -20,9 +20,6 @@ import Result from '../util/Result';
 const randomID = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz_', 20);
 const log = new Debug('SqlMgr');
 
-const writeFileAsync = promisify(fs.writeFile);
-const readFileAsync = promisify(fs.readFile);
-
 const ToolOps = {
   DB_TABLE_LIST: 'tableList',
   DB_VIEW_LIST: 'viewList',
@@ -443,7 +440,7 @@ export default class SqlMgr {
     console.log(args);
 
     try {
-      fs.unlinkSync(path.join(this.currentProjectFolder, 'config.xc.json'));
+      await promisify(fs.unlink)(path.join(this.currentProjectFolder, 'config.xc.json'));
 
       args.folder = args.folder || args.project.folder;
       args.folder = path.dirname(args.folder);
@@ -1102,13 +1099,13 @@ export default class SqlMgr {
   public async projectChangeEnv(args) {
     try {
       const xcConfig = JSON.parse(
-        await readFileAsync(
+        await promisify(fs.readFile)(
           path.join(this.currentProjectFolder, 'config.xc.json'),
           'utf8'
         )
       );
       xcConfig.workingEnv = args.env;
-      await writeFileAsync(
+      await promisify(fs.writeFile)(
         path.join(this.currentProjectFolder, 'config.xc.json'),
         JSON.stringify(xcConfig, null, 2)
       );
@@ -1361,7 +1358,7 @@ export default class SqlMgr {
           break;
         case ToolOps.WRITE_FILE:
           console.log('Within WRITE_FILE handler', args);
-          result = await writeFileAsync(args.args.path, args.args.data);
+          result = await promisify(fs.writeFile)(args.args.path, args.args.data);
           break;
 
         case ToolOps.REST_API_CALL:

--- a/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2.ts
@@ -119,6 +119,6 @@ export default class SqlMgrv2 {
   }
 
   protected async getSqlClient(base: Base): Promise<any> {
-    return await NcConnectionMgrv2.getSqlClient(base);
+    return NcConnectionMgrv2.getSqlClient(base);
   }
 }

--- a/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2.ts
@@ -29,11 +29,11 @@ export default class SqlMgrv2 {
     return this;
   }
 
-  public migrator(_base: Base) {
+  public async migrator(_base: Base) {
     return this._migrator;
   }
   public static async testConnection(args = {}) {
-    const client = SqlClientFactory.create(args);
+    const client = await SqlClientFactory.create(args);
     return client.testConnection();
   }
 
@@ -52,7 +52,7 @@ export default class SqlMgrv2 {
     log.api(`${func}:args:`, base, op, opArgs);
 
     // create sql client for this operation
-    const client = this.getSqlClient(base);
+    const client = await this.getSqlClient(base);
 
     // do sql operation
     const data = await client[op](opArgs);
@@ -75,7 +75,7 @@ export default class SqlMgrv2 {
     log.api(`${func}:args:`, base, op, opArgs);
 
     // create sql client for this operation
-    const sqlClient = this.getSqlClient(base); //await this.projectGetSqlClient(args);
+    const sqlClient = await this.getSqlClient(base); //await this.projectGetSqlClient(args);
 
     // do sql operation
     const sqlMigrationStatements = await sqlClient[op](opArgs);
@@ -118,7 +118,7 @@ export default class SqlMgrv2 {
     return sqlMigrationStatements;
   }
 
-  protected getSqlClient(base: Base) {
-    return NcConnectionMgrv2.getSqlClient(base);
+  protected async getSqlClient(base: Base): Promise<any> {
+    return await NcConnectionMgrv2.getSqlClient(base);
   }
 }

--- a/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2Trans.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2Trans.ts
@@ -53,7 +53,7 @@ export default class SqlMgrv2Trans extends SqlMgrv2 {
   }
 
   protected async getSqlClient(base: Base): Promise<any> {
-    return await NcConnectionMgrv2.getSqlClient(base, this.trx);
+    return NcConnectionMgrv2.getSqlClient(base, this.trx);
   }
 
   public async sqlOp(base: Base, op, opArgs): Promise<any> {

--- a/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2Trans.ts
+++ b/packages/nocodb/src/lib/db/sql-mgr/v2/SqlMgrv2Trans.ts
@@ -25,10 +25,10 @@ export default class SqlMgrv2Trans extends SqlMgrv2 {
     this.base = base;
   }
 
-  public migrator() {
+  public async migrator() {
     return new KnexMigratorv2Tans(
       { id: this.projectId },
-      this.getSqlClient(this.base),
+      await this.getSqlClient(this.base),
       this.ncMeta
     );
   }
@@ -52,8 +52,8 @@ export default class SqlMgrv2Trans extends SqlMgrv2 {
     }
   }
 
-  protected getSqlClient(base: Base) {
-    return NcConnectionMgrv2.getSqlClient(base, this.trx);
+  protected async getSqlClient(base: Base): Promise<any> {
+    return await NcConnectionMgrv2.getSqlClient(base, this.trx);
   }
 
   public async sqlOp(base: Base, op, opArgs): Promise<any> {

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigrator.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigrator.ts
@@ -381,7 +381,7 @@ export default class KnexMigrator extends SqlMigrator {
 
   async _initDbWithSql(connectionConfig) {
     const sqlClient =
-      connectionConfig.sqlClient || SqlClientFactory.create(connectionConfig);
+      connectionConfig.sqlClient || await SqlClientFactory.create(connectionConfig);
     if (connectionConfig.client === 'oracledb') {
       this.emit(
         `${connectionConfig.client}: Creating DB if not exists ${connectionConfig.connection.user}`
@@ -427,7 +427,7 @@ export default class KnexMigrator extends SqlMigrator {
   }
 
   async _cleanDbWithSql(connectionConfig) {
-    const sqlClient = SqlClientFactory.create(connectionConfig);
+    const sqlClient = await SqlClientFactory.create(connectionConfig);
     if (connectionConfig.client === 'oracledb') {
       this.emit(`Dropping DB : ${connectionConfig.connection.user}`);
       await sqlClient.dropDatabase({
@@ -567,7 +567,7 @@ export default class KnexMigrator extends SqlMigrator {
         args.dbAlias,
         args.env
       );
-      const sqlClient = args.sqlClient || SqlClientFactory.create(connection);
+      const sqlClient = args.sqlClient || await SqlClientFactory.create(connection);
 
       let migrations = await sqlClient.selectAll(
         sqlClient.getTnPath(connection.meta.tn)
@@ -820,7 +820,7 @@ export default class KnexMigrator extends SqlMigrator {
         args.dbAlias,
         args.env
       );
-      const sqlClient = SqlClientFactory.create(connection);
+      const sqlClient = await SqlClientFactory.create(connection);
       const migrations = await sqlClient.selectAll(
         sqlClient.getTnPath(connection.meta.tn)
       );

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigrator.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigrator.ts
@@ -309,7 +309,7 @@ export default class KnexMigrator extends SqlMigrator {
         await this._readProjectJson(projJsonFilePath);
         this.emit('Migrator for project initalised successfully');
       } else if (NcConfigFactory.hasDbUrl()) {
-        this.project = NcConfigFactory.make();
+        this.project = await NcConfigFactory.make();
       } else {
         args.type = args.type || 'sqlite';
 

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2.ts
@@ -429,7 +429,7 @@ export default class KnexMigratorv2 {
   }
 
   protected async getSqlClient(base: Base): Promise<any> {
-    return await NcConnectionMgrv2.getSqlClient(base);
+    return NcConnectionMgrv2.getSqlClient(base);
   }
 
   async _cleanDbWithSql(connectionConfig) {

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2.ts
@@ -382,7 +382,7 @@ export default class KnexMigratorv2 {
   // }
 
   async _initDbWithSql(base: Base) {
-    const sqlClient = this.getSqlClient(base);
+    const sqlClient = await this.getSqlClient(base);
     const connectionConfig = base.getConnectionConfig();
     if (connectionConfig.client === 'oracledb') {
       this.emit(
@@ -428,12 +428,12 @@ export default class KnexMigratorv2 {
     // }
   }
 
-  protected getSqlClient(base: Base) {
-    return NcConnectionMgrv2.getSqlClient(base);
+  protected async getSqlClient(base: Base): Promise<any> {
+    return await NcConnectionMgrv2.getSqlClient(base);
   }
 
   async _cleanDbWithSql(connectionConfig) {
-    const sqlClient = SqlClientFactory.create(connectionConfig);
+    const sqlClient = await SqlClientFactory.create(connectionConfig);
     if (connectionConfig.client === 'oracledb') {
       this.emit(`Dropping DB : ${connectionConfig.connection.user}`);
       await sqlClient.dropDatabase({
@@ -584,7 +584,7 @@ export default class KnexMigratorv2 {
       //   args.dbAlias,
       //   args.env
       // );
-      const sqlClient = this.getSqlClient(base);
+      const sqlClient = await this.getSqlClient(base);
 
       let migrations = await sqlClient.selectAll(
         // todo: replace
@@ -849,7 +849,7 @@ export default class KnexMigratorv2 {
       //   args.dbAlias,
       //   args.env
       // );
-      const sqlClient = this.getSqlClient(base); // SqlClientFactory.create(connection);
+      const sqlClient = await this.getSqlClient(base); // SqlClientFactory.create(connection);
       const migrations = await sqlClient.selectAll(
         sqlClient.getTnPath('nc_evolutions')
       );

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2Tans.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2Tans.ts
@@ -24,7 +24,7 @@ export default class KnexMigratorv2Tans extends KnexMigratorv2 {
   protected get metaDb(): XKnex {
     return this.ncMeta.knex || Noco.ncMeta.knex;
   }
-  protected getSqlClient(base: Base) {
-    return this.sqlClient || NcConnectionMgrv2.getSqlClient(base);
+  protected async getSqlClient(base: Base): Promise<any> {
+    return this.sqlClient || await NcConnectionMgrv2.getSqlClient(base);
   }
 }

--- a/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2Tans.ts
+++ b/packages/nocodb/src/lib/db/sql-migrator/lib/KnexMigratorv2Tans.ts
@@ -25,6 +25,6 @@ export default class KnexMigratorv2Tans extends KnexMigratorv2 {
     return this.ncMeta.knex || Noco.ncMeta.knex;
   }
   protected async getSqlClient(base: Base): Promise<any> {
-    return this.sqlClient || await NcConnectionMgrv2.getSqlClient(base);
+    return this.sqlClient || NcConnectionMgrv2.getSqlClient(base);
   }
 }

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -2904,9 +2904,9 @@ export default class NcMetaMgr {
     }
   }
 
-  protected async projectGetSqlClient(args) {
+  protected async projectGetSqlClient(args): Promise<any> {
     const builder = this.getBuilder(args);
-    return await builder?.getSqlClient();
+    return builder?.getSqlClient();
   }
 
   protected getBuilder(args): RestApiBuilder | GqlApiBuilder {
@@ -3441,7 +3441,7 @@ export default class NcMetaMgr {
 
   // @ts-ignore
   protected async getSqlClient(project_id: string, dbAlias: string) {
-    return await this.app?.projectBuilders
+    return this.app?.projectBuilders
       ?.find((pb) => pb?.id === project_id)
       ?.apiBuilders?.find((builder) => builder.dbAlias === dbAlias)
       ?.getSqlClient();

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -522,7 +522,7 @@ export default class NcMetaMgr {
 
         if (projectConfig?.prefix) {
           const metaProjConfig =
-            NcConfigFactory.makeProjectConfigFromConnection(
+            await NcConfigFactory.makeProjectConfigFromConnection(
               this.config?.meta?.db,
               args.args.projectType
             );
@@ -1605,7 +1605,7 @@ export default class NcMetaMgr {
           break;
         case 'projectCreateByOneClick':
           {
-            const config = NcConfigFactory.makeProjectConfigFromUrl(
+            const config = await NcConfigFactory.makeProjectConfigFromUrl(
               process.env.NC_DB,
               args.args.projectType
             );
@@ -1638,7 +1638,7 @@ export default class NcMetaMgr {
           break;
         case 'projectCreateByWebWithXCDB': {
           await this.checkIsUserAllowedToCreateProject(req);
-          const config = NcConfigFactory.makeProjectConfigFromConnection(
+          const config = await NcConfigFactory.makeProjectConfigFromConnection(
             this.config?.meta?.db,
             args.args.projectType
           );

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -702,7 +702,7 @@ export default class NcMetaMgr {
           'meta'
         );
 
-        mkdirp.sync(metaFolder);
+        await mkdirp(metaFolder);
 
         // const client = await this.projectGetSqlClient(args);
         const dbAlias = this.getDbAlias(args);

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -1554,7 +1554,7 @@ export default class NcMetaMgr {
           break;
 
         case 'testConnection':
-          result = await SqlClientFactory.create(args.args).testConnection();
+          result = await (await SqlClientFactory.create(args.args)).testConnection();
           break;
         case 'xcProjectGetConfig':
           result = await this.xcMeta.projectGetById(this.getProjectId(args));
@@ -2907,9 +2907,9 @@ export default class NcMetaMgr {
     }
   }
 
-  protected projectGetSqlClient(args) {
+  protected async projectGetSqlClient(args) {
     const builder = this.getBuilder(args);
-    return builder?.getSqlClient();
+    return await builder?.getSqlClient();
   }
 
   protected getBuilder(args): RestApiBuilder | GqlApiBuilder {
@@ -3443,8 +3443,8 @@ export default class NcMetaMgr {
   }
 
   // @ts-ignore
-  protected getSqlClient(project_id: string, dbAlias: string) {
-    return this.app?.projectBuilders
+  protected async getSqlClient(project_id: string, dbAlias: string) {
+    return await this.app?.projectBuilders
       ?.find((pb) => pb?.id === project_id)
       ?.apiBuilders?.find((builder) => builder.dbAlias === dbAlias)
       ?.getSqlClient();
@@ -4253,7 +4253,7 @@ export default class NcMetaMgr {
         return { data: { list: columns } };
       }
 
-      return this.projectGetSqlClient(args).columnList(args.args);
+      return (await this.projectGetSqlClient(args)).columnList(args.args);
     } catch (e) {
       throw e;
     }
@@ -4598,7 +4598,7 @@ export default class NcMetaMgr {
         {}
       );
 
-      const sqlClient = this.projectGetSqlClient(args);
+      const sqlClient = await this.projectGetSqlClient(args);
 
       switch (args.args.type) {
         case 'table':

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -47,6 +47,9 @@ const XC_PLUGIN_DET = 'XC_PLUGIN_DET';
 
 const NOCO_RELEASE = 'NOCO_RELEASE';
 
+const writeFileAsync = promisify(fs.writeFile);
+const readFileAsync = promisify(fs.readFile);
+
 export default class NcMetaMgr {
   public projectConfigs = {};
   public readonly pluginMgr: NcPluginMgr;
@@ -439,7 +442,7 @@ export default class NcMetaMgr {
       for (const tn of META_TABLES[this.config.projectType.toLowerCase()]) {
         if (fs.existsSync(path.join(metaFolder, `${tn}.json`))) {
           const data = JSON.parse(
-            fs.readFileSync(path.join(metaFolder, `${tn}.json`), 'utf8')
+            await readFileAsync(path.join(metaFolder, `${tn}.json`), 'utf8')
           );
           for (const row of data) {
             delete row.id;
@@ -495,7 +498,7 @@ export default class NcMetaMgr {
         throw new Error('Missing project config file');
       }
 
-      const projectDetailsJSON: any = fs.readFileSync(
+      const projectDetailsJSON: any = await readFileAsync(
         path.join(this.config.toolDir, 'uploads', projectConfigPath),
         'utf8'
       );
@@ -618,7 +621,7 @@ export default class NcMetaMgr {
 
       if (projectConfigPath) {
         // read project config and extract project id
-        let projectConfig: any = fs.readFileSync(
+        let projectConfig: any = await readFileAsync(
           path.join(this.config?.toolDir, projectConfigPath),
           'utf8'
         );
@@ -709,7 +712,7 @@ export default class NcMetaMgr {
         for (const tn of META_TABLES[this.config.projectType.toLowerCase()]) {
           // const metaData = await client.knex(tn).select();
           const metaData = await this.xcMeta.metaList(projectId, dbAlias, tn);
-          fs.writeFileSync(
+          await writeFileAsync(
             path.join(metaFolder, `${tn}.json`),
             JSON.stringify(metaData, null, 2)
           );
@@ -720,7 +723,7 @@ export default class NcMetaMgr {
           true
         );
         projectMetaData.key = this.config?.auth?.jwt?.secret;
-        fs.writeFileSync(
+        await writeFileAsync(
           path.join(metaFolder, `nc_project.json`),
           JSON.stringify(projectMetaData, null, 2)
         );

--- a/packages/nocodb/src/lib/meta/NcMetaMgr.ts
+++ b/packages/nocodb/src/lib/meta/NcMetaMgr.ts
@@ -47,9 +47,6 @@ const XC_PLUGIN_DET = 'XC_PLUGIN_DET';
 
 const NOCO_RELEASE = 'NOCO_RELEASE';
 
-const writeFileAsync = promisify(fs.writeFile);
-const readFileAsync = promisify(fs.readFile);
-
 export default class NcMetaMgr {
   public projectConfigs = {};
   public readonly pluginMgr: NcPluginMgr;
@@ -440,9 +437,9 @@ export default class NcMetaMgr {
       await this.xcMetaTablesReset(args);
 
       for (const tn of META_TABLES[this.config.projectType.toLowerCase()]) {
-        if (fs.existsSync(path.join(metaFolder, `${tn}.json`))) {
+        if (await promisify(fs.exists)(path.join(metaFolder, `${tn}.json`))) {
           const data = JSON.parse(
-            await readFileAsync(path.join(metaFolder, `${tn}.json`), 'utf8')
+            await promisify(fs.readFile)(path.join(metaFolder, `${tn}.json`), 'utf8')
           );
           for (const row of data) {
             delete row.id;
@@ -491,14 +488,14 @@ export default class NcMetaMgr {
         },
       });
       // delete temporary upload file
-      fs.unlinkSync(file.path);
+      await promisify(fs.unlink)(file.path);
 
       let projectId = this.getProjectId(args);
       if (!projectConfigPath) {
         throw new Error('Missing project config file');
       }
 
-      const projectDetailsJSON: any = await readFileAsync(
+      const projectDetailsJSON: any = await promisify(fs.readFile)(
         path.join(this.config.toolDir, 'uploads', projectConfigPath),
         'utf8'
       );
@@ -617,11 +614,11 @@ export default class NcMetaMgr {
         },
       });
       // delete temporary upload file
-      fs.unlinkSync(file.path);
+      await promisify(fs.unlink)(file.path);
 
       if (projectConfigPath) {
         // read project config and extract project id
-        let projectConfig: any = await readFileAsync(
+        let projectConfig: any = await promisify(fs.readFile)(
           path.join(this.config?.toolDir, projectConfigPath),
           'utf8'
         );
@@ -712,7 +709,7 @@ export default class NcMetaMgr {
         for (const tn of META_TABLES[this.config.projectType.toLowerCase()]) {
           // const metaData = await client.knex(tn).select();
           const metaData = await this.xcMeta.metaList(projectId, dbAlias, tn);
-          await writeFileAsync(
+          await promisify(fs.writeFile)(
             path.join(metaFolder, `${tn}.json`),
             JSON.stringify(metaData, null, 2)
           );
@@ -723,7 +720,7 @@ export default class NcMetaMgr {
           true
         );
         projectMetaData.key = this.config?.auth?.jwt?.secret;
-        await writeFileAsync(
+        await promisify(fs.writeFile)(
           path.join(metaFolder, `nc_project.json`),
           JSON.stringify(projectMetaData, null, 2)
         );

--- a/packages/nocodb/src/lib/meta/api/baseApis.ts
+++ b/packages/nocodb/src/lib/meta/api/baseApis.ts
@@ -119,7 +119,7 @@ async function populateMeta(base: Base, project: Project): Promise<any> {
   };
 
   const t = process.hrtime();
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
   let order = 1;
   const models2: { [tableName: string]: Model } = {};
 

--- a/packages/nocodb/src/lib/meta/api/columnApis.ts
+++ b/packages/nocodb/src/lib/meta/api/columnApis.ts
@@ -674,7 +674,7 @@ export async function columnAdd(
           ],
         };
 
-        const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+        const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
         const sqlMgr = await ProjectMgrv2.getSqlMgr({ id: base.project_id });
         await sqlMgr.sqlOpPlus(base, 'tableUpdate', tableUpdateBody);
 

--- a/packages/nocodb/src/lib/meta/api/metaDiffApis.ts
+++ b/packages/nocodb/src/lib/meta/api/metaDiffApis.ts
@@ -548,7 +548,7 @@ export async function metaDiff(req, res) {
   for (const base of project.bases) {
     try {
       // @ts-ignore
-      const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+      const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
       changes = changes.concat(await getMetaDiff(sqlClient, project, base));
     } catch (e) {
       console.log(e);
@@ -563,7 +563,7 @@ export async function baseMetaDiff(req, res) {
   const base = await Base.get(req.params.baseId);
   let changes = [];
 
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
   changes = await getMetaDiff(sqlClient, project, base);
 
   res.json(changes);
@@ -575,7 +575,7 @@ export async function metaDiffSync(req, res) {
     const virtualColumnInsert: Array<() => Promise<void>> = [];
 
     // @ts-ignore
-    const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+    const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
     const changes = await getMetaDiff(sqlClient, project, base);
 
     /* Get all relations */
@@ -778,7 +778,7 @@ export async function baseMetaDiffSync(req, res) {
   const virtualColumnInsert: Array<() => Promise<void>> = [];
 
   // @ts-ignore
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
   const changes = await getMetaDiff(sqlClient, project, base);
 
   /* Get all relations */

--- a/packages/nocodb/src/lib/meta/api/projectApis.ts
+++ b/packages/nocodb/src/lib/meta/api/projectApis.ts
@@ -27,6 +27,7 @@ import { extractAndGenerateManyToManyRelations } from './metaDiffApis';
 import { metaApiMetrics } from '../helpers/apiMetrics';
 import { extractPropsAndSanitize } from '../helpers/extractProps';
 import NcConfigFactory from '../../utils/NcConfigFactory';
+import { promisify } from 'util';
 
 const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz_', 4);
 
@@ -121,8 +122,8 @@ async function projectCreate(req: Request<any, any>, res) {
         '1234567890abcdefghijklmnopqrstuvwxyz',
         14
       );
-      if (!fs.existsSync(`${toolDir}/nc_minimal_dbs`)) {
-        fs.mkdirSync(`${toolDir}/nc_minimal_dbs`);
+      if (!await promisify(fs.exists)(`${toolDir}/nc_minimal_dbs`)) {
+        await promisify(fs.mkdir)(`${toolDir}/nc_minimal_dbs`);
       }
       const dbId = nanoidv2();
       const projectTitle = DOMPurify.sanitize(projectBody.title);

--- a/packages/nocodb/src/lib/meta/api/projectApis.ts
+++ b/packages/nocodb/src/lib/meta/api/projectApis.ts
@@ -213,7 +213,7 @@ async function populateMeta(base: Base, project: Project): Promise<any> {
   };
 
   const t = process.hrtime();
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
   let order = 1;
   const models2: { [tableName: string]: Model } = {};
 
@@ -467,7 +467,7 @@ export async function projectCost(req, res) {
   const project = await Project.getWithInfo(req.params.projectId);
 
   for (const base of project.bases) {
-    const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+    const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
     const userCount = await ProjectUser.getUsersCount(req.query);
     const recordCount = (await sqlClient.totalRecords())?.data.TotalRecords;
 

--- a/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
+++ b/packages/nocodb/src/lib/meta/api/sync/helpers/job.ts
@@ -8,6 +8,7 @@ import { Api } from 'nocodb-sdk';
 import Airtable from 'airtable';
 import jsonfile from 'jsonfile';
 import hash from 'object-hash';
+import { promisify } from 'util';
 
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -15,6 +16,8 @@ import tinycolor from 'tinycolor2';
 import { importData, importLTARData } from './readAndProcessData';
 
 import EntityMap from './EntityMap';
+
+const writeJsonFileAsync = promisify(jsonfile.writeFile);
 
 dayjs.extend(utc);
 
@@ -204,7 +207,7 @@ export default async (
     // store copy of airtable schema globally
     g_aTblSchema = file.tableSchemas;
 
-    if (debugMode) jsonfile.writeFileSync('aTblSchema.json', ft, { spaces: 2 });
+    if (debugMode) await writeJsonFileAsync('aTblSchema.json', ft, { spaces: 2 });
 
     return file;
   }
@@ -216,7 +219,7 @@ export default async (
     rtc.fetchAt.count++;
     rtc.fetchAt.time += duration;
 
-    if (debugMode) jsonfile.writeFileSync(`${viewId}.json`, ft, { spaces: 2 });
+    if (debugMode) await writeJsonFileAsync(`${viewId}.json`, ft, { spaces: 2 });
     return ft.view;
   }
 
@@ -1917,13 +1920,13 @@ export default async (
     logBasic(`:: Axios fetch time:    ${rtc.fetchAt.time}`);
 
     if (debugMode) {
-      jsonfile.writeFileSync('stats.json', perfStats, { spaces: 2 });
+      await writeJsonFileAsync('stats.json', perfStats, { spaces: 2 });
       const perflog = [];
       for (let i = 0; i < perfStats.length; i++) {
         perflog.push(`${perfStats[i].e}, ${perfStats[i].d}`);
       }
-      jsonfile.writeFileSync('stats.csv', perflog, { spaces: 2 });
-      jsonfile.writeFileSync('skip.txt', rtc.migrationSkipLog.log, {
+      await writeJsonFileAsync('stats.csv', perflog, { spaces: 2 });
+      await writeJsonFileAsync('skip.txt', rtc.migrationSkipLog.log, {
         spaces: 2,
       });
     }

--- a/packages/nocodb/src/lib/meta/api/tableApis.ts
+++ b/packages/nocodb/src/lib/meta/api/tableApis.ts
@@ -148,7 +148,7 @@ export async function tableCreate(req: Request<any, any, TableReqType>, res) {
   }
 
   const sqlMgr = await ProjectMgrv2.getSqlMgr(project);
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
 
   let tableNameLengthLimit = 255;
   const sqlClientType = sqlClient.clientType;
@@ -295,7 +295,7 @@ export async function tableUpdate(req: Request<any, any>, res) {
   }
 
   const sqlMgr = await ProjectMgrv2.getSqlMgr(project);
-  const sqlClient = NcConnectionMgrv2.getSqlClient(base);
+  const sqlClient = await NcConnectionMgrv2.getSqlClient(base);
 
   let tableNameLengthLimit = 255;
   const sqlClientType = sqlClient.clientType;

--- a/packages/nocodb/src/lib/meta/api/utilApis.ts
+++ b/packages/nocodb/src/lib/meta/api/utilApis.ts
@@ -320,8 +320,8 @@ export async function aggregatedMetaInfo(_req: Request, res: Response) {
               project.getBases().then(async (bases) => {
                 return extractResultOrNull(
                   await Promise.allSettled(
-                    bases.map((base) =>
-                      NcConnectionMgrv2.getSqlClient(base)
+                    bases.map(async (base) =>
+                      (await NcConnectionMgrv2.getSqlClient(base))
                         .totalRecords?.()
                         ?.then((result) => result?.data)
                     )

--- a/packages/nocodb/src/lib/meta/handlers/xcMetaDiff.ts
+++ b/packages/nocodb/src/lib/meta/handlers/xcMetaDiff.ts
@@ -42,7 +42,7 @@ export default async function (
   const builder = this.getBuilder(args);
 
   // @ts-ignore
-  const sqlClient = this.projectGetSqlClient(args);
+  const sqlClient = await this.projectGetSqlClient(args);
 
   // @ts-ignore
   const tableList = (await sqlClient.tableList())?.data?.list?.filter((t) => {

--- a/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
+++ b/packages/nocodb/src/lib/plugins/backblaze/Backblaze.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -132,7 +133,7 @@ export default class Backblaze implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/gcs/Gcs.ts
+++ b/packages/nocodb/src/lib/plugins/gcs/Gcs.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import { Storage, StorageOptions } from '@google-cloud/storage';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -96,7 +97,7 @@ export default class Gcs implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/linode/LinodeObjectStorage.ts
+++ b/packages/nocodb/src/lib/plugins/linode/LinodeObjectStorage.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -122,7 +123,7 @@ export default class LinodeObjectStorage implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/mino/Minio.ts
+++ b/packages/nocodb/src/lib/plugins/mino/Minio.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import { Client as MinioClient } from 'minio';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -84,7 +85,7 @@ export default class Minio implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/ovhCloud/OvhCloud.ts
+++ b/packages/nocodb/src/lib/plugins/ovhCloud/OvhCloud.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -122,7 +123,7 @@ export default class OvhCloud implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/s3/S3.ts
+++ b/packages/nocodb/src/lib/plugins/s3/S3.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -125,7 +126,7 @@ export default class S3 implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/scaleway/ScalewayObjectStorage.ts
+++ b/packages/nocodb/src/lib/plugins/scaleway/ScalewayObjectStorage.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import AWS from 'aws-sdk';
 import request from 'request';
@@ -40,7 +41,7 @@ export default class ScalewayObjectStorage implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/spaces/Spaces.ts
+++ b/packages/nocodb/src/lib/plugins/spaces/Spaces.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -130,7 +131,7 @@ export default class Spaces implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/upcloud/UpoCloud.ts
+++ b/packages/nocodb/src/lib/plugins/upcloud/UpoCloud.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -120,7 +121,7 @@ export default class UpoCloud implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/plugins/vultr/Vultr.ts
+++ b/packages/nocodb/src/lib/plugins/vultr/Vultr.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { promisify } from 'util';
 import AWS from 'aws-sdk';
 import { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import request from 'request';
@@ -122,7 +123,7 @@ export default class Vultr implements IStorageAdapterV2 {
         originalname: 'temp.txt',
         size: '',
       });
-      fs.unlinkSync(tempFile);
+      await promisify(fs.unlink)(tempFile);
       return true;
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/utils/NcConfigFactory.ts
+++ b/packages/nocodb/src/lib/utils/NcConfigFactory.ts
@@ -19,8 +19,6 @@ const {
   animals,
 } = require('unique-names-generator');
 
-const readFileAsync = promisify(fs.readFile);
-
 const driverClientMapping = {
   mysql: 'mysql2',
   mariadb: 'mysql2',
@@ -124,11 +122,11 @@ export default class NcConfigFactory implements NcConfig {
     } else if (process.env.NC_DB_JSON_FILE) {
       const filePath = process.env.NC_DB_JSON_FILE;
 
-      if (!fs.existsSync(filePath)) {
+      if (!await promisify(fs.exists)(filePath)) {
         throw new Error(`NC_DB_JSON_FILE not found: ${filePath}`);
       }
 
-      const fileContent = await readFileAsync(filePath, { encoding: 'utf8' });
+      const fileContent = await promisify(fs.readFile)(filePath, { encoding: 'utf8' });
       ncConfig.meta.db = JSON.parse(fileContent);
     }
 
@@ -381,12 +379,12 @@ export default class NcConfigFactory implements NcConfig {
       typeof dbConfig?.connection?.ssl === 'object'
     ) {
       if (dbConfig.connection.ssl.caFilePath && !dbConfig.connection.ssl.ca) {
-        dbConfig.connection.ssl.ca = await readFileAsync(
+        dbConfig.connection.ssl.ca = await promisify(fs.readFile)(
           dbConfig.connection.ssl.caFilePath
         ).toString();
       }
       if (dbConfig.connection.ssl.keyFilePath && !dbConfig.connection.ssl.key) {
-        dbConfig.connection.ssl.key = await readFileAsync(
+        dbConfig.connection.ssl.key = await promisify(fs.readFile)(
           dbConfig.connection.ssl.keyFilePath
         ).toString();
       }
@@ -394,7 +392,7 @@ export default class NcConfigFactory implements NcConfig {
         dbConfig.connection.ssl.certFilePath &&
         !dbConfig.connection.ssl.cert
       ) {
-        dbConfig.connection.ssl.cert = await readFileAsync(
+        dbConfig.connection.ssl.cert = await promisify(fs.readFile)(
           dbConfig.connection.ssl.certFilePath
         ).toString();
       }
@@ -642,7 +640,7 @@ export default class NcConfigFactory implements NcConfig {
 
   public static async jdbcToXcUrl() {
     if (process.env.NC_DATABASE_URL_FILE || process.env.DATABASE_URL_FILE) {
-      const database_url = await readFileAsync(
+      const database_url = await promisify(fs.readFile)(
         process.env.NC_DATABASE_URL_FILE || process.env.DATABASE_URL_FILE,
         'utf-8'
       );

--- a/packages/nocodb/src/lib/utils/NcConfigFactory.ts
+++ b/packages/nocodb/src/lib/utils/NcConfigFactory.ts
@@ -584,7 +584,7 @@ export default class NcConfigFactory implements NcConfig {
 
   public static async metaDbCreateIfNotExist(args: NcConfig) {
     if (args.meta?.db?.client === 'sqlite3') {
-      const metaSqlClient = SqlClientFactory.create({
+      const metaSqlClient = await SqlClientFactory.create({
         ...args.meta.db,
         connection: args.meta.db,
       });
@@ -592,7 +592,7 @@ export default class NcConfigFactory implements NcConfig {
         database: args.meta.db?.connection?.filename,
       });
     } else {
-      const metaSqlClient = SqlClientFactory.create(args.meta.db);
+      const metaSqlClient = await SqlClientFactory.create(args.meta.db);
       await metaSqlClient.createDatabaseIfNotExists(args.meta.db?.connection);
       await metaSqlClient.knex.destroy();
     }

--- a/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
+++ b/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
@@ -188,7 +188,7 @@ export default abstract class BaseApiBuilder<T extends Noco>
   }
 
   public async getSqlClient(): Promise<any> {
-    return await NcConnectionMgr.getSqlClient({
+    return NcConnectionMgr.getSqlClient({
       dbAlias: this.dbAlias,
       env: this.config.env,
       config: this.config,

--- a/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
+++ b/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
@@ -187,8 +187,8 @@ export default abstract class BaseApiBuilder<T extends Noco>
     return this.connectionConfig?.meta?.dbAlias;
   }
 
-  public getSqlClient(): any {
-    return NcConnectionMgr.getSqlClient({
+  public async getSqlClient(): Promise<any> {
+    return await NcConnectionMgr.getSqlClient({
       dbAlias: this.dbAlias,
       env: this.config.env,
       config: this.config,
@@ -1676,7 +1676,7 @@ export default abstract class BaseApiBuilder<T extends Noco>
       config: this.config,
       projectId: this.projectId,
     });
-    this.sqlClient = NcConnectionMgr.getSqlClient({
+    this.sqlClient = await NcConnectionMgr.getSqlClient({
       dbAlias: this.dbAlias,
       env: this.config.env,
       config: this.config,
@@ -3064,7 +3064,7 @@ export default abstract class BaseApiBuilder<T extends Noco>
     );
     const colListRef = {};
     const tableList =
-      (await this.getSqlClient()?.tableList())?.data?.list || [];
+      (await (await this.getSqlClient())?.tableList())?.data?.list || [];
 
     colListRef[tableName] = await this.getColumnList(tableName);
 

--- a/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
+++ b/packages/nocodb/src/lib/utils/common/BaseApiBuilder.ts
@@ -1291,8 +1291,8 @@ export default abstract class BaseApiBuilder<T extends Noco>
     this.models[viewName] = this.getBaseModel(newMeta);
   }
 
-  public getDbDriver(): XKnex {
-    this.initDbDriver();
+  public async getDbDriver(): Promise<XKnex> {
+    await this.initDbDriver();
     return this.dbDriver;
   }
 
@@ -1669,8 +1669,8 @@ export default abstract class BaseApiBuilder<T extends Noco>
     await this.cronJob.init();
   }
 
-  protected initDbDriver(): void {
-    this.dbDriver = NcConnectionMgr.get({
+  protected async initDbDriver(): Promise<void> {
+    this.dbDriver = await NcConnectionMgr.get({
       dbAlias: this.dbAlias,
       env: this.config.env,
       config: this.config,

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
@@ -156,7 +156,7 @@ export default class NcConnectionMgr {
       config,
       projectId,
     });
-    return await SqlClientFactory.create({
+    return SqlClientFactory.create({
       knex,
       ...this.getConnectionConfig(config, env, dbAlias),
     });

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
@@ -8,8 +8,6 @@ import { Knex } from 'knex';
 import NcMetaIO from '../../meta/NcMetaIO';
 import { defaultConnectionConfig } from '../NcConfigFactory';
 
-const readFileAsync = promisify(fs.readFile);
-
 export default class NcConnectionMgr {
   private static connectionRefs: {
     [projectId: string]: {
@@ -76,7 +74,7 @@ export default class NcConnectionMgr {
           connectionConfig.connection.ssl.caFilePath &&
           !connectionConfig.connection.ssl.ca
         ) {
-          connectionConfig.connection.ssl.ca = await readFileAsync(
+          connectionConfig.connection.ssl.ca = await promisify(fs.readFile)(
             connectionConfig.connection.ssl.caFilePath
           ).toString();
         }
@@ -84,7 +82,7 @@ export default class NcConnectionMgr {
           connectionConfig.connection.ssl.keyFilePath &&
           !connectionConfig.connection.ssl.key
         ) {
-          connectionConfig.connection.ssl.key = await readFileAsync(
+          connectionConfig.connection.ssl.key = await promisify(fs.readFile)(
             connectionConfig.connection.ssl.keyFilePath
           ).toString();
         }
@@ -92,7 +90,7 @@ export default class NcConnectionMgr {
           connectionConfig.connection.ssl.certFilePath &&
           !connectionConfig.connection.ssl.cert
         ) {
-          connectionConfig.connection.ssl.cert = await readFileAsync(
+          connectionConfig.connection.ssl.cert = await promisify(fs.readFile)(
             connectionConfig.connection.ssl.certFilePath
           ).toString();
         }

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
@@ -141,7 +141,7 @@ export default class NcConnectionMgr {
     return config?.envs?.[env]?.db?.find((db) => db?.meta?.dbAlias === dbAlias);
   }
 
-  public static getSqlClient({
+  public static async getSqlClient({
     projectId,
     dbAlias = 'db',
     env = '_noco',
@@ -151,14 +151,14 @@ export default class NcConnectionMgr {
     env: string;
     config: NcConfig;
     projectId: string;
-  }): any {
+  }): Promise<any> {
     const knex = this.get({
       dbAlias,
       env,
       config,
       projectId,
     });
-    return SqlClientFactory.create({
+    return await SqlClientFactory.create({
       knex,
       ...this.getConnectionConfig(config, env, dbAlias),
     });

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgr.ts
@@ -2,10 +2,13 @@ import SqlClientFactory from '../../db/sql-client/lib/SqlClientFactory';
 import { XKnex } from '../../db/sql-data-mapper';
 import { NcConfig } from '../../../interface/config';
 import fs from 'fs';
+import { promisify } from 'util';
 import { Knex } from 'knex';
 
 import NcMetaIO from '../../meta/NcMetaIO';
 import { defaultConnectionConfig } from '../NcConfigFactory';
+
+const readFileAsync = promisify(fs.readFile);
 
 export default class NcConnectionMgr {
   private static connectionRefs: {
@@ -43,7 +46,7 @@ export default class NcConnectionMgr {
     }
   }
 
-  public static get({
+  public static async get({
     dbAlias = 'db',
     env = '_noco',
     config,
@@ -53,7 +56,7 @@ export default class NcConnectionMgr {
     env: string;
     config: NcConfig;
     projectId: string;
-  }): XKnex {
+  }): Promise<XKnex> {
     if (this.connectionRefs?.[projectId]?.[env]?.[dbAlias]) {
       return this.connectionRefs?.[projectId]?.[env]?.[dbAlias];
     }
@@ -73,25 +76,25 @@ export default class NcConnectionMgr {
           connectionConfig.connection.ssl.caFilePath &&
           !connectionConfig.connection.ssl.ca
         ) {
-          connectionConfig.connection.ssl.ca = fs
-            .readFileSync(connectionConfig.connection.ssl.caFilePath)
-            .toString();
+          connectionConfig.connection.ssl.ca = await readFileAsync(
+            connectionConfig.connection.ssl.caFilePath
+          ).toString();
         }
         if (
           connectionConfig.connection.ssl.keyFilePath &&
           !connectionConfig.connection.ssl.key
         ) {
-          connectionConfig.connection.ssl.key = fs
-            .readFileSync(connectionConfig.connection.ssl.keyFilePath)
-            .toString();
+          connectionConfig.connection.ssl.key = await readFileAsync(
+            connectionConfig.connection.ssl.keyFilePath
+          ).toString();
         }
         if (
           connectionConfig.connection.ssl.certFilePath &&
           !connectionConfig.connection.ssl.cert
         ) {
-          connectionConfig.connection.ssl.cert = fs
-            .readFileSync(connectionConfig.connection.ssl.certFilePath)
-            .toString();
+          connectionConfig.connection.ssl.cert = await readFileAsync(
+            connectionConfig.connection.ssl.certFilePath
+          ).toString();
         }
       }
 

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgrv2.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgrv2.ts
@@ -151,7 +151,7 @@ export default class NcConnectionMgrv2 {
 
   public static async getSqlClient(base: Base, _knex = null): Promise<any> {
     const knex = _knex || this.get(base);
-    return await SqlClientFactory.create({
+    return SqlClientFactory.create({
       knex,
       ...base.getConnectionConfig(),
     });

--- a/packages/nocodb/src/lib/utils/common/NcConnectionMgrv2.ts
+++ b/packages/nocodb/src/lib/utils/common/NcConnectionMgrv2.ts
@@ -149,9 +149,9 @@ export default class NcConnectionMgrv2 {
   //   return config?.envs?.[env]?.db?.find(db => db?.meta?.dbAlias === dbAlias);
   // }
 
-  public static getSqlClient(base: Base, _knex = null): any {
+  public static async getSqlClient(base: Base, _knex = null): Promise<any> {
     const knex = _knex || this.get(base);
-    return SqlClientFactory.create({
+    return await SqlClientFactory.create({
       knex,
       ...base.getConnectionConfig(),
     });

--- a/packages/nocodb/src/lib/utils/common/XcProcedure.ts
+++ b/packages/nocodb/src/lib/utils/common/XcProcedure.ts
@@ -10,8 +10,8 @@ export default class XcProcedure {
   public async callFunction(name: string, args: any[]) {
     try {
       if (this.builder.getDbType() === 'mssql') {
-        const result = await this.builder
-          .getDbDriver()
+        const result = await (await this.builder
+          .getDbDriver())
           .raw(
             `select dbo.??(${new Array(args.length)
               .fill('?')
@@ -20,8 +20,8 @@ export default class XcProcedure {
           );
         return result[0];
       } else {
-        const result = await this.builder
-          .getDbDriver()
+        const result = await (await this.builder
+          .getDbDriver())
           .raw(
             `select ??(${new Array(args.length).fill('?').join(',')}) as ??`,
             [name, ...args, name]
@@ -65,7 +65,7 @@ export default class XcProcedure {
       ) {
         const knexRef = args.reduce(
           (knex, val, i) => knex.raw(`SET @var${i}=?`, [val]),
-          this.builder.getDbDriver().schema
+          (await this.builder.getDbDriver()).schema
         );
         const count = args.length;
         const result = await knexRef.raw(
@@ -76,8 +76,8 @@ export default class XcProcedure {
         );
         return [result[count][0][0]];
       } else if (this.builder.getDbType() === 'pg') {
-        const result = await this.builder
-          .getDbDriver()
+        const result = await (await this.builder
+          .getDbDriver())
           .raw(`Call ??(${new Array(args.length).fill('?').join(',')})`, [
             name,
             ...args,

--- a/packages/nocodb/src/lib/utils/common/handlers/xcMetaDiffSync.ts
+++ b/packages/nocodb/src/lib/utils/common/handlers/xcMetaDiffSync.ts
@@ -10,8 +10,8 @@ import { GqlApiBuilder } from '../../../v1-legacy/gql/GqlApiBuilder';
 export default async function (this: BaseApiBuilder<any> | any) {
   const changes: Array<NcMetaDiffType> = await xcMetaDiff.call(
     {
-      projectGetSqlClient: () => {
-        return this.getSqlClient();
+      projectGetSqlClient: async () => {
+        return await this.getSqlClient();
       },
       getProjectId: () => this.getProjectId(),
       getDbAlias: () => this.getDbAlias(),
@@ -57,7 +57,7 @@ export default async function (this: BaseApiBuilder<any> | any) {
       return true;
     });
   // @ts-ignore
-  const relationList = (await this.getSqlClient().tableList())?.data?.list;
+  const relationList = (await (await this.getSqlClient()).tableList())?.data?.list;
 
   const oldModels = await this.xcMeta.metaList(
     this.getProjectId(),

--- a/packages/nocodb/src/lib/v1-legacy/NcProjectBuilder.ts
+++ b/packages/nocodb/src/lib/v1-legacy/NcProjectBuilder.ts
@@ -626,7 +626,7 @@ export default class NcProjectBuilder {
         i++;
       } else if (db.meta?.allSchemas) {
         /* get all schemas and create APIs for all of them */
-        const sqlClient = SqlClientFactory.create({
+        const sqlClient = await SqlClientFactory.create({
           ...db,
           connection: { ...db.connection, database: undefined },
         });
@@ -697,7 +697,7 @@ export default class NcProjectBuilder {
 
       for (const connectionConfig of dbs) {
         try {
-          const sqlClient = NcConnectionMgr.getSqlClient({
+          const sqlClient = await NcConnectionMgr.getSqlClient({
             dbAlias: connectionConfig?.meta?.dbAlias,
             env: this.config.env,
             config: this.config,

--- a/packages/nocodb/src/lib/v1-legacy/NcProjectBuilder.ts
+++ b/packages/nocodb/src/lib/v1-legacy/NcProjectBuilder.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { promisify } from 'util';
 
 import axios from 'axios';
 import { Router } from 'express';
@@ -718,7 +719,7 @@ export default class NcProjectBuilder {
             connectionConfig.meta.dbAlias,
             'migrations'
           );
-          if (!fs.existsSync(migrationFolder)) {
+          if (!await promisify(fs.exists)(migrationFolder)) {
             await migrator.init({
               folder: this.app.getToolDir(),
               env: this.appConfig.workingEnv,

--- a/packages/nocodb/src/lib/v1-legacy/gql/GqlApiBuilder.ts
+++ b/packages/nocodb/src/lib/v1-legacy/gql/GqlApiBuilder.ts
@@ -249,7 +249,7 @@ export class GqlApiBuilder extends BaseApiBuilder<Noco> implements XcMetaMgr {
 
     const t = process.hrtime();
 
-    this.initDbDriver();
+    await this.initDbDriver();
 
     // todo: change condition
     if (this.connectionConfig.meta.reset) {

--- a/packages/nocodb/src/lib/v1-legacy/nc.try.ts
+++ b/packages/nocodb/src/lib/v1-legacy/nc.try.ts
@@ -19,7 +19,7 @@ export default async function (dbUrl): Promise<void> {
     server.use(
       await app.init({
         async afterMetaMigrationInit(): Promise<void> {
-          const config = NcConfigFactory.makeProjectConfigFromUrl(dbUrl);
+          const config = await NcConfigFactory.makeProjectConfigFromUrl(dbUrl);
           await app.ncMeta.projectCreate(
             'Dvdrental (Sample SQLite Database)',
             config,

--- a/packages/nocodb/src/lib/v1-legacy/plugins/adapters/storage/Local.ts
+++ b/packages/nocodb/src/lib/v1-legacy/plugins/adapters/storage/Local.ts
@@ -9,10 +9,6 @@ import NcConfigFactory from '../../../../utils/NcConfigFactory';
 
 import axios from 'axios';
 
-const writeFileAsync = promisify(fs.writeFile)
-const readFileAsync = promisify(fs.readFile)
-const unlinkAsync = promisify(fs.unlink)
-
 export default class Local implements IStorageAdapterV2 {
   constructor() {}
 
@@ -20,9 +16,9 @@ export default class Local implements IStorageAdapterV2 {
     const destPath = path.join(NcConfigFactory.getToolDir(), ...key.split('/'));
     try {
       await mkdirp(path.dirname(destPath));
-      const data = await readFileAsync(file.path)
-      await writeFileAsync(destPath, data);
-      await unlinkAsync(file.path);
+      const data = await promisify(fs.readFile)(file.path)
+      await promisify(fs.writeFile)(destPath, data);
+      await promisify(fs.unlink)(file.path);
       // await fs.promises.rename(file.path, destPath);
     } catch (e) {
       throw e;

--- a/packages/nocodb/src/lib/v1-legacy/rest/RestApiBuilder.ts
+++ b/packages/nocodb/src/lib/v1-legacy/rest/RestApiBuilder.ts
@@ -44,10 +44,6 @@ import { MetaTable } from '../../utils/globals';
 const log = debug('nc:api:rest');
 const NC_CUSTOM_ROUTE_KEY = '__xc_custom';
 
-const globAsync = promisify(glob);
-const writeFileAsync = promisify(fs.writeFile);
-const readFileAsync = promisify(fs.readFile);
-
 export class RestApiBuilder extends BaseApiBuilder<Noco> {
   public readonly type = 'rest';
   private controllers: {
@@ -2608,7 +2604,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
         'swagger'
       );
       await mkdirp(swaggerFilePath);
-      await writeFileAsync(
+      await promisify(fs.writeFile)(
         path.join(swaggerFilePath, 'swagger.json'),
         JSON.stringify(swaggerDoc)
       );
@@ -2653,7 +2649,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
         scheme,
         scheme === 'http' ? 'https' : 'http',
       ];
-      await globAsync(
+      await promisify(glob)(
           path.join(
             this.app.getToolDir(),
             'nc',
@@ -2664,7 +2660,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
           )
         )
         .forEach(async (jsonFile) => {
-          const swaggerJson = JSON.parse(await readFileAsync(jsonFile, 'utf8'));
+          const swaggerJson = JSON.parse(await promisify(fs.readFile)(jsonFile, 'utf8'));
           swaggerBaseDocument.tags.push(...swaggerJson.tags);
           Object.assign(swaggerBaseDocument.paths, swaggerJson.paths);
           Object.assign(
@@ -2733,7 +2729,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
       'swagger'
     );
     const swaggerJson = JSON.parse(
-      await readFileAsync(path.join(swaggerFilePath, 'swagger.json'), 'utf8')
+      await promisify(fs.readFile)(path.join(swaggerFilePath, 'swagger.json'), 'utf8')
     );
 
     /* remove tags, paths and keys */
@@ -2799,7 +2795,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
       }
     }
 
-    await writeFileAsync(
+    await promisify(fs.writeFile)(
       path.join(swaggerFilePath, 'swagger.json'),
       JSON.stringify(swaggerJson)
     );

--- a/packages/nocodb/src/lib/v1-legacy/rest/RestApiBuilder.ts
+++ b/packages/nocodb/src/lib/v1-legacy/rest/RestApiBuilder.ts
@@ -86,7 +86,7 @@ export class RestApiBuilder extends BaseApiBuilder<Noco> {
     this.log('loadRoutes');
     const t = process.hrtime();
 
-    this.initDbDriver();
+    await this.initDbDriver();
 
     // todo: change condition
     if (this.connectionConfig.meta.reset) {

--- a/packages/nocodb/src/run/docker.ts
+++ b/packages/nocodb/src/run/docker.ts
@@ -18,8 +18,8 @@ server.set('view engine', 'ejs');
 process.env[`DEBUG`] = 'xc*';
 
 (async () => {
-  const httpServer = server.listen(process.env.PORT || 8080, () => {
-    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  const httpServer = server.listen(process.env.PORT || 8080, async () => {
+    server.use(await Noco.init({}, httpServer, server));
   });
-  server.use(await Noco.init({}, httpServer, server));
+  
 })().catch((e) => console.log(e));

--- a/packages/nocodb/src/run/dockerRunMysql.ts
+++ b/packages/nocodb/src/run/dockerRunMysql.ts
@@ -28,8 +28,7 @@ process.env[`NC_DB`] = `mysql2://localhost:3306?u=root&p=password&d=${metaDb}`;
 // process.env[`DEBUG`] = 'xc*';
 
 (async () => {
-  const httpServer = server.listen(process.env.PORT || 8080, () => {
-    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  const httpServer = server.listen(process.env.PORT || 8080, async () => {
+    server.use(await Noco.init({}, httpServer, server));
   });
-  server.use(await Noco.init({}, httpServer, server));
 })().catch((e) => console.log(e));

--- a/packages/nocodb/src/run/dockerRunPG.ts
+++ b/packages/nocodb/src/run/dockerRunPG.ts
@@ -28,8 +28,7 @@ process.env[`NC_DB`] = `pg://localhost:5432?u=postgres&p=password&d=${metaDb}`;
 // process.env[`DEBUG`] = 'xc*';
 
 (async () => {
-  const httpServer = server.listen(process.env.PORT || 8080, () => {
-    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  const httpServer = server.listen(process.env.PORT || 8080, async () => {
+    server.use(await Noco.init({}, httpServer, server));
   });
-  server.use(await Noco.init({}, httpServer, server));
 })().catch((e) => console.log(e));

--- a/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
+++ b/packages/nocodb/src/run/dockerRunPG_CyQuick.ts
@@ -21,8 +21,7 @@ process.env[
 //process.env[`DEBUG`] = 'xc*';
 
 (async () => {
-  const httpServer = server.listen(process.env.PORT || 8080, () => {
-    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  const httpServer = server.listen(process.env.PORT || 8080, async () => {
+    server.use(await Noco.init({}, httpServer, server));
   });
-  server.use(await Noco.init({}, httpServer, server));
 })().catch((e) => console.log(e));

--- a/packages/nocodb/src/run/testDocker.ts
+++ b/packages/nocodb/src/run/testDocker.ts
@@ -21,22 +21,18 @@ server.set('view engine', 'ejs');
 process.env[`DEBUG`] = 'xc*';
 
 (async () => {
-  const httpServer = server.listen(process.env.PORT || 8080, () => {
-    console.log(`App started successfully.\nVisit -> ${Noco.dashboardUrl}`);
+  const httpServer = server.listen(process.env.PORT || 8080, async () => {
+    server.use(await Noco.init({}, httpServer, server));
+    
+    if (!(await User.getByEmail('user@nocodb.com'))) {
+      const response = await axios.post(
+        `http://localhost:${process.env.PORT || 8080}/api/v1/auth/user/signup`,
+        {
+          email: 'user@nocodb.com',
+          password: 'Password123.',
+        }
+      );
+      console.log(response.data);
+    }
   });
-  server.use(await Noco.init({}, httpServer, server));
-
-  // Wait for 0.5 seconds for the server to start
-  await new Promise((resolve) => setTimeout(resolve, 500));
-
-  if (!(await User.getByEmail('user@nocodb.com'))) {
-    const response = await axios.post(
-      `http://localhost:${process.env.PORT || 8080}/api/v1/auth/user/signup`,
-      {
-        email: 'user@nocodb.com',
-        password: 'Password123.',
-      }
-    );
-    console.log(response.data);
-  }
 })().catch((e) => console.log(e));

--- a/packages/nocodb/src/run/try.ts
+++ b/packages/nocodb/src/run/try.ts
@@ -20,7 +20,7 @@ process.env.NC_DB = url;
     await app.init({
       async afterMetaMigrationInit(): Promise<void> {
         if (!(await app.ncMeta.projectList())?.length) {
-          const config = NcConfigFactory.makeProjectConfigFromUrl(url);
+          const config = await NcConfigFactory.makeProjectConfigFromUrl(url);
           const project = await app.ncMeta.projectCreate(
             config.title,
             config,


### PR DESCRIPTION
## Change Summary

Re #5026
- Move Noco.ts config handling to init from constructor
  - Moved `App started...` message to init (Noco.dashboardUrl requires NcConfig)
- Move ssl cert file reading from path logic to SqlClientFactory.ts from KnexClient.ts (await not possible in constructor)
- Replace synchronous calls with asynchronous ones:
  - Local file write
  - SSL config read
  - RestApiBuilder
  - All mkdirp.sync calls
  - NcMetaMgr | NcMetaMgrv2 | SqlMgr | SqlMgrv2 | KnexMigrator | KnexMigratorv2 | NcConnectionMgr | NcConnectionMgrv2 | NcConfigFactory |
  - Storage plugins (unlinkSync)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
