### PR TITLE
Bug fix for Issue #5438, resolved text-overflow with text-wrapping

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -743,7 +743,7 @@ watch(view, (nextView) => {
                     </LazySmartsheetDivDataCell>
                   </a-form-item>
 
-                  <div class="text-gray-500 text-xs" data-testid="nc-form-input-help-text-label">{{ element.description }}</div>
+                  <div class="nc-form-input-description text-gray-500 text-xs" data-testid="nc-form-input-help-text-label">{{ element.description }}</div>
                 </div>
               </template>
 
@@ -859,6 +859,12 @@ watch(view, (nextView) => {
   &::placeholder {
     @apply !text-gray-500 !text-xs;
   }
+}
+
+.nc-form-input-description {
+  max-width: 100%;
+  word-break: break-all;
+  white-space: pre-line;
 }
 
 :deep(.nc-cell-attachment) {

--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -861,7 +861,7 @@ watch(view, (nextView) => {
   }
 }
 
-.nc-form-input-description {
+.nc-form-help-text {
   max-width: 100%;
   word-break: break-all;
   white-space: pre-line;

--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -743,7 +743,7 @@ watch(view, (nextView) => {
                     </LazySmartsheetDivDataCell>
                   </a-form-item>
 
-                  <div class="nc-form-input-description text-gray-500 text-xs" data-testid="nc-form-input-help-text-label">{{ element.description }}</div>
+                  <div class="nc-form-help-text text-gray-500 text-xs" data-testid="nc-form-input-help-text-label">{{ element.description }}</div>
                 </div>
               </template>
 

--- a/packages/nc-gui/components/smartsheet/header/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/header/Cell.vue
@@ -53,7 +53,7 @@ const openHeaderMenu = () => {
       v-if="column"
       class="name"
       :class="{ 'cursor-pointer': !isForm && isUIAllowed('edit-column') }"
-      style="white-space: nowrap"
+      style="white-space: pre-line"
       :title="column.title"
       @dblclick="openHeaderMenu"
       >{{ column.title }}</span
@@ -95,7 +95,6 @@ const openHeaderMenu = () => {
 <style scoped>
 .name {
   max-width: calc(100% - 40px);
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-all;
 }
 </style>


### PR DESCRIPTION
## Change Summary

This PR resolves [Issue ##5438](https://github.com/nocodb/nocodb/issues/5438) regarding the buggy view of the text on the form view, specifically the form input label and the form help text. Both were resolved by setting `word-break` to `break-all` and allowing wrapping to occur in these text fields.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Here's some pictures of it working, and the text is now wrapping. No truncation or overflow is occurring.

<img width="590" alt="Screen Shot 2023-04-23 at 9 12 34 PM" src="https://user-images.githubusercontent.com/75632283/233898469-75aef501-c1d9-44e3-8b4a-457d5897516d.png">
<img width="610" alt="Screen Shot 2023-04-23 at 9 12 42 PM" src="https://user-images.githubusercontent.com/75632283/233898496-f39d1229-2a23-4e8d-8ab6-3078b39360fc.png">

## Additional information / screenshots (optional)

This is my first PR to NocoDB, so please let me know if there's anything I can fix for y'all!
