### PR TITLE
fix: wrong baseid in QuickImport

### DIFF
--- a/packages/nc-gui/composables/useProject.ts
+++ b/packages/nc-gui/composables/useProject.ts
@@ -35,7 +35,7 @@ export const useProject = createSharedComposable(() => {
 
   const project = ref<ProjectType>({})
 
-  const bases = computed<BaseType[]>(() => project.value?.bases || [])
+  const bases = computed<BaseType[]>(() => project.value?.bases?.filter((base: BaseType) => base.enabled) || [])
 
   const tables = ref<TableType[]>([])
 

--- a/packages/nc-gui/composables/useProject.ts
+++ b/packages/nc-gui/composables/useProject.ts
@@ -35,7 +35,7 @@ export const useProject = createSharedComposable(() => {
 
   const project = ref<ProjectType>({})
 
-  const bases = computed<BaseType[]>(() => project.value?.bases?.filter((base: BaseType) => base.enabled) || [])
+  const bases = computed<BaseType[]>(() => project.value?.bases || [])
 
   const tables = ref<TableType[]>([])
 

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -12,7 +12,6 @@ import {
   useUIPermission,
   watch,
 } from '#imports'
-import {BaseType} from "nocodb-sdk";
 
 const dropZone = ref<HTMLDivElement>()
 
@@ -99,7 +98,7 @@ function openQuickImportDialog(type: QuickImportTypes, file: File) {
     'modelValue': isOpen,
     'importType': type,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value[0].id,
+    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
   })
 
   vNode.value?.component?.exposed?.handleChange({
@@ -130,7 +129,7 @@ function openCreateTable() {
   const { close } = useDialog(resolveComponent('DlgTableCreate'), {
     'modelValue': isOpen,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
+    'baseId': bases.value[0].id,
   })
 
   function closeDialog() {

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -98,6 +98,7 @@ function openQuickImportDialog(type: QuickImportTypes, file: File) {
     'modelValue': isOpen,
     'importType': type,
     'onUpdate:modelValue': closeDialog,
+    'baseId': bases.value[0].id,
   })
 
   vNode.value?.component?.exposed?.handleChange({

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -12,6 +12,7 @@ import {
   useUIPermission,
   watch,
 } from '#imports'
+import {BaseType} from "nocodb-sdk";
 
 const dropZone = ref<HTMLDivElement>()
 
@@ -129,7 +130,7 @@ function openCreateTable() {
   const { close } = useDialog(resolveComponent('DlgTableCreate'), {
     'modelValue': isOpen,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value[0].id,
+    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
   })
 
   function closeDialog() {

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -130,7 +130,7 @@ function openCreateTable() {
   const { close } = useDialog(resolveComponent('DlgTableCreate'), {
     'modelValue': isOpen,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value[0].id,
+    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
   })
 
   function closeDialog() {

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import type { UploadChangeParam, UploadFile } from 'ant-design-vue'
+import type { BaseType } from 'nocodb-sdk'
 import {
   message,
   ref,
@@ -98,7 +99,7 @@ function openQuickImportDialog(type: QuickImportTypes, file: File) {
     'modelValue': isOpen,
     'importType': type,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value?.filter((base: any) => base.enabled)[0].id,
+    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
   })
 
   vNode.value?.component?.exposed?.handleChange({

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -98,7 +98,7 @@ function openQuickImportDialog(type: QuickImportTypes, file: File) {
     'modelValue': isOpen,
     'importType': type,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value?.filter((base: BaseType) => base.enabled)[0].id,
+    'baseId': bases.value[0].id,
   })
 
   vNode.value?.component?.exposed?.handleChange({

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index/index/index.vue
@@ -98,7 +98,7 @@ function openQuickImportDialog(type: QuickImportTypes, file: File) {
     'modelValue': isOpen,
     'importType': type,
     'onUpdate:modelValue': closeDialog,
-    'baseId': bases.value[0].id,
+    'baseId': bases.value?.filter((base: any) => base.enabled)[0].id,
   })
 
   vNode.value?.component?.exposed?.handleChange({


### PR DESCRIPTION
## Change Summary

PR for:
- closes https://github.com/nocodb/nocodb/issues/5103

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ x ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

1. The useProject.ts file in the nc-gui package:
A filter has been added to the bases computed property to only include those that have the enabled property set to true.

2. The index.vue file in the nc-gui package:
The baseId property has been added to the openQuickImportDialog function, and it is set to the id of the first base in the bases array that has the enabled property set to true.
In summary, these changes filter out disabled bases in the bases computed property, and pass the id of the first enabled base to the openQuickImportDialog function as the baseId property.

You can test it like in the issue description
