### PR TITLE
Allow uploads for public base url users with editor role

### DIFF
--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -23,20 +23,26 @@ const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
   try {
     // check user is super admin or creator
     if (
-      req['user'].roles?.includes(OrgUserRoles.SUPER_ADMIN) ||
-      req['user'].roles?.includes(OrgUserRoles.CREATOR) ||
-      (req['user'].isPublicBase && req['user'].roles?.includes(ProjectRoles.EDITOR)) ||
-      // if viewer then check at-least one project have editor or higher role
-      // todo: cache
-      !!(await Noco.ncMeta
-        .knex(MetaTable.PROJECT_USERS)
-        .where(function () {
-          this.where('roles', ProjectRoles.OWNER);
-          this.orWhere('roles', ProjectRoles.CREATOR);
-          this.orWhere('roles', ProjectRoles.EDITOR);
-        })
-        .andWhere('fk_user_id', req['user'].id)
-        .first())
+      req['user'].id &&
+      (req['user'].roles?.includes(OrgUserRoles.SUPER_ADMIN) ||
+        req['user'].roles?.includes(OrgUserRoles.CREATOR) ||
+        // if viewer then check at-least one project have editor or higher role
+        // todo: cache
+        !!(await Noco.ncMeta
+          .knex(MetaTable.PROJECT_USERS)
+          .where(function () {
+            this.where('roles', ProjectRoles.OWNER);
+            this.orWhere('roles', ProjectRoles.CREATOR);
+            this.orWhere('roles', ProjectRoles.EDITOR);
+          })
+          .andWhere('fk_user_id', req['user'].id)
+          .first()))
+    )
+      return next();
+    // check public base url with editor role
+    else if (
+      req['user'].isPublicBase &&
+      req['user'].roles?.includes(ProjectRoles.EDITOR)
     )
       return next();
   } catch {}
@@ -55,7 +61,7 @@ export async function upload(req: Request, res: Response) {
     (req as any).files?.map(async (file) => {
       const fileName = `${nanoid(18)}${path.extname(file.originalname)}`;
 
-      let url = await storageAdapter.fileCreate(
+      const url = await storageAdapter.fileCreate(
         slash(path.join(destPath, fileName)),
         file
       );
@@ -99,7 +105,7 @@ export async function uploadViaURL(req: Request, res: Response) {
 
       const fileName = `${nanoid(18)}${_fileName || url.split('/').pop()}`;
 
-      let attachmentUrl = await (storageAdapter as any).fileCreateByUrl(
+      const attachmentUrl = await (storageAdapter as any).fileCreateByUrl(
         slash(path.join(destPath, fileName)),
         url
       );

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -17,32 +17,28 @@ import { NC_ATTACHMENT_FIELD_SIZE } from '../../constants';
 
 const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
   if (!req['user']?.id) {
-    if (
-      req['user']?.isPublicBase &&
-      req['user'].roles?.includes(ProjectRoles.EDITOR)
-    )
-      return next()
-
-    NcError.unauthorized('Unauthorized');
+    if (!req['user']?.isPublicBase) {
+      NcError.unauthorized('Unauthorized');
+    }
   }
 
   try {
     // check user is super admin or creator
     if (
-      req['user'].id &&
-      (req['user'].roles?.includes(OrgUserRoles.SUPER_ADMIN) ||
-        req['user'].roles?.includes(OrgUserRoles.CREATOR) ||
-        // if viewer then check at-least one project have editor or higher role
-        // todo: cache
-        !!(await Noco.ncMeta
-          .knex(MetaTable.PROJECT_USERS)
-          .where(function () {
-            this.where('roles', ProjectRoles.OWNER);
-            this.orWhere('roles', ProjectRoles.CREATOR);
-            this.orWhere('roles', ProjectRoles.EDITOR);
-          })
-          .andWhere('fk_user_id', req['user'].id)
-          .first()))
+      req['user'].roles?.includes(OrgUserRoles.SUPER_ADMIN) ||
+      req['user'].roles?.includes(OrgUserRoles.CREATOR) ||
+      req['user'].roles?.includes(ProjectRoles.EDITOR) ||
+      // if viewer then check at-least one project have editor or higher role
+      // todo: cache
+      !!(await Noco.ncMeta
+        .knex(MetaTable.PROJECT_USERS)
+        .where(function () {
+          this.where('roles', ProjectRoles.OWNER);
+          this.orWhere('roles', ProjectRoles.CREATOR);
+          this.orWhere('roles', ProjectRoles.EDITOR);
+        })
+        .andWhere('fk_user_id', req['user'].id)
+        .first())
     )
       return next();
   } catch {}

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -16,7 +16,7 @@ import Local from '../../v1-legacy/plugins/adapters/storage/Local';
 import { NC_ATTACHMENT_FIELD_SIZE } from '../../constants';
 
 const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
-  if (!req['user']?.id) {
+  if (!req['user']) {
     NcError.unauthorized('Unauthorized');
   }
 
@@ -25,6 +25,7 @@ const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
     if (
       req['user'].roles?.includes(OrgUserRoles.SUPER_ADMIN) ||
       req['user'].roles?.includes(OrgUserRoles.CREATOR) ||
+      (req['user'].isPublicBase && req['user'].roles?.includes(ProjectRoles.EDITOR)) ||
       // if viewer then check at-least one project have editor or higher role
       // todo: cache
       !!(await Noco.ncMeta

--- a/packages/nocodb/src/lib/meta/api/attachmentApis.ts
+++ b/packages/nocodb/src/lib/meta/api/attachmentApis.ts
@@ -16,7 +16,13 @@ import Local from '../../v1-legacy/plugins/adapters/storage/Local';
 import { NC_ATTACHMENT_FIELD_SIZE } from '../../constants';
 
 const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
-  if (!req['user']) {
+  if (!req['user']?.id) {
+    if (
+      req['user']?.isPublicBase &&
+      req['user'].roles?.includes(ProjectRoles.EDITOR)
+    )
+      return next()
+
     NcError.unauthorized('Unauthorized');
   }
 
@@ -37,12 +43,6 @@ const isUploadAllowed = async (req: Request, _res: Response, next: any) => {
           })
           .andWhere('fk_user_id', req['user'].id)
           .first()))
-    )
-      return next();
-    // check public base url with editor role
-    else if (
-      req['user'].isPublicBase &&
-      req['user'].roles?.includes(ProjectRoles.EDITOR)
     )
       return next();
   } catch {}


### PR DESCRIPTION
## Change Summary

Allows uploads for public base url users with editors. This was not working anymore in the latest versions (and I am not sure it was ever implemented correctly).

This fix is probably not 100% correct, but I need a working docker image for my quickfix, but don't I am not able to create the image manully successfully, so I created this PR.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

* Share a project via the public base url with editor role.
* Try to upload a file on an attachment field when using the base url.