### PR TITLE
test: fix project operations flaky test

### DIFF
--- a/tests/playwright/pages/ProjectsPage/index.ts
+++ b/tests/playwright/pages/ProjectsPage/index.ts
@@ -147,6 +147,9 @@ export class ProjectsPage extends BasePage {
     });
     await projRow.locator('.nc-action-btn').nth(0).click();
 
+    // there is a flicker; add delay to avoid flakiness
+    await this.rootPage.waitForTimeout(1000);
+
     await project.locator('input.nc-metadb-project-name').fill(newTitle);
     // press enter to save
     const submitAction = () => project.locator('input.nc-metadb-project-name').press('Enter');

--- a/tests/playwright/tests/projectOperations.spec.ts
+++ b/tests/playwright/tests/projectOperations.spec.ts
@@ -3,11 +3,13 @@ import { DashboardPage } from '../pages/Dashboard';
 import setup from '../setup';
 import { ToolbarPage } from '../pages/Dashboard/common/Toolbar';
 import { ProjectsPage } from '../pages/ProjectsPage';
+import { Api } from 'nocodb-sdk';
 
 test.describe('Project operations', () => {
   let dashboard: DashboardPage;
   let toolbar: ToolbarPage;
   let context: any;
+  let api: Api<any>;
   let projectPage: ProjectsPage;
 
   test.beforeEach(async ({ page }) => {
@@ -15,9 +17,28 @@ test.describe('Project operations', () => {
     dashboard = new DashboardPage(page, context.project);
     projectPage = new ProjectsPage(page);
     toolbar = dashboard.grid.toolbar;
+
+    api = new Api({
+      baseURL: `http://localhost:8080/`,
+      headers: {
+        'xc-auth': context.token,
+      },
+    });
   });
 
   test('rename, delete', async () => {
+    // if project already exists, delete it
+    try {
+      const projectList = await api.project.list();
+      const project = projectList.list.find((p: any) => p.title === 'project-firstName');
+      if (project) {
+        await api.project.delete(project.id);
+        console.log('deleted project: ', project.id);
+      }
+    } catch (e) {
+      console.log('Error: ', e);
+    }
+
     await dashboard.clickHome();
     await projectPage.createProject({ name: 'project-firstName', withoutPrefix: true });
     await dashboard.clickHome();


### PR DESCRIPTION
## Change Summary

Project operations test suite was flaky. Could be
- because of flicker in project rename modal
- project being created already existed (due to retry may be)

Proposed remedy
- ensure project is removed always before test (using API)
- add a second delay to ensure rename modal flicker is sorted out

## Change type
- [x] test: (adding missing tests, refactoring tests; no production code change)

