### PR TITLE
feat: custom css and js

### DIFF
--- a/packages/nc-gui/components/account/Customization.vue
+++ b/packages/nc-gui/components/account/Customization.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import { useNuxtApp } from '#app'
+import { message } from 'ant-design-vue'
+import { extractSdkResponseErrorMsg, useApi, useGlobal } from '#imports'
+
+const { api, isLoading } = useApi()
+
+const { $e } = useNuxtApp()
+
+const { loadAppInfo } = useGlobal()
+
+let css = $ref('')
+let js = $ref('')
+
+const loadCustomization = async () => {
+  try {
+    const response = await api.orgCustomization.get()
+    css = response.css!
+    js = response.js!
+  } catch (e: any) {
+    message.error(await extractSdkResponseErrorMsg(e))
+  }
+}
+const setCustomization = async () => {
+  try {
+    await api.orgCustomization.set({ css: css, js: js })
+    message.success('Customization updated')
+    await loadAppInfo()
+  } catch (e: any) {
+    message.error(await extractSdkResponseErrorMsg(e))
+  }
+  $e('a:account:customization')
+}
+
+loadCustomization()
+</script>
+
+<template>
+  <div class="h-full overflow-y-scroll scrollbar-thin-dull">
+    <div class="text-xl mt-4 mb-8 text-center font-weight-bold">Custom CSS</div>
+    <div class="mx-auto w-150">
+      <div>
+        <a-textarea v-model:value="css" placeholder="selector{attr:value}" class="!mt-2 !max-w-[600px]"></a-textarea>
+      </div>
+    </div>
+    <div class="text-xl mt-4 mb-8 text-center font-weight-bold">Custom JS</div>
+    <div class="mx-auto w-150">
+      <div>
+        <a-textarea v-model:value="js" placeholder="document.querySelector ..." class="!mt-2 !max-w-[600px]"></a-textarea>
+      </div>
+    </div>
+    <div class="text-center"><a-button class="mt-4" @click="setCustomization" type="primary">Save customization</a-button></div>
+  </div>
+</template>

--- a/packages/nc-gui/composables/useCustomization.ts
+++ b/packages/nc-gui/composables/useCustomization.ts
@@ -1,0 +1,43 @@
+import { useNuxtApp, useHead, extractSdkResponseErrorMsg, useApi } from '#imports'
+
+export async function useCustomization() {
+  
+  const { hooks } = useNuxtApp()
+  const { api } = useApi()
+
+  let css = ''
+  let js = ''
+
+  const loadCustomization = async () => {
+    try {
+      const response = await api.orgCustomization.get()
+      css = response.css!
+      js = response.js!
+    } catch (e: any) {
+      message.error(await extractSdkResponseErrorMsg(e))
+    }
+  }
+
+  await loadCustomization()
+
+  useHead({
+    style: [
+      { children: css }
+    ]
+  })
+
+  hooks.hook('page:finish', () => {
+    /**
+     * Kinda fix console error due to transitions see https://github.com/nuxt/nuxt/issues/13309 ,
+     * without the if statement the hook fires once for the transition where the document is empty and once more when the document is loaded
+    */
+    if(document.querySelector('section') !== null){
+        try {
+          eval(js)
+        } catch (e: any) {
+            console.warn('Custom JS Error: ' + e.message)
+        }
+    }
+  })
+
+}

--- a/packages/nc-gui/layouts/base.vue
+++ b/packages/nc-gui/layouts/base.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { computed, navigateTo, ref, useGlobal, useNuxtApp, useRoute, useSidebar } from '#imports'
+import { computed, navigateTo, ref, useGlobal, useNuxtApp, useRoute, useSidebar, useCustomization } from '#imports'
 
 const { signOut, signedIn, isLoading, user, currentVersion } = useGlobal()
 
@@ -28,6 +28,8 @@ hooks.hook('page:finish', () => {
     hasSider.value = sidebar.value?.children.length > 0
   }
 })
