### PR TITLE
fix(nocodb): add missing parsing logic

### DIFF
--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -3242,17 +3242,24 @@ function extractCondition(nestedArrayConditions, aliasColObjMap) {
     // eslint-disable-next-line prefer-const
     let [logicOp, alias, op, value] =
       str.match(/(?:~(and|or|not))?\((.*?),(\w+),(.*)\)/)?.slice(1) || [];
+
+    if (!alias && !op && !value) {
+      // try match with blank filter format
+      [logicOp, alias, op, value] =
+        str.match(/(?:~(and|or|not))?\((.*?),(\w+)\)/)?.slice(1) || [];
+    }
     let sub_op = null;
 
     if (aliasColObjMap[alias]) {
       if (
         [UITypes.Date, UITypes.DateTime].includes(aliasColObjMap[alias].uidt)
       ) {
-        value = value.split(',');
+        value = value?.split(',');
         // the first element would be sub_op
-        sub_op = value[0];
+        sub_op = value?.[0];
         // remove the first element which is sub_op
-        value.shift();
+        value?.shift();
+        value = value?.[0];
       } else if (op === 'in') {
         value = value.split(',');
       }


### PR DESCRIPTION
## Change Summary

closes: #5456

- previously we only handle `(x,y,z)` but not `(x,y)`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
