### PR TITLE
fix: bridge table identification

### DIFF
--- a/packages/nocodb/src/lib/db/sql-client/lib/sqlite/SqliteClient.ts
+++ b/packages/nocodb/src/lib/db/sql-client/lib/sqlite/SqliteClient.ts
@@ -409,7 +409,7 @@ class SqliteClient extends KnexClient {
         response[i].not_nullable = response[i].notnull === 1;
         response[i].rqd = response[i].notnull === 1;
         response[i].cdf = response[i].dflt_value;
-        response[i].pk = response[i].pk === 1;
+        response[i].pk = response[i].pk > 0;
         response[i].cop = response[i].cid;
 
         // https://stackoverflow.com/a/7906029

--- a/packages/nocodb/src/lib/services/metaDiff.svc.ts
+++ b/packages/nocodb/src/lib/services/metaDiff.svc.ts
@@ -1010,7 +1010,7 @@ export async function extractAndGenerateManyToManyRelations(
     }
 
     // todo: impl better method to identify m2m relation
-    if (belongsToCols?.length === 2 && normalColumns.length < 5) {
+    if (belongsToCols?.length === 2 && normalColumns.length < 5 && assocModel.primaryKeys.length === 2) {
       const modelA = await belongsToCols[0].colOptions.getRelatedTable();
       const modelB = await belongsToCols[1].colOptions.getRelatedTable();
 


### PR DESCRIPTION
## Change Summary

Inventory table on sakila db was mapped as mm incorrectly.
- Check if bridge table has exactly 2 primary keys
- SQLite pragma table_info returns pk as incremental so use >0 instead of === 1 to support composite pks

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
