### PR TITLE
add feature to set custom pvc access mode, e.g. read-write-many

### DIFF
--- a/charts/nocodb/templates/pvc.yaml
+++ b/charts/nocodb/templates/pvc.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "nocodb.selectorLabels" . | nindent 8 }}
 spec:
-  accessModes:
-    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.storage.size }}
   storageClassName: {{ .Values.storage.storageClassName }}
+  accessModes:
+    {{- default (toYaml .Values.storage.accessModes) "- ReadWriteMany" | nindent 4 }}
   volumeMode: Filesystem


### PR DESCRIPTION
## Change Summary

This feature of allowing custom PVC access modes in the NocoDB Helm chart can be very useful for several reasons. One of the main reasons is that it provides greater flexibility and control over the storage of the application's data.

In a Kubernetes cluster, different workloads may have different storage requirements. For example, some applications may require shared read-write access to a common set of data, while others may require only read-only or write-only access. By allowing the customization of PVC access modes, the NocoDB Helm chart can better support a wider range of storage requirements and provide more fine-grained control over the access mode of the PVC.

In addition, some managed Kubernetes providers, such as certain cloud providers, do not have a standard way to create read-write-many PVCs. By providing the ability to set custom PVC access modes, the NocoDB Helm chart can provide a solution for users of these platforms who require read-write-many PVCs.

Overall, the ability to set custom PVC access modes in the NocoDB Helm chart can improve the user experience and make it easier to deploy and manage the application in a Kubernetes environment.

This diff shows changes to the pvc.yaml template of the NocoDB Helm chart. The changes add a feature to set custom access mode for the Persistent Volume Claim (PVC), such as read-write-many.

The specific changes made in this commit include:

Adding a new section for accessModes, which sets the access mode for the PVC.
Moving the accessModes section below resources to ensure it is set correctly.
Using the default function to set the accessModes to the storage.accessModes value from values.yaml, or "ReadWriteMany" if storage.accessModes is not set.
Overall, this change allows users of the NocoDB Helm chart to set a custom access mode for the PVC to match the requirements of their particular use case.

## Change type

- [ x ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Tested in a deployed scenario with a custom dockerfile / helm-chart.
