### PR TITLE
fix: Attachment lookup column bug

### DIFF
--- a/packages/nc-gui/components/cell/attachment/Modal.vue
+++ b/packages/nc-gui/components/cell/attachment/Modal.vue
@@ -146,7 +146,10 @@ function onRemoveFileClick(title: any, i: number) {
               </div>
             </a-tooltip>
 
-            <a-tooltip placement="bottom">
+            <a-tooltip
+              v-if="isSharedForm || (!readOnly && isUIAllowed('tableAttachment') && !isPublic && !isLocked)"
+              placement="bottom"
+            >
               <template #title> Rename File </template>
 
               <div class="nc-attachment-download group-hover:(opacity-100) mr-[35px]">

--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -501,16 +501,12 @@ async function importTemplate() {
             }
           }
         }
-        const createdTable = await $api.base.tableCreate(
-          project.value?.id as string,
-          (baseId || project.value?.bases?.[0].id)!,
-          {
-            table_name: table.table_name,
-            // leave title empty to get a generated one based on table_name
-            title: '',
-            columns: table.columns || [],
-          },
-        )
+        const createdTable = await $api.base.tableCreate(project.value?.id as string, (baseId || project.value?.bases?.[0].id)!, {
+          table_name: table.table_name,
+          // leave title empty to get a generated one based on table_name
+          title: '',
+          columns: table.columns || [],
+        })
         table.id = createdTable.id
         table.title = createdTable.title
 

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -19,8 +19,6 @@ import {
 
 const { metas, getMeta } = useMetas()
 
-provide(ReadonlyInj, ref(true))
-
 const column = inject(ColumnInj, ref())
 
 const meta = inject(MetaInj, ref())
@@ -94,10 +92,12 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
               :edit-enabled="false"
               :model-value="v"
               :column="lookupColumn"
+              :readOnly="true"
             />
           </template>
 
-          <LazySmartsheetVirtualCell v-else :edit-enabled="false" :model-value="arrValue" :column="lookupColumn" />
+          <LazySmartsheetVirtualCell v-else :edit-enabled="false"
+                                     :readOnly="true" :model-value="arrValue" :column="lookupColumn" />
         </div>
 
         <!-- Render normal cell -->
@@ -106,7 +106,8 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
             v-if="isAttachment(lookupColumn) && arrValue[0] && !Array.isArray(arrValue[0]) && typeof arrValue[0] === 'object'"
             class="min-w-max"
           >
-            <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false" />
+            <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false"
+                                :readOnly="true" />
           </div>
           <!-- For attachment cell avoid adding chip style -->
           <template v-else>
@@ -121,7 +122,8 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
                 ),
               }"
             >
-              <LazySmartsheetCell :model-value="v" :column="lookupColumn" :edit-enabled="false" :virtual="true" />
+              <LazySmartsheetCell :model-value="v" :column="lookupColumn" :edit-enabled="false" :virtual="true"
+                                  :readOnly="true" />
             </div>
           </template>
         </template>

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -92,12 +92,17 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
               :edit-enabled="false"
               :model-value="v"
               :column="lookupColumn"
-              :readOnly="true"
+              :read-only="true"
             />
           </template>
 
-          <LazySmartsheetVirtualCell v-else :edit-enabled="false"
-                                     :readOnly="true" :model-value="arrValue" :column="lookupColumn" />
+          <LazySmartsheetVirtualCell
+            v-else
+            :edit-enabled="false"
+            :read-only="true"
+            :model-value="arrValue"
+            :column="lookupColumn"
+          />
         </div>
 
         <!-- Render normal cell -->
@@ -106,8 +111,7 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
             v-if="isAttachment(lookupColumn) && arrValue[0] && !Array.isArray(arrValue[0]) && typeof arrValue[0] === 'object'"
             class="min-w-max"
           >
-            <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false"
-                                :readOnly="true" />
+            <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false" :read-only="true" />
           </div>
           <!-- For attachment cell avoid adding chip style -->
           <template v-else>
