### PR TITLE
docs: adopt NuxtLink for internal routes

### DIFF
--- a/packages/noco-docs/content/en/developer-resources/rest-apis.md
+++ b/packages/noco-docs/content/en/developer-resources/rest-apis.md
@@ -12,7 +12,7 @@ Once you've created the schemas, you can manipulate the data or invoke actions u
 
 Here's the overview of all APIs. For the details, please check out <a href="https://all-apis.nocodb.com/" target="_blank">NocoDB API Documentation</a>. 
 
-You may also interact with the API's resources via <a href="./accessing-apis#swagger-ui" target="_blank">Swagger UI</a>.
+You may also interact with the API's resources via <NuxtLink to="/developer-resources/accessing-apis#swagger-ui" target="_blank">Swagger UI</NuxtLink>.
 
 <alert type="success">
 Currently, the default value for {orgs} is <b>noco</b>. Users will be able to change it in the future release.

--- a/packages/noco-docs/content/en/developer-resources/sdk.md
+++ b/packages/noco-docs/content/en/developer-resources/sdk.md
@@ -9,7 +9,7 @@ menuTitle: 'NocoDB SDK'
 We provide SDK for users to integrate with their applications. Currently only SDK for Javascript is supported.
 
 <alert>
-Note: The NocoDB SDK requires authorization token. If you haven't created one, please check out <a href="./accessing-apis" target="_blank">Accessing APIs</a> for details.
+Note: The NocoDB SDK requires authorization token. If you haven't created one, please check out <NuxtLink to="/developer-resources/accessing-apis" target="_blank">Accessing APIs</NuxtLink> for details.
 </alert>
 
 ## SDK For Javascript
