### PR TITLE
fix(nc-gui): retrieve the comment part from the audit description

### DIFF
--- a/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
@@ -158,7 +158,11 @@ watch(
                     class="block caption my-2 nc-chip w-full min-h-20px p-2 rounded"
                     :style="{ backgroundColor: enumColor.light[2] }"
                   >
-                    {{ log.description }}
+                    <!--
+                      retrieve the comment part from the audit description
+                      `The following comment has been created: foo` -> `foo`
+                    -->
+                    {{ log.description.substring(log.description.indexOf(':') + 1) }}
                   </p>
                 </div>
 

--- a/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
@@ -166,7 +166,9 @@ watch(
                   </p>
                 </div>
 
-                <p v-else v-dompurify-html="log.details" class="caption my-3" style="word-break: break-all" />
+                <p v-if="log.details" v-dompurify-html="log.details" class="caption my-3" style="word-break: break-all" />
+
+                <p v-else>{{ log.description }}</p>
 
                 <p class="time text-right text-[10px] mb-0 mt-1 text-gray-500">
                   {{ timeAgo(log.created_at) }}

--- a/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Comments.vue
@@ -166,7 +166,7 @@ watch(
                   </p>
                 </div>
 
-                <p v-if="log.details" v-dompurify-html="log.details" class="caption my-3" style="word-break: break-all" />
+                <p v-else-if="log.details" v-dompurify-html="log.details" class="caption my-3" style="word-break: break-all" />
 
                 <p v-else>{{ log.description }}</p>
 

--- a/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/lib/db/sql-data-mapper/lib/sql/BaseModelSqlv2.ts
@@ -2402,6 +2402,7 @@ class BaseModelSqlv2 {
   ): Promise<void> {
     const id = this._extractPksValues(newData);
     let desc = `Record with ID ${id} has been updated in Table ${this.model.title}.`;
+    let details = '';
     if (updateObj) {
       updateObj = await this.model.mapColumnToAlias(updateObj);
       for (const k of Object.keys(updateObj)) {
@@ -2415,6 +2416,9 @@ class BaseModelSqlv2 {
             : newData[k];
         desc += `\n`;
         desc += `Column "${k}" got changed from "${prevValue}" to "${newValue}"`;
+        details += DOMPurify.sanitize(`<span class="">${k}</span>
+  : <span class="text-decoration-line-through red px-2 lighten-4 black--text">${prevValue}</span>
+  <span class="black--text green lighten-4 px-2">${newValue}</span>`);
       }
     }
     await Audit.insert({
@@ -2423,7 +2427,7 @@ class BaseModelSqlv2 {
       op_type: AuditOperationTypes.DATA,
       op_sub_type: AuditOperationSubTypes.UPDATE,
       description: DOMPurify.sanitize(desc),
-      // details: JSON.stringify(data),
+      details,
       ip: req?.clientIp,
       user: req?.user?.email,
     });


### PR DESCRIPTION
## Change Summary

- currently comments would show `The following comment has been created: <comment>` which is from audit description. In comment component, we just need to show the comment part.
- fix missing audit edit details
- if details are not found, use description instead.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

before

![image](https://user-images.githubusercontent.com/35857179/233248682-61d0c79a-404b-4d58-8eca-a04394d1cd36.png)

after 

![image](https://user-images.githubusercontent.com/35857179/233248645-223af9eb-1803-4784-a769-fac9cbd9b019.png)