@@ -122,8 +126,13 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
                 ),
               }"
             >
-              <LazySmartsheetCell :model-value="v" :column="lookupColumn" :edit-enabled="false" :virtual="true"
-                                  :readOnly="true" />
+              <LazySmartsheetCell
+                :model-value="v"
+                :column="lookupColumn"
+                :edit-enabled="false"
+                :virtual="true"
+                :read-only="true"
+              />
             </div>
           </template>
         </template>

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -106,10 +106,7 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
 
         <!-- Render normal cell -->
         <template v-else>
-          <div
-            v-if="isAttachment(lookupColumn) && arrValue[0] && !Array.isArray(arrValue[0]) && typeof arrValue[0] === 'object'"
-            class="min-w-max"
-          >
+          <div v-if="isAttachment(lookupColumn) && arrValue[0] && !Array.isArray(arrValue[0]) && typeof arrValue[0] === 'object'">
             <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false" :read-only="true" />
           </div>
           <!-- For attachment cell avoid adding chip style -->

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -102,20 +102,28 @@ const { showEditNonEditableFieldWarning, showClearNonEditableFieldWarning, activ
 
         <!-- Render normal cell -->
         <template v-else>
-          <!-- For attachment cell avoid adding chip style -->
           <div
-            v-for="(v, i) of arrValue"
-            :key="i"
+            v-if="isAttachment(lookupColumn) && arrValue[0] && !Array.isArray(arrValue[0]) && typeof arrValue[0] === 'object'"
             class="min-w-max"
-            :class="{
-              'bg-gray-100 px-1 rounded-full flex-1': !isAttachment(lookupColumn),
-              ' border-gray-200 rounded border-1': ![UITypes.Attachment, UITypes.MultiSelect, UITypes.SingleSelect].includes(
-                lookupColumn.uidt,
-              ),
-            }"
           >
-            <LazySmartsheetCell :model-value="v" :column="lookupColumn" :edit-enabled="false" :virtual="true" />
+            <LazySmartsheetCell :model-value="arrValue" :column="lookupColumn" :edit-enabled="false" />
           </div>
+          <!-- For attachment cell avoid adding chip style -->
+          <template v-else>
+            <div
+              v-for="(v, i) of arrValue"
+              :key="i"
+              class="min-w-max"
+              :class="{
+                'bg-gray-100 px-1 rounded-full flex-1': !isAttachment(lookupColumn),
+                'border-gray-200 rounded border-1': ![UITypes.Attachment, UITypes.MultiSelect, UITypes.SingleSelect].includes(
+                  lookupColumn.uidt,
+                ),
+              }"
+            >
+              <LazySmartsheetCell :model-value="v" :column="lookupColumn" :edit-enabled="false" :virtual="true" />
+            </div>
+          </template>
         </template>
       </template>
     </div>

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -6,7 +6,6 @@ import {
   CellValueInj,
   ColumnInj,
   MetaInj,
-  ReadonlyInj,
   computed,
   inject,
   isAttachment,
@@ -27,7 +26,7 @@ const cellValue = inject(CellValueInj, ref())
 
 const relationColumn = computed(
   () =>
-    meta.value?.columns?.find((c) => c.id === (column.value?.colOptions as LookupType)?.fk_relation_column_id) as
+    meta.value?.columns?.find((c: ColumnType) => c.id === (column.value?.colOptions as LookupType)?.fk_relation_column_id) as
       | (ColumnType & {
           colOptions: LinkToAnotherRecordType | undefined
         })
@@ -36,7 +35,7 @@ const relationColumn = computed(
 
 watch(
   relationColumn,
-  async (relationCol) => {
+  async (relationCol: { colOptions: LinkToAnotherRecordType }) => {
     if (relationCol && relationCol.colOptions) await getMeta(relationCol.colOptions.fk_related_model_id!)
   },
   { immediate: true },


### PR DESCRIPTION
## Change Summary

- Render attachment cell properly in the lookup
- Render lookup cells in read-only mode
- Hide attachment edit(rename) option in read-only mode


 re #5052 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
