### PR TITLE
fix(nocodb): allow kanban for calling publicHmList and publicMmList

### DIFF
--- a/packages/nocodb-nest/src/services/public-datas.service.ts
+++ b/packages/nocodb-nest/src/services/public-datas.service.ts
@@ -360,7 +360,8 @@ export class PublicDatasService {
     const view = await View.getByUUID(param.sharedViewUuid);
 
     if (!view) NcError.notFound('Not found');
-    if (view.type !== ViewTypes.GRID) NcError.notFound('Not found');
+    if (view.type !== ViewTypes.GRID && view.type !== ViewTypes.KANBAN)
+      NcError.notFound('Not found');
 
     if (view.password && view.password !== param.password) {
       NcError.forbidden(ErrorMessages.INVALID_SHARED_VIEW_PASSWORD);
@@ -425,7 +426,8 @@ export class PublicDatasService {
     const view = await View.getByUUID(param.sharedViewUuid);
 
     if (!view) NcError.notFound('Not found');
-    if (view.type !== ViewTypes.GRID) NcError.notFound('Not found');
+    if (view.type !== ViewTypes.GRID && view.type !== ViewTypes.KANBAN)
+      NcError.notFound('Not found');
 
     if (view.password && view.password !== param.password) {
       NcError.forbidden(ErrorMessages.INVALID_SHARED_VIEW_PASSWORD);


### PR DESCRIPTION
## Change Summary

- previously you can see the error in network tab if a shared kanban contains hm / mm 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://user-images.githubusercontent.com/35857179/234251237-7efdb7bd-b9f2-4e33-aea1-bae4e9616772.png)
