### PR TITLE
add mysql to helm chart

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -5,6 +5,10 @@ dependencies:
   name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: ~11.6.6
+- condition: mysql.enabled
+  name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: ~9.4.6
 description: A Helm chart for Kubernetes
 maintainers: []
 name: nocodb

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -83,6 +83,7 @@ extraEnvs:
 
 extraSecretEnvs:
   NC_AUTH_JWT_SECRET: secretString
+  NC_DB: "mysql2://mysql:3306?u=nocodb&p=secretPass&d=nocodb"
 
 storage:
   size: 3Gi
@@ -95,4 +96,14 @@ postgresql:
     username: nocodb
     password: secretPass
   persistence:
+    size: 8Gi
+
+mysql:
+  enabled: false
+  auth:
+    database: nocodb
+    username: nocodb
+    password: secretPass
+  persistence:
+    enabled: false
     size: 8Gi


### PR DESCRIPTION
## Change Summary

This diff adds support for MySQL to the Helm chart used to deploy NocoDB on Kubernetes. Specifically, it makes the following changes:

In Chart.yaml, it adds a new dependency on the MySQL chart from the Bitnami repository, and sets a condition for enabling it (mysql.enabled).
In values.yaml, it adds a new environment variable (NC_DB) that specifies the connection string for the MySQL database. It also adds a new section for configuring the MySQL chart, including authentication credentials and persistence settings. The enabled flag for MySQL is set to false by default.
Overall, this change allows users to deploy NocoDB using MySQL as the underlying database instead of Postgres, providing more options for managing the application's data.

## Change type

- [ x ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Tested l in a deployed scenario with a custom dockerfile / helm-chart on a k3s.
