### PR TITLE
feat: Add the same behaviour to LinkToAnotherRecord field type like in Multiselect

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/ListItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/ListItems.vue
@@ -58,11 +58,7 @@ const linkRow = async (row: Record<string, any>) => {
   } else {
     await link(row)
   }
-  if (isAltKeyDown.value) {
-    loadChildrenExcludedList()
-  } else {
-    vModel.value = false
-  }
+  loadChildrenExcludedList()
 }
 
 /** reload list on modal open */


### PR DESCRIPTION
## Change Summary
#closes:  https://github.com/nocodb/nocodb/issues/5068

For 'LinkToAnotherRecord' field type the popup is automatically closed after choose first item. But often there is a need two choose more than one item at the same time. For example when you have dictionary table with nationalities and want to allow user to select more than in another table.


## Change type

- [x] feat: Add the same behaviour to LinkToAnotherRecord field type like in Multiselect

## Test/ Verification

Provide summary of changes.
https://www.loom.com/share/a563fab8f7564fb390e63dc701f2816d


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
