### PR TITLE
fix(nocodb): prevent from hashing a null salt

### DIFF
--- a/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
@@ -207,6 +207,13 @@ export function initStrategies(router): void {
           if (!user) {
             return done({ msg: `Email ${email} is not registered!` });
           }
+
+          if (!user.salt) {
+            return done({
+              msg: `Please sign up with the invite token first!`,
+            });
+          }
+
           const hashedPassword = await promisify(bcrypt.hash)(
             password,
             user.salt

--- a/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
+++ b/packages/nocodb/src/lib/meta/api/userApi/initStrategies.ts
@@ -210,7 +210,7 @@ export function initStrategies(router): void {
 
           if (!user.salt) {
             return done({
-              msg: `Please sign up with the invite token first!`,
+              msg: `Please sign up with the invite token first or reset the password by clicking Forgot your password.`,
             });
           }
 

--- a/packages/nocodb/src/lib/v1-legacy/gql/GqlAuthResolver.ts
+++ b/packages/nocodb/src/lib/v1-legacy/gql/GqlAuthResolver.ts
@@ -164,7 +164,7 @@ export default class GqlAuthResolver {
             }
             if (!user.salt) {
               return done({
-                msg: `Please sign up with the invite token first!`,
+                msg: `Please sign up with the invite token first or reset the password by clicking Forgot your password.`,
               });
             }
             const hashedPassword = await promisify(bcrypt.hash)(

--- a/packages/nocodb/src/lib/v1-legacy/gql/GqlAuthResolver.ts
+++ b/packages/nocodb/src/lib/v1-legacy/gql/GqlAuthResolver.ts
@@ -162,7 +162,11 @@ export default class GqlAuthResolver {
             if (!user) {
               return done({ msg: `Email ${email} is not registered!` });
             }
-
+            if (!user.salt) {
+              return done({
+                msg: `Please sign up with the invite token first!`,
+              });
+            }
             const hashedPassword = await promisify(bcrypt.hash)(
               password,
               user.salt

--- a/packages/nocodb/src/lib/v1-legacy/rest/RestAuthCtrl.ts
+++ b/packages/nocodb/src/lib/v1-legacy/rest/RestAuthCtrl.ts
@@ -334,6 +334,11 @@ export default class RestAuthCtrl {
             if (!user) {
               return done({ msg: `Email ${email} is not registered!` });
             }
+            if (!user.salt) {
+              return done({
+                msg: `Please sign up with the invite token first!`,
+              });
+            }
             const hashedPassword = await promisify(bcrypt.hash)(
               password,
               user.salt

--- a/packages/nocodb/src/lib/v1-legacy/rest/RestAuthCtrl.ts
+++ b/packages/nocodb/src/lib/v1-legacy/rest/RestAuthCtrl.ts
@@ -336,7 +336,7 @@ export default class RestAuthCtrl {
             }
             if (!user.salt) {
               return done({
-                msg: `Please sign up with the invite token first!`,
+                msg: `Please sign up with the invite token first or reset the password by clicking Forgot your password.`,
               });
             }
             const hashedPassword = await promisify(bcrypt.hash)(


### PR DESCRIPTION
## Change Summary

- If A invites B, and B sign in without setting the password (using invite token), then it would show the reported error due to null salt. 
- This PR is to check if `user.salt` is null and remind them to sign up with the invite token to set the password first.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
