### PR TITLE
fix(nocodb): Add postgres data source w/o `CREATE ON DATABASE` permission

### DIFF
--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
@@ -474,7 +474,7 @@ class PGClient extends KnexClient {
         ]);
       }
 
-      const schemaName = this.connectionConfig.searchPath?.[0] || 'public'
+      const schemaName = this.connectionConfig.searchPath?.[0] || 'public';
 
       // Check schemaExists because `CREATE SCHEMA IF NOT EXISTS` requires permissions of `CREATE ON DATABASE`
       const schemaExists = !!(

--- a/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/pg/PgClient.ts
@@ -474,17 +474,22 @@ class PGClient extends KnexClient {
         ]);
       }
 
-      // if (this.connectionConfig.searchPath && this.connectionConfig.searchPath[0]) {
-      await this.sqlClient.raw(
-        ` CREATE SCHEMA IF NOT EXISTS ??  AUTHORIZATION ?? `,
-        [
-          (this.connectionConfig.searchPath &&
-            this.connectionConfig.searchPath[0]) ||
-            'public',
-          this.connectionConfig.connection.user,
-        ]
-      );
-      // }
+      const schemaName = this.connectionConfig.searchPath?.[0] || 'public'
+
+      // Check schemaExists because `CREATE SCHEMA IF NOT EXISTS` requires permissions of `CREATE ON DATABASE`
+      const schemaExists = !!(
+        await this.sqlClient.raw(
+          `SELECT schema_name FROM information_schema.schemata WHERE schema_name = ?`,
+          [schemaName]
+        )
+      ).rows?.[0];
+
+      if(!schemaExists) {
+        await this.sqlClient.raw(
+          `CREATE SCHEMA IF NOT EXISTS ??  AUTHORIZATION ?? `,
+          [schemaName, this.connectionConfig.connection.user]
+        );
+      }
 
       // this.sqlClient = knex(this.connectionConfig);
     } catch (e) {


### PR DESCRIPTION
## Change Summary

This change adds a schemaExists check. The check doesn't need `CREATE ON DATABASE` permissions. Whereas the `CREATE SCHEMA IF NOT EXISTS ??  AUTHORIZATION ?? ` does.

So it avoids throwing an error in case where both: 
- The schema already exists
- The user doesn't have  `CREATE ON DATABASE` permission

Fixes issue: https://github.com/nocodb/nocodb/issues/5398

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Running loaclly. Awaiting workflow 
