### PR TITLE
Fix/pg rels as non table owner

### DIFF
--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
@@ -997,6 +997,8 @@ class PGClient extends KnexClient {
            JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
            JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
         where tbl.relname='${args.tn}'
+        -- Possible bug. column "constraint_name" & "constraint_type" does not exist
+        -- GROUP BY conname, col.attnum, contype, "schema", "table", definition
         GROUP BY constraint_name, col.attnum, constraint_type, "schema", "table", definition
         ORDER BY "schema", "table"; `);
 
@@ -1053,28 +1055,56 @@ class PGClient extends KnexClient {
     const result = new Result();
     log.api(`${_func}:args:`, args);
     try {
+      // Here are 2 queries, 
+      // The first query got the relation list, but only if the pg user owned the table.
+      // The 2nd query should get table relations without the need to own the table.
+      // But it has not been thouroughly tested yet.
+      // I think the first query doesnn't return x-schema relation so I added 
+      // in the WHERE clause: AND f_sch.nspname = sch.nspname
+      // remove this if it's not desired behavior.
+      // Resource: https://dba.stackexchange.com/a/218969
       const { rows } = await this.sqlClient.raw(
-        `SELECT distinct
-                                  tc.table_schema as ts,
-                                  tc.constraint_name as cstn,
-                                  tc.table_name as tn,
-                                  kcu.column_name as cn,
-                                  ccu.table_schema AS foreign_table_schema,
-                                  ccu.table_name AS rtn,
-                                  ccu.column_name AS rcn,
-                                  pc.confupdtype as ur, pc.confdeltype as dr
-                          FROM
-                              information_schema.table_constraints AS tc
-                              JOIN information_schema.key_column_usage AS kcu
-                                ON tc.constraint_name = kcu.constraint_name
-                                AND tc.table_schema = kcu.table_schema
-                              JOIN information_schema.constraint_column_usage AS ccu
-                                ON ccu.constraint_name = tc.constraint_name
-                                AND ccu.table_schema = tc.table_schema
-                              join (select conname,confupdtype,confdeltype from pg_catalog.pg_constraint) pc
-                              on pc.conname = tc.constraint_name
-                          WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema=? and tc.table_name='${args.tn}'
-                          order by tc.table_name;`,
+        // `SELECT distinct
+        //         tc.table_schema as ts,
+        //         tc.constraint_name as cstn,
+        //         tc.table_name as tn,
+        //         kcu.column_name as cn,
+        //         ccu.table_schema AS foreign_table_schema,
+        //         ccu.table_name AS rtn,
+        //         ccu.column_name AS rcn,
+        //         pc.confupdtype as ur, pc.confdeltype as dr
+        // FROM
+        //     information_schema.table_constraints AS tc
+        //     JOIN information_schema.key_column_usage AS kcu
+        //       ON tc.constraint_name = kcu.constraint_name
+        //       AND tc.table_schema = kcu.table_schema
+        //     JOIN information_schema.constraint_column_usage AS ccu
+        //       ON ccu.constraint_name = tc.constraint_name
+        //       AND ccu.table_schema = tc.table_schema
+        //     join (select conname,confupdtype,confdeltype from pg_catalog.pg_constraint) pc
+        //     on pc.conname = tc.constraint_name
+        // WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema=? and tc.table_name='${args.tn}'
+        // order by tc.table_name;`,
+        `SELECT 
+          sch.nspname    AS ts,
+          pc.conname     AS cstn,
+          tbl.relname    AS tn,
+          col.attname    AS cn,
+          f_sch.nspname  AS foreign_table_schema,
+          f_tbl.relname  AS rtn,
+          f_col.attname  AS rcn,
+          pc.confupdtype AS ur,
+          pc.confdeltype AS dr
+        FROM pg_constraint pc
+          LEFT JOIN LATERAL UNNEST(pc.conkey)  WITH ORDINALITY AS u(attnum, attposition)   ON TRUE
+          LEFT JOIN LATERAL UNNEST(pc.confkey) WITH ORDINALITY AS f_u(attnum, attposition) ON f_u.attposition = u.attposition
+          JOIN pg_class tbl ON tbl.oid = pc.conrelid
+          JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
+          LEFT JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
+          LEFT JOIN pg_class f_tbl ON f_tbl.oid = pc.confrelid
+          LEFT JOIN pg_namespace f_sch ON f_sch.oid = f_tbl.relnamespace
+          LEFT JOIN pg_attribute f_col ON (f_col.attrelid = f_tbl.oid AND f_col.attnum = f_u.attnum)
+        WHERE pc.contype = 'f' AND sch.nspname = ? AND f_sch.nspname = sch.nspname AND tbl.relname='${args.tn}';`,
         [this.schema]
       );
 