@@ -57,7 +57,7 @@ const api = new Api({
 Once you have configured `api`, you can call different types of APIs by `api.<Tag>.<FunctionName>`. 
 
 <alert>
-For Tag and FunctionName, please check out the API table <a href="./rest-apis" target="_blank">here</a>.
+For Tag and FunctionName, please check out the API table <NuxtLink to="/developer-resources/rest-apis" target="_blank">here</NuxtLink>.
 </alert>
 
 #### Example: Calling API - /api/v1/db/meta/projects/{projectId}/tables

--- a/packages/noco-docs/content/en/getting-started/upgrading.md
+++ b/packages/noco-docs/content/en/getting-started/upgrading.md
@@ -8,7 +8,7 @@ link: https://codesandbox.io/embed/vigorous-firefly-80kq5?hidenavigation=1&theme
 ---
 
 By default, if `NC_DB` is not specified upon 
-<a href="./installation" target="_blank">installation</a>, then SQLite will be used to store metadata. We suggest users to separate the metadata and user data in different databases as pictured in our <a href="../engineering/architecture" target="_blank">architecture</a>. 
+<NuxtLink to="/getting-started/installation" target="_blank">installation</NuxtLink>, then SQLite will be used to store metadata. We suggest users to separate the metadata and user data in different databases as pictured in our <NuxtLink to="/engineering/architecture" target="_blank">architecture</NuxtLink>. 
 
 ## Docker
 

--- a/packages/noco-docs/content/en/index.md
+++ b/packages/noco-docs/content/en/index.md
@@ -31,7 +31,7 @@ Also NocoDB's app store allows you to build business workflows on views with com
 
 ### App Store for Workflow Automations
 
-We provide different integrations in three main categories. See <a href="./setup-and-usages/app-store" target="_blank">App Store</a> for details.
+We provide different integrations in three main categories. See <NuxtLink to="/setup-and-usages/account-settings#app-store" target="_blank">App Store</NuxtLink> for details.
 
 - ⚡ &nbsp;Chat : Slack, Discord, Mattermost, and etc
 - ⚡ &nbsp;Email : AWS SES, SMTP, MailerSend, and etc
@@ -46,11 +46,11 @@ We provide the following ways to let users to invoke actions in a programmatic w
 
 ### Sync Schema
 
-We allow you to sync schema changes if you have made changes outside NocoDB GUI. However, it has to be noted then you will have to bring your own schema migrations for moving from environment to others. See <a href="./setup-and-usages/sync-schema" target="_blank">Sync Schema</a> for details.
+We allow you to sync schema changes if you have made changes outside NocoDB GUI. However, it has to be noted then you will have to bring your own schema migrations for moving from environment to others. See <NuxtLink to="/setup-and-usages/sync-schema" target="_blank">Sync Schema</NuxtLink> for details.
 
 ### Audit 
 
-We are keeping all the user operation logs under one place. See <a href="./setup-and-usages/audit" target="_blank">Audit</a> for details.
+We are keeping all the user operation logs under one place. See <NuxtLink to="/setup-and-usages/audit" target="_blank">Audit</NuxtLink> for details.
 
 ##  Why are we building this?
 Most internet businesses equip themselves with either spreadsheet or a database to solve their business needs. Spreadsheets are used by a Billion+ humans collaboratively every single day. However, we are way off working at similar speeds on databases which are way more powerful tools when it comes to computing. Attempts to solve this with SaaS offerings has meant horrible access controls, vendor lockin, data lockin, abrupt price changes & most importantly a glass ceiling on what's possible in future.

--- a/packages/noco-docs/content/en/setup-and-usages/meta-management.md
+++ b/packages/noco-docs/content/en/setup-and-usages/meta-management.md
@@ -28,7 +28,7 @@ To access it, click the down arrow button next to Project Name on the top left s
 
 ## Sync Metadata
 
-Go to `Data Sources`, click ``Sync Metadata``, you can see your metadata sync status. If it is out of sync, you can sync the schema. See <a href="./sync-schema">Sync Schema</a> for more.0
+Go to `Data Sources`, click ``Sync Metadata``, you can see your metadata sync status. If it is out of sync, you can sync the schema. See <NuxtLink to="/setup-and-usages/sync-schema">Sync Schema</NuxtLink> for more.
 
 ![image](https://user-images.githubusercontent.com/35857179/219833485-3bcaa6ec-88bc-47cc-b938-5abb4835dc31.png)
 

--- a/packages/noco-docs/content/en/setup-and-usages/table-operations.md
+++ b/packages/noco-docs/content/en/setup-and-usages/table-operations.md
@@ -155,7 +155,7 @@ You can use Quick Import when you have data from external sources such as Airtab
 
 ### Import Airtable into an Existing Project
 
-- See <a href="./import-airtable-to-sql-database-within-a-minute-for-free">here</a>
+- See <NuxtLink to="/setup-and-usages/import-airtable-to-sql-database-within-a-minute-for-free">here</NuxtLink>
 
 ### Import CSV data into an Existing Project
 
@@ -165,7 +165,7 @@ You can use Quick Import when you have data from external sources such as Airtab
   - **Use First Row as Headers**: If it is checked, the first row will be treated as header row.
   - **Import Data**: If it is checked, all data will be imported. Otherwise, only table will be created.
   ![image](https://user-images.githubusercontent.com/35857179/197454479-1ed18dce-1d0b-4ee3-88b3-9b6a132dea2a.png)
-- You can revise the table name by double clicking it, column name and column type. By default, the first column will be chosen as <a href="./display-value" target="_blank">Display Value</a> and cannot be deleted.
+- You can revise the table name by double clicking it, column name and column type. By default, the first column will be chosen as <NuxtLink to="/setup-and-usages/display-value" target="_blank">Display Value</NuxtLink> and cannot be deleted.
   ![image](https://user-images.githubusercontent.com/35857179/197454633-5b30323e-2b13-4c55-843a-948c093d373e.png)
 - Click `Import` to start importing process. The table will be created and the data will be imported.
   ![image](https://user-images.githubusercontent.com/35857179/197455547-2d93df5e-a7f0-4c88-af53-990067625967.png)
@@ -178,7 +178,7 @@ You can use Quick Import when you have data from external sources such as Airtab
   - **Use First Row as Headers**: If it is checked, the first row will be treated as header row.
   - **Import Data**: If it is checked, all data will be imported. Otherwise, only table will be created.
   ![image](https://user-images.githubusercontent.com/35857179/197455788-8dd8a7d1-38f3-48c3-a05e-6ab0cf25045c.png)
-- You can revise the table name, column name and column type. By default, the first column will be chosen as <a href="./display-value" target="_blank">Display Value</a> and cannot be deleted.
+- You can revise the table name, column name and column type. By default, the first column will be chosen as <NuxtLink to="/setup-and-usages/display-value" target="_blank">Display Value</NuxtLink> and cannot be deleted.
   <alert>
   Note: If your Excel file contains multiple sheets, each sheet will be stored in a separate table.
   </alert>


### PR DESCRIPTION
## Change Summary

Currently if you directly access a page then click a link, the target link will not be correct. This PR is to change `<a href="...">...</a>` to `<NuxtLink/>` with full path for all internal routes. External routes will remain unchanged. 

- closes: #5468

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
