### PR TITLE
fix(nc-gui): keyA selection

### DIFF
--- a/packages/nc-gui/app.vue
+++ b/packages/nc-gui/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { applyNonSelectable, computed, useRoute, useTheme } from '#imports'
+import { computed, useRoute, useTheme } from '#imports'
 
 const route = useRoute()
 
@@ -7,7 +7,18 @@ const disableBaseLayout = computed(() => route.path.startsWith('/nc/view') || ro
 
 useTheme()
 
-applyNonSelectable()
+useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
+  const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
+  if (cmdOrCtrl) {
+    switch (e.code) {
+      case 'KeyA':
+        // prevent Ctrl + A selection for non-editable nodes
+        if (!['input', 'textarea'].includes((e.target as any).nodeName.toLowerCase())) {
+          e.preventDefault()
+        }
+    }
+  }
+})
 
 // TODO: Remove when https://github.com/vuejs/core/issues/5513 fixed
 const key = ref(0)

--- a/packages/nc-gui/assets/css/global.css
+++ b/packages/nc-gui/assets/css/global.css
@@ -31,14 +31,3 @@ For Drag and Drop
 .grabbing * {
   cursor: grabbing;
 }
-
-/*
-Prevent Ctrl + A selection
-*/
-.non-selectable {
-  -webkit-user-select: none;
-  -webkit-touch-callout: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import tinycolor from 'tinycolor2'
-import type { TableType } from 'nocodb-sdk'
 import {
   TabType,
   computed,
@@ -224,8 +223,8 @@ function openKeyboardShortcutDialog() {
 useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
   const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
   if (e.altKey && !e.shiftKey && !cmdOrCtrl) {
-    switch (e.keyCode) {
-      case 188: {
+    switch (e.code) {
+      case 'Comma': {
         // ALT + ,
         if (isUIAllowed('settings') && !isDrawerOrModalExist()) {
           e.preventDefault()
@@ -237,8 +236,8 @@ useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
     }
   }
   if (cmdOrCtrl) {
-    switch (e.key) {
-      case '/':
+    switch (e.code) {
+      case 'Slash':
         if (!isDrawerOrModalExist()) {
           $e('c:shortcut', { key: 'CTRL + /' })
           openKeyboardShortcutDialog()

--- a/packages/nc-gui/utils/viewUtils.ts
+++ b/packages/nc-gui/utils/viewUtils.ts
@@ -41,10 +41,6 @@ export function applyLanguageDirection(dir: typeof rtl | typeof ltr) {
   document.body.style.direction = dir
 }
 
-export function applyNonSelectable() {
-  document.body.classList.add('non-selectable')
-}
-
 export const getViewIcon = (key?: string | number) => {
   if (!key) return
 


### PR DESCRIPTION
## Change Summary

The existing CSS approach would block lots of selections which is not expected. This PR is to block it for non editable nodes only.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
