### PR TITLE
fix: use nvarchar as default single/multi select datatype in mssql

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
@@ -971,9 +971,11 @@ export class MssqlUi {
         break;
       case 'MultiSelect':
         colProp.dt = 'nvarchar';
+        colProp.dtxp = 4000;
         break;
       case 'SingleSelect':
         colProp.dt = 'nvarchar';
+        colProp.dtxp = 4000;
         break;
       case 'Collaborator':
         colProp.dt = 'varchar';

--- a/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/MssqlUi.ts
@@ -970,10 +970,10 @@ export class MssqlUi {
         colProp.cdf = '0';
         break;
       case 'MultiSelect':
-        colProp.dt = 'text';
+        colProp.dt = 'nvarchar';
         break;
       case 'SingleSelect':
-        colProp.dt = 'text';
+        colProp.dt = 'nvarchar';
         break;
       case 'Collaborator':
         colProp.dt = 'varchar';
@@ -1099,10 +1099,10 @@ export class MssqlUi {
         return ['bigint', 'bit', 'int', 'tinyint'];
 
       case 'MultiSelect':
-        return ['text', 'ntext'];
+        return ['varchar', 'nvarchar', 'text', 'ntext'];
 
       case 'SingleSelect':
-        return ['text', 'ntext'];
+        return ['varchar', 'nvarchar', 'text', 'ntext'];
 
       case 'Year':
         return ['int'];


### PR DESCRIPTION
## Change Summary

Use nvarchar/varchar as the default single select datatype since the text field doesn't support grouping in MSSQL.

re #5062

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of



## TODO 

- [ ] Handle `dtxp`
