### PR TITLE
fix: Remove double click column edit option from shared form

### DIFF
--- a/packages/nc-gui/components/account/ResetPassword.vue
+++ b/packages/nc-gui/components/account/ResetPassword.vue
@@ -54,7 +54,7 @@ const passwordChange = async () => {
 
   message.success(t('msg.success.passwordChanged'))
 
-  signOut()
+  await signOut()
 
   navigateTo('/signin')
 }

--- a/packages/nc-gui/components/general/MiniSidebar.vue
+++ b/packages/nc-gui/components/general/MiniSidebar.vue
@@ -11,8 +11,8 @@ const route = useRoute()
 
 const email = computed(() => user.value?.email ?? '---')
 
-const logout = () => {
-  signOut()
+const logout = async () => {
+  await signOut()
   navigateTo('/signin')
 }
 </script>

--- a/packages/nc-gui/components/smartsheet/header/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/header/Cell.vue
@@ -37,7 +37,7 @@ const closeAddColumnDropdown = () => {
 }
 
 const openHeaderMenu = () => {
-  if (!isForm && isUIAllowed('edit-column')) {
+  if (!isForm.value && isUIAllowed('edit-column')) {
     editColumnDropdown.value = true
   }
 }
@@ -51,11 +51,13 @@ const openHeaderMenu = () => {
     <SmartsheetHeaderCellIcon v-if="column" />
     <span
       v-if="column"
-      class="name cursor-pointer"
+      class="name"
+      :class="{ 'cursor-pointer': !isForm && isUIAllowed('edit-column') }"
       style="white-space: nowrap"
       :title="column.title"
       @dblclick="openHeaderMenu"
-      >{{ column.title }}</span>
+      >{{ column.title }}</span
+    >
 
     <span v-if="(column.rqd && !column.cdf) || required" class="text-red-500">&nbsp;*</span>
 

--- a/packages/nc-gui/components/smartsheet/header/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/header/Cell.vue
@@ -7,6 +7,7 @@ interface Props {
   required?: boolean | number
   hideMenu?: boolean
 }
+
 const props = defineProps<Props>()
 
 const hideMenu = toRef(props, 'hideMenu')
@@ -34,6 +35,12 @@ const closeAddColumnDropdown = () => {
   columnOrder.value = null
   editColumnDropdown.value = false
 }
+
+const openHeaderMenu = () => {
+  if (!isForm && isUIAllowed('edit-column')) {
+    editColumnDropdown.value = true
+  }
+}
 </script>
 
 <template>
@@ -47,20 +54,15 @@ const closeAddColumnDropdown = () => {
       class="name cursor-pointer"
       style="white-space: nowrap"
       :title="column.title"
-      @dblclick="editColumnDropdown = true"
-      >{{ column.title }}</span
-    >
+      @dblclick="openHeaderMenu"
+      >{{ column.title }}</span>
 
     <span v-if="(column.rqd && !column.cdf) || required" class="text-red-500">&nbsp;*</span>
 
     <template v-if="!hideMenu">
       <div class="flex-1" />
 
-      <LazySmartsheetHeaderMenu
-        v-if="!isForm && isUIAllowed('edit-column')"
-        @add-column="addField"
-        @edit="editColumnDropdown = true"
-      />
+      <LazySmartsheetHeaderMenu v-if="!isForm && isUIAllowed('edit-column')" @add-column="addField" @edit="openHeaderMenu" />
     </template>
 
     <a-dropdown

--- a/packages/nc-gui/composables/useApi/interceptors.ts
+++ b/packages/nc-gui/composables/useApi/interceptors.ts
@@ -66,7 +66,7 @@ export function addAxiosInterceptors(api: Api<any>) {
           })
         })
         .catch(async (error) => {
-          state.signOut()
+          await state.signOut()
           // todo: handle new user
 
           navigateTo('/signIn')

--- a/packages/nc-gui/composables/useGlobal/actions.ts
+++ b/packages/nc-gui/composables/useGlobal/actions.ts
@@ -7,7 +7,7 @@ export function useGlobalActions(state: State): Actions {
     state.token.value = null
     state.user.value = null
     try {
-      if(state.token.value) {
+      if (state.token.value) {
         const nuxtApp = useNuxtApp()
         await nuxtApp.$api.auth.signout()
       }

--- a/packages/nc-gui/composables/useGlobal/actions.ts
+++ b/packages/nc-gui/composables/useGlobal/actions.ts
@@ -3,9 +3,15 @@ import { message, useNuxtApp } from '#imports'
 
 export function useGlobalActions(state: State): Actions {
   /** Sign out by deleting the token from localStorage */
-  const signOut: Actions['signOut'] = () => {
+  const signOut: Actions['signOut'] = async () => {
     state.token.value = null
     state.user.value = null
+    try {
+      if(state.token.value) {
+        const nuxtApp = useNuxtApp()
+        await nuxtApp.$api.auth.signout()
+      }
+    } catch {}
   }
 
   /** Sign in by setting the token in localStorage */
@@ -38,9 +44,9 @@ export function useGlobalActions(state: State): Actions {
             signIn(response.data.token)
           }
         })
-        .catch((err) => {
+        .catch(async (err) => {
           message.error(err.message || t('msg.error.youHaveBeenSignedOut'))
-          signOut()
+          await signOut()
         })
         .finally(resolve)
     })

--- a/packages/nc-gui/layouts/base.vue
+++ b/packages/nc-gui/layouts/base.vue
@@ -13,8 +13,8 @@ const hasSider = ref(false)
 
 const sidebar = ref<HTMLDivElement>()
 
-const logout = () => {
-  signOut()
+const logout = async () => {
+  await signOut()
   navigateTo('/signin')
 }
 

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
@@ -70,8 +70,8 @@ const sidebar = ref()
 
 const email = computed(() => user.value?.email ?? '---')
 
-const logout = () => {
-  signOut()
+const logout = async () => {
+  await signOut()
   navigateTo('/signin')
 }
 

--- a/packages/nc-gui/pages/index/index/user.vue
+++ b/packages/nc-gui/pages/index/index/user.vue
@@ -57,7 +57,7 @@ const passwordChange = async () => {
 
   message.success(t('msg.success.passwordChanged'))
 
-  signOut()
+  await signOut()
 
   navigateTo('/signin')
 }

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -1131,8 +1131,8 @@ export class Api<
  * 
  * @tags Auth
  * @name Signout
- * @summary Signin
- * @request POST:/api/v1/auth/user/signin
+ * @summary Signout
+ * @request POST:/api/v1/auth/user/signout
  * @response `200` `{
   msg?: string,
 
@@ -1145,7 +1145,7 @@ export class Api<
         },
         any
       >({
-        path: `/api/v1/auth/user/signin`,
+        path: `/api/v1/auth/user/signout`,
         method: 'POST',
         format: 'json',
         ...params,
@@ -1157,7 +1157,7 @@ export class Api<
  * @tags Auth
  * @name Signin
  * @summary Signin
- * @request POST:/api/v1/auth/user/signout
+ * @request POST:/api/v1/auth/user/signin
  * @response `200` `{
   token?: string,
 
@@ -1176,7 +1176,7 @@ export class Api<
           msg?: string;
         }
       >({
-        path: `/api/v1/auth/user/signout`,
+        path: `/api/v1/auth/user/signin`,
         method: 'POST',
         body: data,
         type: ContentType.Json,

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -1127,12 +1127,37 @@ export class Api<
       }),
 
     /**
+ * @description Clear refresh token from the database and cookie.
+ * 
+ * @tags Auth
+ * @name Signout
+ * @summary Signin
+ * @request POST:/api/v1/auth/user/signin
+ * @response `200` `{
+  msg?: string,
+
+}` OK
+ */
+    signout: (params: RequestParams = {}) =>
+      this.request<
+        {
+          msg?: string;
+        },
+        any
+      >({
+        path: `/api/v1/auth/user/signin`,
+        method: 'POST',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
  * @description Authenticate existing user with their email and password. Successful login will return a JWT access-token. 
  * 
  * @tags Auth
  * @name Signin
  * @summary Signin
- * @request POST:/api/v1/auth/user/signin
+ * @request POST:/api/v1/auth/user/signout
  * @response `200` `{
   token?: string,
 
@@ -1151,7 +1176,7 @@ export class Api<
           msg?: string;
         }
       >({
-        path: `/api/v1/auth/user/signin`,
+        path: `/api/v1/auth/user/signout`,
         method: 'POST',
         body: data,
         type: ContentType.Json,

--- a/packages/nocodb/src/schema/swagger.json
+++ b/packages/nocodb/src/schema/swagger.json
@@ -98,6 +98,34 @@
     "/api/v1/auth/user/signin": {
       "post": {
         "summary": "Signin",
+        "operationId": "auth-signout",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Auth"
+        ],
+        "description": "Clear refresh token from the database and cookie."
+      },
+      "parameters": []
+    },
+    "/api/v1/auth/user/signout": {
+      "post": {
+        "summary": "Signin",
         "operationId": "auth-signin",
         "responses": {
           "200": {

--- a/packages/nocodb/src/schema/swagger.json
+++ b/packages/nocodb/src/schema/swagger.json
@@ -95,9 +95,9 @@
         "description": "Create a new user with provided email and password and first user is marked as super admin. "
       }
     },
-    "/api/v1/auth/user/signin": {
+    "/api/v1/auth/user/signout": {
       "post": {
-        "summary": "Signin",
+        "summary": "Signout",
         "operationId": "auth-signout",
         "responses": {
           "200": {
@@ -123,7 +123,7 @@
       },
       "parameters": []
     },
-    "/api/v1/auth/user/signout": {
+    "/api/v1/auth/user/signin": {
       "post": {
         "summary": "Signin",
         "operationId": "auth-signin",


### PR DESCRIPTION
## Change Summary

- Hide the column edit option from the shared form
- Add logout API for clearing refresh token from cookie and database to avoid automatic token generation in GUI

closes #5205 
closes #5197

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
