### PR TITLE
fix(sdk): escapeLiteral

### DIFF
--- a/packages/nocodb-sdk/src/lib/formulaHelpers.ts
+++ b/packages/nocodb-sdk/src/lib/formulaHelpers.ts
@@ -218,10 +218,10 @@ function escapeLiteral(v: string) {
   return (
     v
       // replace \ to \\
-      .replace(/\\/g, '\\\\')
+      .replace(/\\/g, `\\\\`)
       // replace " to \"
-      .replace(/"/g, '\\"')
+      .replace(/"/g, `\\"`)
       // replace ' to \'
-      .replace(/'/g, '\\"')
+      .replace(/'/g, `\\'`)
   );
 }

--- a/packages/nocodb-sdk/src/lib/formulaHelpers.ts
+++ b/packages/nocodb-sdk/src/lib/formulaHelpers.ts
@@ -179,7 +179,7 @@ export function jsepTreeToFormula(node) {
 
   if (node.type === 'Literal') {
     if (typeof node.value === 'string') {
-      return String.raw`"${escapeDoubleQuotes(node.value)}"`;
+      return String.raw`"${escapeLiteral(node.value)}"`;
     }
     return '' + node.value;
   }
@@ -214,6 +214,14 @@ export function jsepTreeToFormula(node) {
   return '';
 }
 
-function escapeDoubleQuotes(v: string) {
-  return v.replace(/"/g, '\\"');
+function escapeLiteral(v: string) {
+  return (
+    v
+      // replace \ to \\
+      .replace(/\\/g, '\\\\')
+      // replace " to \"
+      .replace(/"/g, '\\"')
+      // replace ' to \'
+      .replace(/'/g, '\\"')
+  );
 }


### PR DESCRIPTION
## Change Summary

- handle `\` in formula. Use `\\`. closes #5315
- handle `'` in formula. Use `\'`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

```
CONCAT("\\", "A")
```

![image](https://user-images.githubusercontent.com/35857179/225814884-2af28b7d-9261-42f6-b0da-86a12eb3265e.png)

```
CONCAT("\'", "A")
```

![image](https://user-images.githubusercontent.com/35857179/225815260-97dbee87-990f-45ab-8937-b91ce30b0a20.png)

