### PR TITLE
fix(nc-gui): move eventOperation and onNotTypeChange logic out of loadPluginList

### DIFF
--- a/packages/nc-gui/components/webhook/Editor.vue
+++ b/packages/nc-gui/components/webhook/Editor.vue
@@ -325,17 +325,11 @@ async function loadPluginList() {
         ...(p as any),
       }
       plugin.tags = p.tags ? p.tags.split(',') : []
-      plugin.parsedInput = p.input && JSON.parse(p.input)
+      plugin.parsedInput = typeof p.input === 'string' ? JSON.parse(p.input) : p.input
       o[plugin.title] = plugin
 
       return o
     }, {} as Record<string, any>)
-
-    if (hook.event && hook.operation) {
-      hook.eventOperation = `${hook.event} ${hook.operation}`
-    }
-
-    onNotTypeChange()
   } catch (e: any) {
     message.error(await extractSdkResponseErrorMsg(e))
   }
@@ -422,7 +416,15 @@ watch(
   { immediate: true },
 )
 
-onMounted(loadPluginList)
+onMounted(async () => {
+  await loadPluginList()
+
+  if (hook.event && hook.operation) {
+    hook.eventOperation = `${hook.event} ${hook.operation}`
+  }
+
+  onNotTypeChange()
+})
 </script>
 
 <template>


### PR DESCRIPTION
## Change Summary

with `NC_CLOUD=true`, eventOperation will be blocked since the logic is inside loadPluginList. Since eventOperation and onNotTypeChange logic doesn't relate to loadPluginList, this PR is simply to move them out.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
