### PR TITLE
Update font priorities for RTL languages

### DIFF
--- a/packages/nc-gui/assets/css/global.css
+++ b/packages/nc-gui/assets/css/global.css
@@ -9,7 +9,7 @@ html {
 }
 
 body , *  {
-  font-family: 'Inter', 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, Vazirmatn,
+  font-family: Arial, Vazirmatn, 'Inter', 'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     sans-serif;
 }
 


### PR DESCRIPTION
Update font priorities to apply Vazirmatn for RTL languages

## Change Summary

We discussed the problem in https://github.com/nocodb/nocodb/issues/5212

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] **fix: (bug fix for the user, not a fix to a build script)**
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Font priorities for body are changed.

## Additional information / screenshots (optional)

Vazirmatn is already applied as the primary font for RTL languages but it isn't working in some certain PC Windows systems. 