@@ -1123,29 +1153,54 @@ class PGClient extends KnexClient {
     const result = new Result();
     log.api(`${_func}:args:`, args);
     try {
+      // Here are 2 queries, 
+      // The first query got relations, but only if the pg user owned the tables.
+      // The 2nd query should get table relations without the need to own the tables.
+      // But it has not been thouroughly tested yet.
       const { rows } = await this.sqlClient.raw(
-        `SELECT DISTINCT tc.table_schema as ts,
-                                                      tc.constraint_name as cstn,
-                                                      tc.table_name as tn,
-                                                      kcu.column_name as cn,
-                                                      ccu.table_schema AS foreign_table_schema,
-                                                      ccu.table_name   AS rtn,
-                                                      ccu.column_name  AS rcn,
-                                                      pc.confupdtype   as ur,
-                                                      pc.confdeltype   as dr
-                                               FROM information_schema.table_constraints AS tc
-                                                      JOIN information_schema.key_column_usage AS kcu
-                                                           ON tc.constraint_name = kcu.constraint_name
-                                                             AND tc.table_schema = kcu.table_schema
-                                                      JOIN information_schema.constraint_column_usage AS ccu
-                                                           ON ccu.constraint_name = tc.constraint_name
-                                                             AND ccu.table_schema = tc.table_schema
-                                                      join (select conname, confupdtype, confdeltype
-                                                            from pg_catalog.pg_constraint) pc
-                                                           on pc.conname = tc.constraint_name
-                                               WHERE tc.constraint_type = 'FOREIGN KEY'
-                                                 AND tc.table_schema = ?
-                                               order by tc.table_name;`,
+        // `SELECT DISTINCT tc.table_schema as ts,
+        //       tc.constraint_name as cstn,
+        //       tc.table_name as tn,
+        //       kcu.column_name as cn,
+        //       ccu.table_schema AS foreign_table_schema,
+        //       ccu.table_name   AS rtn,
+        //       ccu.column_name  AS rcn,
+        //       pc.confupdtype   as ur,
+        //       pc.confdeltype   as dr
+        // FROM information_schema.table_constraints AS tc
+        //       JOIN information_schema.key_column_usage AS kcu
+        //             ON tc.constraint_name = kcu.constraint_name
+        //               AND tc.table_schema = kcu.table_schema
+        //       JOIN information_schema.constraint_column_usage AS ccu
+        //             ON ccu.constraint_name = tc.constraint_name
+        //               AND ccu.table_schema = tc.table_schema
+        //       join (select conname, confupdtype, confdeltype
+        //             from pg_catalog.pg_constraint) pc
+        //             on pc.conname = tc.constraint_name
+        // WHERE tc.constraint_type = 'FOREIGN KEY'
+        //   AND tc.table_schema = ?
+        // order by tc.table_name;`,
+        `SELECT 
+          sch.nspname    AS ts,
+          pc.conname     AS cstn,
+          tbl.relname    AS tn,
+          col.attname    AS cn,
+          f_sch.nspname  AS foreign_table_schema,
+          f_tbl.relname  AS rtn,
+          f_col.attname  AS rcn,
+          pc.confupdtype AS ur,
+          pc.confdeltype AS dr
+        FROM pg_constraint pc
+          LEFT JOIN LATERAL UNNEST(pc.conkey)  WITH ORDINALITY AS u(attnum, attposition)   ON TRUE
+          LEFT JOIN LATERAL UNNEST(pc.confkey) WITH ORDINALITY AS f_u(attnum, attposition) ON f_u.attposition = u.attposition
+          JOIN pg_class tbl ON tbl.oid = pc.conrelid
+          JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
+          LEFT JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
+          LEFT JOIN pg_class f_tbl ON f_tbl.oid = pc.confrelid
+          LEFT JOIN pg_namespace f_sch ON f_sch.oid = f_tbl.relnamespace
+          LEFT JOIN pg_attribute f_col ON (f_col.attrelid = f_tbl.oid AND f_col.attnum = f_u.attnum)
+        WHERE pc.contype = 'f' AND sch.nspname = ?
+        ORDER BY tn;`,
         [this.schema]
       );
 

--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
@@ -997,8 +997,6 @@ class PGClient extends KnexClient {
            JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
            JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)
         where tbl.relname='${args.tn}'
-        -- Possible bug. column "constraint_name" & "constraint_type" does not exist
-        -- GROUP BY conname, col.attnum, contype, "schema", "table", definition
         GROUP BY constraint_name, col.attnum, constraint_type, "schema", "table", definition
         ORDER BY "schema", "table"; `);
 
@@ -1055,36 +1053,12 @@ class PGClient extends KnexClient {
     const result = new Result();
     log.api(`${_func}:args:`, args);
     try {
-      // Here are 2 queries, 
-      // The first query got the relation list, but only if the pg user owned the table.
-      // The 2nd query should get table relations without the need to own the table.
-      // But it has not been thouroughly tested yet.
-      // I think the first query doesnn't return x-schema relation so I added 
-      // in the WHERE clause: AND f_sch.nspname = sch.nspname
-      // remove this if it's not desired behavior.
+      // The relationList & relationListAll queries is may look needlessly long, but it is a way 
+      // to get relationships without the `information_schema.constraint_column_usage` table (view). 
+      // As that view only returns fk relations if the pg user is the table owner. 
       // Resource: https://dba.stackexchange.com/a/218969
+      // Remove clause `WHERE clause: AND f_sch.nspname = sch.nspname` for x-schema relations.
       const { rows } = await this.sqlClient.raw(
-        // `SELECT distinct
-        //         tc.table_schema as ts,
-        //         tc.constraint_name as cstn,
-        //         tc.table_name as tn,
-        //         kcu.column_name as cn,
-        //         ccu.table_schema AS foreign_table_schema,
-        //         ccu.table_name AS rtn,
-        //         ccu.column_name AS rcn,
-        //         pc.confupdtype as ur, pc.confdeltype as dr
-        // FROM
-        //     information_schema.table_constraints AS tc
-        //     JOIN information_schema.key_column_usage AS kcu
-        //       ON tc.constraint_name = kcu.constraint_name
-        //       AND tc.table_schema = kcu.table_schema
-        //     JOIN information_schema.constraint_column_usage AS ccu
-        //       ON ccu.constraint_name = tc.constraint_name
-        //       AND ccu.table_schema = tc.table_schema
-        //     join (select conname,confupdtype,confdeltype from pg_catalog.pg_constraint) pc
-        //     on pc.conname = tc.constraint_name
-        // WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema=? and tc.table_name='${args.tn}'
-        // order by tc.table_name;`,
         `SELECT 
           sch.nspname    AS ts,
           pc.conname     AS cstn,
@@ -1153,33 +1127,7 @@ class PGClient extends KnexClient {
     const result = new Result();
     log.api(`${_func}:args:`, args);
     try {
-      // Here are 2 queries, 
-      // The first query got relations, but only if the pg user owned the tables.
-      // The 2nd query should get table relations without the need to own the tables.
-      // But it has not been thouroughly tested yet.
       const { rows } = await this.sqlClient.raw(
-        // `SELECT DISTINCT tc.table_schema as ts,
-        //       tc.constraint_name as cstn,
-        //       tc.table_name as tn,
-        //       kcu.column_name as cn,
-        //       ccu.table_schema AS foreign_table_schema,
-        //       ccu.table_name   AS rtn,
-        //       ccu.column_name  AS rcn,
-        //       pc.confupdtype   as ur,
-        //       pc.confdeltype   as dr
-        // FROM information_schema.table_constraints AS tc
-        //       JOIN information_schema.key_column_usage AS kcu
-        //             ON tc.constraint_name = kcu.constraint_name
-        //               AND tc.table_schema = kcu.table_schema
-        //       JOIN information_schema.constraint_column_usage AS ccu
-        //             ON ccu.constraint_name = tc.constraint_name
-        //               AND ccu.table_schema = tc.table_schema
-        //       join (select conname, confupdtype, confdeltype
-        //             from pg_catalog.pg_constraint) pc
-        //             on pc.conname = tc.constraint_name
-        // WHERE tc.constraint_type = 'FOREIGN KEY'
-        //   AND tc.table_schema = ?
-        // order by tc.table_name;`,
         `SELECT 
           sch.nspname    AS ts,
           pc.conname     AS cstn,

--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/pg.queries.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/pg.queries.ts
@@ -150,11 +150,6 @@ AND t.table_name=?;`,
 
   relationList: {
     default: {
-      -- I'm not sure if this query is relevant to the issue
-      -- It won't execute manually on my PG15 as columns don't exist:
-      -- REFERENCED_TABLE_NAME
-      -- REFERENCED_COLUMN_NAME
-      -- Is it legacy code?
       sql: `SELECT
       kcu.CONSTRAINT_NAME as cstn,
       kcu.TABLE_NAME as tn,

--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/pg.queries.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/pg.queries.ts
@@ -150,6 +150,11 @@ AND t.table_name=?;`,
 
   relationList: {
     default: {
+      -- I'm not sure if this query is relevant to the issue
+      -- It won't execute manually on my PG15 as columns don't exist:
+      -- REFERENCED_TABLE_NAME
+      -- REFERENCED_COLUMN_NAME
+      -- Is it legacy code?
       sql: `SELECT
       kcu.CONSTRAINT_NAME as cstn,
       kcu.TABLE_NAME as tn,


### PR DESCRIPTION
## Change Summary

Updated 2 quereis to allow for table relations to be returned in a case where the pg user is not the table owner.

The changes have been thouroughly commented and this will need review please.

It should fix https://github.com/nocodb/nocodb/issues/719

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

The changes work when using the web interface + PG15.

I have not yet run tests. I hope they will be run as an action upon pull request.

## Additional information / screenshots (optional)

To see this change 

1. Create a couple of tables with a foreign key relationship.
2. Create a new user with access to these tables but is not owner.
  ```
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_user WHERE usename = 'noco_data') THEN
    CREATE USER noco_data WITH PASSWORD 'password'; 
  END IF;
END $$;

GRANT USAGE  ON SCHEMA public TO noco_data;
GRANT SELECT ON all tables IN SCHEMA public TO noco_data;

GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE table_1 TO noco_data;
GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE table_2 TO noco_data;
  ```
3. Add the database as a datasource in the web ui.
4. Click ERD you will see table relations. (these were not being shown earlier)