+
+useCustomization()
 </script>
 
 <template>

--- a/packages/nc-gui/lib/constants.ts
+++ b/packages/nc-gui/lib/constants.ts
@@ -33,6 +33,7 @@ export const rolePermissions = {
       superAdminUserManagement: true,
       superAdminAppSettings: true,
       appLicense: true,
+      appCustomization: true,
     },
   },
   [ProjectRole.Owner]: {
@@ -41,6 +42,7 @@ export const rolePermissions = {
       superAdminUserManagement: true,
       superAdminAppSettings: true,
       appLicense: true,
+      appCustomization: true,
     },
   },
   [ProjectRole.Editor]: {

--- a/packages/nc-gui/pages/account/index.vue
+++ b/packages/nc-gui/pages/account/index.vue
@@ -83,6 +83,18 @@ const openKeys = ref([/^\/account\/users/.test($route.fullPath) && 'users'])
               </div>
             </a-menu-item>
             <a-menu-item
+              v-if="isUIAllowed('customization')"
+              key="customization"
+              class="group active:(!ring-0) hover:(!bg-primary !bg-opacity-25)"
+              @click="navigateTo('/account/customization')"
+            >
+              <div class="flex items-center space-x-2">
+                <MdiBrush />
+
+                <div class="select-none">Customization</div>
+              </div>
+            </a-menu-item>
+            <a-menu-item
               v-if="isUIAllowed('license')"
               key="license"
               class="group active:(!ring-0) hover:(!bg-primary !bg-opacity-25)"

--- a/packages/nc-gui/pages/account/index/[page].vue
+++ b/packages/nc-gui/pages/account/index/[page].vue
@@ -7,5 +7,6 @@ const { appInfo } = useGlobal()
   <AccountToken v-else-if="$route.params.page === 'tokens'" />
   <AccountAppStore v-else-if="$route.params.page === 'apps' && !appInfo.isCloud" />
   <AccountLicense v-else-if="$route.params.page === 'license'" />
+  <AccountCustomization v-else-if="$route.params.page === 'customization'" />
   <span v-else></span>
 </template>

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -3311,6 +3311,83 @@ export class Api<
         ...params,
       }),
   };
