### PR TITLE
fix(nc-gui): filter nested group

### DIFF
--- a/packages/nocodb/src/controllers/filters.controller.ts
+++ b/packages/nocodb/src/controllers/filters.controller.ts
@@ -71,7 +71,7 @@ export class FiltersController {
 
   @Get('/api/v1/db/meta/filters/:filterParentId/children')
   @Acl('filterChildrenList')
-  async filterChildrenRead(filterParentId: string) {
+  async filterChildrenRead(@Param('filterParentId') filterParentId: string) {
     return new PagedResponseImpl(
       await this.filtersService.filterChildrenList({
         filterId: filterParentId,

--- a/packages/nocodb/src/services/filters.service.ts
+++ b/packages/nocodb/src/services/filters.service.ts
@@ -51,7 +51,7 @@ export class FiltersService {
     return filter;
   }
 
-  async filterChildrenList(param: { filterId: any }) {
+  async filterChildrenList(param: { filterId: string }) {
     return Filter.parentFilterList({
       parentId: param.filterId,
     });


### PR DESCRIPTION
## Change Summary

- closes: #5639
- previously `filterParentId` is always undefined since we haven't added `@Param()` decorator for `filterParentId`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://github.com/nocodb/nocodb/assets/35857179/bff7f7c3-28f9-4b7f-9933-0b4378ad8e5b)