### PR TITLE
test: docker PG version upgrade

### DIFF
--- a/packages/nocodb/docker-compose.yml
+++ b/packages/nocodb/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.2"
 
 services:
     # db55:
@@ -96,8 +96,8 @@ services:
     #     - 5495:5432
     #   volumes:
     #     - ./pg-sakila-db:/docker-entrypoint-initdb.d
-    pg96:
-     image: postgres:9.6
+    pg147:
+     image: postgres:14.7
      restart: always
      environment:
        POSTGRES_PASSWORD: password

--- a/tests/playwright/scripts/docker-compose-pg-pw-quick.yml
+++ b/tests/playwright/scripts/docker-compose-pg-pw-quick.yml
@@ -1,8 +1,8 @@
-version: "2.1"
+version: "2.2"
 
 services:
-    pg96:
-        image: postgres:9.6
+    pg147:
+        image: postgres:14.7
         restart: always
         environment:
             POSTGRES_PASSWORD: password

--- a/tests/playwright/scripts/docker-compose-pg.yml
+++ b/tests/playwright/scripts/docker-compose-pg.yml
@@ -1,8 +1,8 @@
-version: "2.1"
+version: "2.2"
 
 services:
-    pg96:
-        image: postgres:9.6
+    pg147:
+        image: postgres:14.7
         restart: always
         environment:
             POSTGRES_PASSWORD: password


### PR DESCRIPTION
## Change Summary
PG 9.6 isn't supported anymore. Some of the tests behaved differently with PG 9.6

## Change type
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
Version upgrade for PG docker

## Additional information / screenshots (optional)
https://github.com/nocodb/nocodb/issues/5478