+  orgCustomization = {
+    /**
+ * @description Get custom CSS & Javascript. Exclusive for super admin.
+ * 
+ * @tags Org Customization
+ * @name Get
+ * @summary Get App Customization
+ * @request GET:/api/v1/customization
+ * @response `200` `{
+  \** Custom CSS code *\
+  css?: string,
+  \** Custom JavaScript code *\
+  js?: string,
+
+}` OK
+ * @response `400` `{
+  \** @example BadRequest [Error]: <ERROR MESSAGE> *\
+  msg: string,
+
+}`
+ */
+    get: (params: RequestParams = {}) =>
+      this.request<
+        {
+          /** Custom CSS code */
+          css?: string;
+          /** Custom JavaScript code */
+          js?: string;
+        },
+        {
+          /** @example BadRequest [Error]: <ERROR MESSAGE> */
+          msg: string;
+        }
+      >({
+        path: `/api/v1/customization`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+ * @description Set custom CSS & Javascript. Exclusive for super admin.
+ * 
+ * @tags Org Customization
+ * @name Set
+ * @summary Set custom CSS & Javascript
+ * @request POST:/api/v1/customization
+ * @response `200` `{
+  \** @example The customization has been saved *\
+  msg?: string,
+
+}` OK
+ * @response `400` `{
+  \** @example BadRequest [Error]: <ERROR MESSAGE> *\
+  msg: string,
+
+}`
+ */
+    set: (data: any, params: RequestParams = {}) =>
+      this.request<
+        {
+          /** @example The customization has been saved */
+          msg?: string;
+        },
+        {
+          /** @example BadRequest [Error]: <ERROR MESSAGE> */
+          msg: string;
+        }
+      >({
+        path: `/api/v1/customization`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
   orgAppSettings = {
     /**
  * @description Get the application settings. Exclusive for super admin.

--- a/packages/nocodb/src/lib/controllers/orgCustomization.ctl.ts
+++ b/packages/nocodb/src/lib/controllers/orgCustomization.ctl.ts
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import { OrgUserRoles } from 'nocodb-sdk';
+import { metaApiMetrics } from '../meta/helpers/apiMetrics';
+import ncMetaAclMw from '../meta/helpers/ncMetaAclMw';
+import { orgCustomizationService } from '../services';
+
+async function customizationGet(_req, res) {
+  res.json(await orgCustomizationService.customizationGet());
+}
+
+async function customizationSet(req, res) {
+  await orgCustomizationService.customizationSet({ css: req.body.css || '', js: req.body.js || '' });
+  res.json({ msg: 'The customization has been saved' });
+}
+
+const router = Router({ mergeParams: true });
+router.get(
+  '/api/v1/customization',
+  metaApiMetrics,
+  ncMetaAclMw(customizationGet, 'customizationGet', {
+    allowedRoles: [OrgUserRoles.SUPER_ADMIN],
+    blockApiTokenAccess: true,
+  })
+);
+router.post(
+  '/api/v1/customization',
+  metaApiMetrics,
+  ncMetaAclMw(customizationSet, 'customizationSet', {
+    allowedRoles: [OrgUserRoles.SUPER_ADMIN],
+    blockApiTokenAccess: true,
+  })
+);
+
+export default router;

--- a/packages/nocodb/src/lib/meta/api/index.ts
+++ b/packages/nocodb/src/lib/meta/api/index.ts
@@ -3,6 +3,7 @@ import { T } from 'nc-help';
 import { Server } from 'socket.io';
 import passport from 'passport';
 import orgLicenseController from '../../controllers/orgLicense.ctl';
+import orgCustomizationController from '../../controllers/orgCustomization.ctl';
 import orgTokenController from '../../controllers/orgToken.ctl';
 import orgUserController from '../../controllers/orgUser.ctl';
 import projectController from '../../controllers/project.ctl';
@@ -94,6 +95,7 @@ export default function (router: Router, server) {
   router.use(orgUserController);
   router.use(orgTokenController);
   router.use(orgLicenseController);
+  router.use(orgCustomizationController);
   router.use(sharedBaseController);
   router.use(modelVisibilityController);
   router.use(metaDiffController);

--- a/packages/nocodb/src/lib/services/index.ts
+++ b/packages/nocodb/src/lib/services/index.ts
@@ -22,6 +22,7 @@ export * as modelVisibilityService from './modelVisibility.svc';
 export * as sharedBaseService from './sharedBase.svc';
 export * as orgUserService from './orgUser.svc';
 export * as orgLicenseService from './orgLicense.svc';
+export * as orgCustomizationService from './orgCustomization.svc';
 export * as projectUserService from './projectUser.svc';
 export * as attachmentService from './attachment.svc';
 export * as hookFilterService from './hookFilter.svc';

--- a/packages/nocodb/src/lib/services/orgCustomization.svc.ts
+++ b/packages/nocodb/src/lib/services/orgCustomization.svc.ts
@@ -1,0 +1,19 @@
+import { validatePayload } from '../meta/api/helpers';
+import Store from '../models/Store';
+import Noco from '../Noco';
+
+export async function customizationGet() {
+  const css = await Store.get('customization-css');
+  const js = await Store.get('customization-js');
+
+  return {css: css.value, js: js.value};
+}
+
+export async function customizationSet(param: { css: string, js: string }) {
+  validatePayload('swagger.json#/components/schemas/CustomizationReq', param);
+
+  await Store.saveOrUpdate({ value: param.css, key: 'customization-css' });
+  await Store.saveOrUpdate({ value: param.js, key: 'customization-js' });
+  await Noco.loadEEState();
+  return true;
+}

--- a/packages/nocodb/src/schema/swagger.json
+++ b/packages/nocodb/src/schema/swagger.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "Organisation APIs",
-      "tags": ["Org App Settings", "Org License", "Org Tokens", "Org Users"]
+      "tags": ["Org App Settings", "Org License", "Org Tokens", "Org Users", "Org Customization"]
     }
   ],
   "servers": [
@@ -896,6 +896,116 @@
         },
         "tags": ["Org License"],
         "description": "Set the application license key. Exclusive for super admin.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/xc-auth"
+          }
+        ]
+      }
+    },
+    "/api/v1/customization": {
+      "get": {
+        "summary": "Get App Customization",
+        "operationId": "org-customization-get",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "css": {
+                      "type": "string",
+                      "description": "Custom CSS code"
+                    },
+                    "js": {
+                      "type": "string",
+                      "description": "Custom JavaScript code"
+                    }
+                  }
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "css": "div[data-testid=\"projects-container\"] h1 { color: rgba(var(--color-primary),var(--tw-text-opacity)); }",
+                      "js": "/* Add a print button */ let node=document.querySelector(\".nc-tab-bar .nc-fullscreen-btn\"),newNode=document.createElement(\"div\");newNode.classList=\"flex items-center h-full mb-1px\",newNode.innerHTML='<div><button class=\"ant-btn ant-btn-primary !rounded-md mr-1\" type=\"button\" onclick=\"window.print()\"><div class=\"flex items-center space-x-1 cursor-pointer text-xs font-weight-bold\"><svg class=\"nc-icon mr-1 nc-share-base hover:text-accent text-sm\" preserveAspectRatio=\"xMidYMid meet\" viewBox=\"0 0 48 48\" width=\"1.2em\" height=\"1.2em\"><path fill=\"currentColor\" d=\"M32.9 15.6V9H15.1v6.6h-3V6h23.8v9.6ZM7 18.6h34-28.9Zm29.95 4.75q.6 0 1.05-.45.45-.45.45-1.05 0-.6-.45-1.05-.45-.45-1.05-.45-.6 0-1.05.45-.45.45-.45 1.05 0 .6.45 1.05.45.45 1.05.45ZM32.9 39v-9.6H15.1V39Zm3 3H12.1v-8.8H4V20.9q0-2.25 1.525-3.775T9.3 15.6h29.4q2.25 0 3.775 1.525T44 20.9v12.3h-8.1ZM41 30.2v-9.3q0-1-.65-1.65-.65-.65-1.65-.65H9.3q-1 0-1.65.65Q7 19.9 7 20.9v9.3h5.1v-3.8h23.8v3.8Z\"/></svg>Print</div></button></div>',node.parentNode.insertBefore(newNode,node);"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          }
+        },
+        "description": "Get custom CSS & Javascript. Exclusive for super admin.",
+        "tags": ["Org Customization"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/xc-auth"
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/xc-auth"
+        }
+      ],
+      "post": {
+        "summary": "Set custom CSS & Javascript",
+        "operationId": "org-customization-set",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "msg": {
+                      "type": "string",
+                      "x-stoplight": {
+                        "id": "n7ahrs0n8lcwf"
+                      },
+                      "example": "The customization has been saved"
+                    }
+                  }
+                },
+                "examples": {
+                  "Example 1": {
+                    "value": {
+                      "msg": "The customization has been saved"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomizationReq"
+              },
+              "examples": {
+                "Example 1": {
+                  "value": {
+                    "css": "div[data-testid=\"projects-container\"] h1 { color: rgba(var(--color-primary),var(--tw-text-opacity)); }",
+                    "js": "/* Add a print button */ let node=document.querySelector(\".nc-tab-bar .nc-fullscreen-btn\"),newNode=document.createElement(\"div\");newNode.classList=\"flex items-center h-full mb-1px\",newNode.innerHTML='<div><button class=\"ant-btn ant-btn-primary !rounded-md mr-1\" type=\"button\" onclick=\"window.print()\"><div class=\"flex items-center space-x-1 cursor-pointer text-xs font-weight-bold\"><svg class=\"nc-icon mr-1 nc-share-base hover:text-accent text-sm\" preserveAspectRatio=\"xMidYMid meet\" viewBox=\"0 0 48 48\" width=\"1.2em\" height=\"1.2em\"><path fill=\"currentColor\" d=\"M32.9 15.6V9H15.1v6.6h-3V6h23.8v9.6ZM7 18.6h34-28.9Zm29.95 4.75q.6 0 1.05-.45.45-.45.45-1.05 0-.6-.45-1.05-.45-.45-1.05-.45-.6 0-1.05.45-.45.45-.45 1.05 0 .6.45 1.05.45.45 1.05.45ZM32.9 39v-9.6H15.1V39Zm3 3H12.1v-8.8H4V20.9q0-2.25 1.525-3.775T9.3 15.6h29.4q2.25 0 3.775 1.525T44 20.9v12.3h-8.1ZM41 30.2v-9.3q0-1-.65-1.65-.65-.65-1.65-.65H9.3q-1 0-1.65.65Q7 19.9 7 20.9v9.3h5.1v-3.8h23.8v3.8Z\"/></svg>Print</div></button></div>',node.parentNode.insertBefore(newNode,node);"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": ["Org Customization"],
+        "description": "Set custom CSS & Javascript. Exclusive for super admin.",
         "parameters": [
           {
             "$ref": "#/components/parameters/xc-auth"
@@ -16590,7 +16700,7 @@
         }
       },
       "LicenseReq": {
-        "description": "Model for Kanban Request",
+        "description": "Model for License Request",
         "examples": [
           {
             "key": "1234567890"
@@ -16609,6 +16719,36 @@
         "type": "object",
         "x-stoplight": {
           "id": "ydf14317b0zdt"
+        }
+      },
+      "CustomizationReq": {
+        "description": "Model for Customization Request",
+        "examples": [
+          {
+			      "css": "div[data-testid=\"projects-container\"] h1 { color: rgba(var(--color-primary),var(--tw-text-opacity)); }",
+            "js": "/* Add a print button */ let node=document.querySelector(\".nc-tab-bar .nc-fullscreen-btn\"),newNode=document.createElement(\"div\");newNode.classList=\"flex items-center h-full mb-1px\",newNode.innerHTML='<div><button class=\"ant-btn ant-btn-primary !rounded-md mr-1\" type=\"button\" onclick=\"window.print()\"><div class=\"flex items-center space-x-1 cursor-pointer text-xs font-weight-bold\"><svg class=\"nc-icon mr-1 nc-share-base hover:text-accent text-sm\" preserveAspectRatio=\"xMidYMid meet\" viewBox=\"0 0 48 48\" width=\"1.2em\" height=\"1.2em\"><path fill=\"currentColor\" d=\"M32.9 15.6V9H15.1v6.6h-3V6h23.8v9.6ZM7 18.6h34-28.9Zm29.95 4.75q.6 0 1.05-.45.45-.45.45-1.05 0-.6-.45-1.05-.45-.45-1.05-.45-.6 0-1.05.45-.45.45-.45 1.05 0 .6.45 1.05.45.45 1.05.45ZM32.9 39v-9.6H15.1V39Zm3 3H12.1v-8.8H4V20.9q0-2.25 1.525-3.775T9.3 15.6h29.4q2.25 0 3.775 1.525T44 20.9v12.3h-8.1ZM41 30.2v-9.3q0-1-.65-1.65-.65-.65-1.65-.65H9.3q-1 0-1.65.65Q7 19.9 7 20.9v9.3h5.1v-3.8h23.8v3.8Z\"/></svg>Print</div></button></div>',node.parentNode.insertBefore(newNode,node);"
+          }
+        ],
+        "properties": {
+          "css": {
+            "description": "Custom CSS code",
+            "example": "div[data-testid=\"projects-container\"] h1 { color: rgba(var(--color-primary),var(--tw-text-opacity)); }",
+            "maxLength": 4096,
+            "minLength": 0,
+            "type": "string"
+          },
+          "js": {
+            "description": "Custom Javascript code",
+            "example": "/* Add a print button */ let node=document.querySelector(\".nc-tab-bar .nc-fullscreen-btn\"),newNode=document.createElement(\"div\");newNode.classList=\"flex items-center h-full mb-1px\",newNode.innerHTML='<div><button class=\"ant-btn ant-btn-primary !rounded-md mr-1\" type=\"button\" onclick=\"window.print()\"><div class=\"flex items-center space-x-1 cursor-pointer text-xs font-weight-bold\"><svg class=\"nc-icon mr-1 nc-share-base hover:text-accent text-sm\" preserveAspectRatio=\"xMidYMid meet\" viewBox=\"0 0 48 48\" width=\"1.2em\" height=\"1.2em\"><path fill=\"currentColor\" d=\"M32.9 15.6V9H15.1v6.6h-3V6h23.8v9.6ZM7 18.6h34-28.9Zm29.95 4.75q.6 0 1.05-.45.45-.45.45-1.05 0-.6-.45-1.05-.45-.45-1.05-.45-.6 0-1.05.45-.45.45-.45 1.05 0 .6.45 1.05.45.45 1.05.45ZM32.9 39v-9.6H15.1V39Zm3 3H12.1v-8.8H4V20.9q0-2.25 1.525-3.775T9.3 15.6h29.4q2.25 0 3.775 1.525T44 20.9v12.3h-8.1ZM41 30.2v-9.3q0-1-.65-1.65-.65-.65-1.65-.65H9.3q-1 0-1.65.65Q7 19.9 7 20.9v9.3h5.1v-3.8h23.8v3.8Z\"/></svg>Print</div></button></div>',node.parentNode.insertBefore(newNode,node);",
+            "maxLength": 4096,
+            "minLength": 0,
+            "type": "string"
+          }
+        },
+        "title": "Customization Request Model",
+        "type": "object",
+        "x-stoplight": {
+          "id": "l60h6z6x2rt5e"
         }
       },
       "LinkToAnotherColumnReq": {


### PR DESCRIPTION
closes: #4913
ref: #181

__Notes__

You need to refresh the page for the new values to apply. In dev if you don't refresh the `$state` gets messed up,

You really have to be creative with your CSS selectors as nocodb uses little to none custom classes or ids. Still I was able to make the ui more useable on a tablet (that was my initial need).

In custom JS code always check if the elements you target exist before manipulating them as the code runs on EVERY view. Errors appear as warnings in the console so as not to halt the whole app.

The JS example in `swagger.json` is huge but I wanted to write something useful.

P.S. Initially I wanted custom CSS per project but it was a lot more work and since injecting JS wasn't that hard I left it in the account settings. For anyone who wants to target individual projects: use custom JS to toggle classes in the body with the project name or id and target that in your custom CSS.

## Change Summary

Added a new component (subpage) under account settings with 2 textareas, 1 for CSS and 1 for JS stored in standard app key-value settings. Only available to Super-Admin.

The CSS is injected to the head, while the JS is run (via eval) on `page:finish` but is kinda buggy because of all the transition wrappers. The fix at `useCustomization.ts:34` should make it play nicely on production.

## Change type

- [X] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

![94b73865-4bf9-4b4b-9e1b-253b349313fc](https://user-images.githubusercontent.com/8031572/226741294-eb8e5b02-2cb5-4ca8-8a89-28e325a61927.png)

