### PR TITLE
refactor(nc-gui): use VNodeRef for focusInput & blur to call onRename

### DIFF
--- a/packages/nc-gui/components/smartsheet/sidebar/RenameableMenuItem.vue
+++ b/packages/nc-gui/components/smartsheet/sidebar/RenameableMenuItem.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import type { VNodeRef } from '@vue/runtime-core'
 import type { KanbanType, ViewType, ViewTypes } from 'nocodb-sdk'
 import type { WritableComputedRef } from '@vue/reactivity'
 import { Tooltip } from 'ant-design-vue'
@@ -93,9 +94,7 @@ onKeyStroke('Enter', (event) => {
   }
 })
 
-function focusInput(el: HTMLInputElement) {
-  if (el) el.focus()
-}
+const focusInput: VNodeRef = (el) => (el as HTMLInputElement)?.focus()
 
 /** Duplicate a view */
 // todo: This is not really a duplication, maybe we need to implement a true duplication?
@@ -183,7 +182,7 @@ function onStopEdit() {
         v-if="isEditing"
         :ref="focusInput"
         v-model:value="vModel.title"
-        @blur="onCancel"
+        @blur="onRename"
         @keydown.stop="onKeyDown($event)"
       />
 


### PR DESCRIPTION
## Change Summary

From DF - Tried to rename form: thought that clicking outside of name edit text field means 'saving'

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
