### PR TITLE
fix bug when creating single- / multi-select (enum / set) with `\` inside

### DIFF
--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -275,6 +275,8 @@ function remapColNames(batchData: any[], columns: ColumnType[]) {
       } else if (col.uidt === UITypes.DateTime && d) {
         const dateTimeFormat = getDateTimeFormat(data[key])
         d = dayjs(data[key], dateTimeFormat).format('YYYY-MM-DD HH:mm')
+      } else if (col.uid === UITypes.SingleSelect || col.uid === UITypes.MultiSelect) {
+        d = data[key].replace('\\', '')
       }
       return {
         ...aggObj,

--- a/packages/nc-gui/composables/useViewData.ts
+++ b/packages/nc-gui/composables/useViewData.ts
@@ -279,7 +279,11 @@ export function useViewData(
         encodeURIComponent(id),
         {
           // if value is undefined treat it as null
-          [property]: toUpdate.row[property] ?? null,
+          [property]:
+            metaValue?.columns?.find((c) => c.title === Object.keys(toUpdate.row)[0])?.dt === 'enum' ||
+            metaValue?.columns?.find((c) => c.title === Object.keys(toUpdate.row)[0])?.dt === 'set'
+              ? toUpdate.row[property]?.replaceAll('\\', '')
+              : toUpdate.row[property] ?? null,
         },
         // todo:
         // {


### PR DESCRIPTION
…side the name

## Change Summary

Related to: https://github.com/nocodb/nocodb/issues/3500

The commit message indicates that it fixes a bug that occurs when creating an enum/set and selecting single/multiple options that contain the **`\`** character in their name.

The first file, **Editor.vue**, has changes made to the remapColNames function starting at line 275. The changes include adding an else if block to handle cases where the **col.uid** is either **UITypes.SingleSelect** or **UITypes.MultiSelect**. In such cases, the data[key] string is modified by replacing all instances of the **`\`** character with an empty string (like the databases do this).

The second file, useViewData.ts, has changed to the useViewData function starting at line 279. The changes include modifying the value of [property] based on the dt property of the column in the metaValue object. If the dt is either **enum** or **set**, then the replaceAll function replaces all instances of the **`\`** character with an empty string before assigning the value to [property].

If you were to write a pull-request comment, you could say something like:

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

This is a relatively simple fix and may not be supported for all databases. I tested it with MYSQL, where I also encountered the error. It would have to be checked whether other databases behave in the same way. If this is not the case, you have to make the bug fix database specific.

The bug issue describes the error when importing an Excel file. However, this is independent of the fix, since the bug also arises when manually creating multi/single-selection columns. When importing, it is enough (similar to header normalization) not to allow it in the first place and to make a conversion.

