### PR TITLE
fix: missing display value

### DIFF
--- a/packages/nocodb/src/lib/Noco.ts
+++ b/packages/nocodb/src/lib/Noco.ts
@@ -105,7 +105,7 @@ export default class Noco {
   constructor() {
     process.env.PORT = process.env.PORT || '8080';
     // todo: move
-    process.env.NC_VERSION = '0104004';
+    process.env.NC_VERSION = '0105002';
 
     // if env variable NC_MINIMAL_DBS is set, then disable project creation with external sources
     if (process.env.NC_MINIMAL_DBS) {

--- a/packages/nocodb/src/lib/meta/api/helpers/populateMeta.ts
+++ b/packages/nocodb/src/lib/meta/api/helpers/populateMeta.ts
@@ -228,6 +228,8 @@ export async function populateMeta(base: Base, project: Project): Promise<any> {
     return async () => {
       const columns = (await sqlClient.columnList({ tn: table.table_name }))
         ?.data?.list;
+      
+      mapDefaultDisplayValue(columns);
 
       /* create nc_models and its rows if it doesn't exists  */
       models2[table.table_name] = await Model.insert(project.id, base.id, {

--- a/packages/nocodb/src/lib/meta/helpers/mapDefaultDisplayValue.ts
+++ b/packages/nocodb/src/lib/meta/helpers/mapDefaultDisplayValue.ts
@@ -4,31 +4,27 @@ export default function mapDefaultDisplayValue<T extends ColumnType>(
   columnsArr: Array<T>
 ): void | T {
   if (!columnsArr.some((column) => column.pv)) {
-    let len = columnsArr.length;
-    let pkIndex = -1;
-
-    while (len--) {
-      if (columnsArr[len].pk) {
-        pkIndex = len;
-        break;
-      }
-    }
+    const pkIndex = columnsArr.findIndex((column) => column.pk)
 
     // if PK is at the end of table
     if (pkIndex === columnsArr.length - 1) {
       if (pkIndex > 0) {
         columnsArr[pkIndex - 1].pv = true;
         return columnsArr[pkIndex - 1];
+      } else if (columnsArr.length > 0) {
+        columnsArr[0].pv = true;
+        return columnsArr[0];
       }
-    }
     // pk is not at the end of table
-    else if (pkIndex > -1) {
+    } else if (pkIndex > -1) { 
       columnsArr[pkIndex + 1].pv = true;
       return columnsArr[pkIndex + 1];
-    }
     //  no pk at all
-    else {
-      // todo:
+    } else {
+      if (columnsArr.length > 0) {
+        columnsArr[0].pv = true;
+        return columnsArr[0];
+      }
     }
   }
 }

--- a/packages/nocodb/src/lib/models/Model.ts
+++ b/packages/nocodb/src/lib/models/Model.ts
@@ -561,14 +561,14 @@ export default class Model implements TableType {
     ncMeta = Noco.ncMeta
   ) {
     const model = await this.getWithInfo({ id: tableId });
-    const currentPvCol = model.displayValue;
     const newPvCol = model.columns.find((c) => c.id === columnId);
 
     if (!newPvCol) NcError.badRequest('Column not found');
 
-    if (currentPvCol) {
+    // drop existing primary column/s
+    for (const col of model.columns?.filter((c) => c.pv) || []) {
       // get existing cache
-      const key = `${CacheScope.COLUMN}:${currentPvCol.id}`;
+      const key = `${CacheScope.COLUMN}:${col.id}`;
       const o = await NocoCache.get(key, CacheGetType.TYPE_OBJECT);
       if (o) {
         o.pv = false;
@@ -583,7 +583,7 @@ export default class Model implements TableType {
         {
           pv: false,
         },
-        currentPvCol.id
+        col.id
       );
     }
 

--- a/packages/nocodb/src/lib/version-upgrader/NcUpgrader.ts
+++ b/packages/nocodb/src/lib/version-upgrader/NcUpgrader.ts
@@ -43,8 +43,8 @@ export default class NcUpgrader {
         { name: '0100002', handler: ncFilterUpgrader },
         { name: '0101002', handler: ncAttachmentUpgrader },
         { name: '0104002', handler: ncAttachmentUpgrader_0104002 },
-        { name: '0104003', handler: ncStickyColumnUpgrader },
         { name: '0104004', handler: ncFilterUpgrader_0104004 },
+        { name: '0105002', handler: ncStickyColumnUpgrader },
       ];
       if (!(await ctx.ncMeta.knexConnection?.schema?.hasTable?.('nc_store'))) {
         return;

--- a/packages/nocodb/src/lib/version-upgrader/ncStickyColumnUpgrader.ts
+++ b/packages/nocodb/src/lib/version-upgrader/ncStickyColumnUpgrader.ts
@@ -38,6 +38,50 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
       view_columns_meta.push(col_meta);
     }
 
+    // if no display value column is set
+    if (!view_columns_meta.some((column) => column.pv)) {
+      const pkIndex = view_columns_meta.findIndex((column) => column.pk)
+  
+      // if PK is at the end of table
+      if (pkIndex === view_columns_meta.length - 1) {
+        if (pkIndex > 0) {
+          await ncMeta.metaUpdate(
+            null,
+            null,
+            MetaTable.COLUMNS,
+            { pv: true },
+            view_columns_meta[pkIndex - 1].id
+          );
+        } else if (view_columns_meta.length > 0) {
+          await ncMeta.metaUpdate(
+            null,
+            null,
+            MetaTable.COLUMNS,
+            { pv: true },
+            view_columns_meta[0].id
+          );
+        }
+      // pk is not at the end of table
+      } else if (pkIndex > -1) { 
+        await ncMeta.metaUpdate(
+          null,
+          null,
+          MetaTable.COLUMNS,
+          { pv: true },
+          view_columns_meta[pkIndex + 1].id
+        );
+      //  no pk at all
+      } else if (view_columns_meta.length > 0) {
+        await ncMeta.metaUpdate(
+          null,
+          null,
+          MetaTable.COLUMNS,
+          { pv: true },
+          view_columns_meta[0].id
+        );
+      }
+    }
+
     const primary_value_column_meta = view_columns_meta.find((col) => col.pv);
 
     if (primary_value_column_meta) {


### PR DESCRIPTION
## Change Summary

Re #5122 
- assign first column as display value if no pk
- assign pk as display value if no other columns
- handle missing display value in ncStickyUpgrader
- drop possible duplicated display values when display value updated

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

