### PR TITLE
fix: drop mm table on column delete

### DIFF
--- a/packages/nc-gui/components/smartsheet/header/Menu.vue
+++ b/packages/nc-gui/components/smartsheet/header/Menu.vue
@@ -14,9 +14,11 @@ import {
   iconMap,
   inject,
   message,
+  useGlobal,
   useI18n,
   useMetas,
   useNuxtApp,
+  useProject,
   useSmartsheetStoreOrThrow,
   useUndoRedo,
 } from '#imports'
@@ -27,6 +29,10 @@ const { virtual = false } = defineProps<{ virtual?: boolean }>()
 const emit = defineEmits(['edit', 'addColumn'])
 
 const { eventBus } = useSmartsheetStoreOrThrow()
+
+const { includeM2M } = useGlobal()
+
+const { loadTables } = useProject()
 
 const column = inject(ColumnInj)
 
@@ -62,6 +68,11 @@ const deleteColumn = () =>
         /** force-reload related table meta if deleted column is a LTAR and not linked to same table */
         if (column?.value?.uidt === UITypes.LinkToAnotherRecord && column.value?.colOptions) {
           await getMeta((column.value?.colOptions as LinkToAnotherRecordType).fk_related_model_id!, true)
+
+          // reload tables if deleted column is mm and include m2m is true
+          if (includeM2M.value && (column.value?.colOptions as LinkToAnotherRecordType).type === RelationTypes.MANY_TO_MANY) {
+            loadTables()
+          }
         }
 
         $e('a:column:delete')

--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -1287,6 +1287,8 @@ export class ColumnsService {
                 // ignore deleting table if it has more than 2 columns
                 // the expected 2 columns would be table1_id & table2_id
                 if (mmTable.columns.length === 2) {
+                  (mmTable as any).tn = mmTable.table_name;
+                  await sqlMgr.sqlOpPlus(base, 'tableDelete', mmTable);
                   await mmTable.delete();
                 }
               }


### PR DESCRIPTION
## Change Summary

We were only removing it from meta (as we only call Model.delete over it) which causing unnecessary mm tables to exist in database.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
