### PR TITLE
fix(nc-gui): datetime filters

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/FilterInput.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/FilterInput.vue
@@ -115,18 +115,28 @@ const booleanOptions = [
   { value: null, label: 'unset' },
 ]
 
+const renderSingleSelect = (op: string) => {
+  // use MultiSelect for SingleSelect columns for anyof / nanyof filters
+  if (['anyof', 'nanyof'].includes(op)) {
+    return MultiSelect
+  }
+  return SingleSelect
+}
+
+const renderDateFilterInput = (sub_op: string) => {
+  if (['daysAgo', 'daysFromNow', 'pastNumberOfDays', 'nextNumberOfDays'].includes(sub_op)) {
+    return Decimal
+  }
+  return DatePicker
+}
+
 const componentMap: Partial<Record<FilterType, any>> = $computed(() => {
   return {
-    // use MultiSelect for SingleSelect columns for anyof / nanyof filters
-    isSingleSelect: ['anyof', 'nanyof'].includes(props.filter.comparison_op!) ? MultiSelect : SingleSelect,
+    isSingleSelect: renderSingleSelect(props.filter.comparison_op!),
     isMultiSelect: MultiSelect,
-    isDate: ['daysAgo', 'daysFromNow', 'pastNumberOfDays', 'nextNumberOfDays'].includes(props.filter.comparison_sub_op!)
-      ? Decimal
-      : DatePicker,
+    isDate: renderDateFilterInput(props.filter.comparison_sub_op!),
     isYear: YearPicker,
-    isDateTime: ['daysAgo', 'daysFromNow', 'pastNumberOfDays', 'nextNumberOfDays'].includes(props.filter.comparison_sub_op!)
-      ? Decimal
-      : DateTimePicker,
+    isDateTime: renderDateFilterInput(props.filter.comparison_sub_op!),
     isTime: TimePicker,
     isRating: Rating,
     isDuration: Duration,

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/conditionV2.ts
@@ -406,7 +406,7 @@ const parseConditionV2 = async (
         switch (filter.comparison_op) {
           case 'eq':
             if (column.uidt === UITypes.DateTime) {
-              // for filter `is + exactDate`, we only match the date only
+              // for filter with input (exactDate), we only match the date
               qb = qb.whereRaw(
                 `${convertDateFormatByType(
                   field,
@@ -446,7 +446,7 @@ const parseConditionV2 = async (
           case 'neq':
           case 'not':
             if (column.uidt === UITypes.DateTime) {
-              // for filter `is + exactDate`, we only match the date only
+              // for filter with input (exactDate), we only match the date
               qb = qb.whereRaw(
                 `${convertDateFormatByType(
                   field,

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/helpers/formulaFnHelper.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/helpers/formulaFnHelper.ts
@@ -54,6 +54,25 @@ export function validateDateWithUnknownFormat(v: string) {
   return false;
 }
 
+export function convertDateFormatByType(query, clientType, dateFormat) {
+  if (clientType === 'mysql2') {
+    query = `DATE_FORMAT(${query}, '${convertDateFormat(
+      dateFormat,
+      clientType
+    )}')`;
+  } else if (clientType === 'pg') {
+    query = `TO_CHAR(${query}, '${convertDateFormat(dateFormat, clientType)}')`;
+  } else if (clientType === 'sqlite3') {
+    query = `strftime('${convertDateFormat(
+      dateFormat,
+      clientType
+    )}', ${query})`;
+  } else if (clientType === 'mssql') {
+    query = `FORMAT(${query}, '${convertDateFormat(dateFormat, clientType)}')`;
+  }
+  return query;
+}
+
 export async function convertDateFormatForConcat(
   o,
   columnIdToUidt,
@@ -71,27 +90,7 @@ export async function convertDateFormatForConcat(
       })
     ).meta;
 
-    if (clientType === 'mysql2') {
-      query = `DATE_FORMAT(${query}, '${convertDateFormat(
-        meta.date_format,
-        clientType
-      )}')`;
-    } else if (clientType === 'pg') {
-      query = `TO_CHAR(${query}, '${convertDateFormat(
-        meta.date_format,
-        clientType
-      )}')`;
-    } else if (clientType === 'sqlite3') {
-      query = `strftime('${convertDateFormat(
-        meta.date_format,
-        clientType
-      )}', ${query})`;
-    } else if (clientType === 'mssql') {
-      query = `FORMAT(${query}, '${convertDateFormat(
-        meta.date_format,
-        clientType
-      )}')`;
-    }
+    return convertDateFormatByType(query, clientType, meta.date_format);
   }
   return query;
 }


### PR DESCRIPTION
## Change Summary

- for `eq` in datetime filter, it will check the date only. (following AT pattern)
- closes: #5483

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
