### PR TITLE
fix(nc-gui): extra patch request

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -118,11 +118,10 @@ const vModel = computed({
   },
 })
 
-const syncAndNavigate = (dir: NavigateDir, e: KeyboardEvent) => {
+const navigate = (dir: NavigateDir, e: KeyboardEvent) => {
   if (isJSON(column.value)) return
 
   if (currentRow.value.rowMeta.changed || currentRow.value.rowMeta.new) {
-    emit('save')
     currentRow.value.rowMeta.changed = false
   }
   emit('navigate', dir)
@@ -159,8 +158,8 @@ const onContextmenu = (e: MouseEvent) => {
       { 'text-blue-600': isPrimary(column) && !props.virtual && !isForm },
       { 'nc-grid-numeric-cell': isGrid && !isForm && isNumericField },
     ]"
-    @keydown.enter.exact="syncAndNavigate(NavigateDir.NEXT, $event)"
-    @keydown.shift.enter.exact="syncAndNavigate(NavigateDir.PREV, $event)"
+    @keydown.enter.exact="navigate(NavigateDir.NEXT, $event)"
+    @keydown.shift.enter.exact="navigate(NavigateDir.PREV, $event)"
     @contextmenu="onContextmenu"
   >
     <template v-if="column">


### PR DESCRIPTION
## Change Summary

> Editing in Grid view would send update request twice

`emit('save')` will be triggered in `vModel.set`. Hence, we don't need to trigger again in `syncAndNavigate`. Since there is no sync in `syncAndNavigate`, `syncAndNavigate` will be renamed to `navigate`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
