### PR TITLE
fix(nocodb): incorrect public path for docker

### DIFF
--- a/packages/nocodb/src/middlewares/public/public.middleware.ts
+++ b/packages/nocodb/src/middlewares/public/public.middleware.ts
@@ -1,6 +1,7 @@
-import { join } from 'path';
+import path, { join } from 'path';
 import { Injectable } from '@nestjs/common';
 import express from 'express';
+import isDocker from 'is-docker';
 import type { NestMiddleware } from '@nestjs/common';
 
 @Injectable()
@@ -13,6 +14,10 @@ export class PublicMiddleware implements NestMiddleware {
     }
 
     // serve static files from public folder
-    express.static(join(process.cwd(), 'public'))(req, res, next);
+    if (isDocker()) {
+      express.static(join(process.cwd(), 'docker', 'public'))(req, res, next);
+    } else {
+      express.static(join(process.cwd(), 'public'))(req, res, next);
+    }
   }
 }


### PR DESCRIPTION
## Change Summary

- in docker, `process.cwd()` is `/usr/src/app` while the public directory is `/usr/src/app/docker/public`
- closes: #5125

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

![image](https://github.com/nocodb/nocodb/assets/35857179/0703c8ba-3981-41ef-a0ad-da09cce5e656)

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
