### PR TITLE
chore: clean up image build script and bug fix with packaging

### DIFF
--- a/build-local-docker-image.sh
+++ b/build-local-docker-image.sh
@@ -8,35 +8,70 @@
 # 3. build nocodb 
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+LOG_FILE=${SCRIPT_DIR}/build-local-docker-image.log
+ERROR=""
 
-#build nocodb-sdk
-echo "Building nocodb-sdk"
-cd ${SCRIPT_DIR}/packages/nocodb-sdk 
-npm ci 
-npm run build
+function build_sdk(){
+    #build nocodb-sdk    
+    cd ${SCRIPT_DIR}/packages/nocodb-sdk 
+    npm ci || ERROR="sdk build failed"
+    npm run build || ERROR="sdk build failed"
+}
 
-# build nc-gui
-echo "Building nc-gui"
-export NODE_OPTIONS="--max_old_space_size=16384"
-# generate static build of nc-gui
-cd ${SCRIPT_DIR}/packages/nc-gui 
-npm ci 
-npm run generate 
+function build_gui(){
+    # build nc-gui
+    export NODE_OPTIONS="--max_old_space_size=16384"
+    # generate static build of nc-gui
+    cd ${SCRIPT_DIR}/packages/nc-gui 
+    npm ci || ERROR="gui build failed"
+    npm run generate || ERROR="gui build failed"
+}
 
-# copy nc-gui build to nocodb dir 
-rsync -rvzh --delete ./dist/ ${SCRIPT_DIR}/packages/nocodb/docker/nc-gui/
+function copy_gui_artifacts(){
+     # copy nc-gui build to nocodb dir          
+    rsync -rvzh --delete ./dist/ ${SCRIPT_DIR}/packages/nocodb/docker/nc-gui/ || ERROR="copy_gui_artifacts failed"
+}
 
-#build nocodb
-# build nocodb ( pack nocodb-sdk and nc-gui )
-cd ${SCRIPT_DIR}/packages/nocodb  
-npm install 
-EE=true ./node_modules/.bin/webpack --config webpack.local.config.js 
-# remove nocodb-sdk since it's packed with the build
-npm uninstall --save nocodb-sdk
+function package_nocodb(){
+    #build nocodb
+    # build nocodb ( pack nocodb-sdk and nc-gui )    
+    cd ${SCRIPT_DIR}/packages/nocodb  
+    npm install || ERROR="package_nocodb failed"
+    EE=true ./node_modules/.bin/webpack --config webpack.local.config.js || ERROR="package_nocodb failed"
+}
 
-# build docker 
-docker build . -f Dockerfile.local -t nocodb-local
+function build_image(){
+    # build docker 
+    docker build . -f Dockerfile.local -t nocodb-local || ERROR="build_image failed"
+}
 
-echo 'docker image with tag "nocodb-local" built sussessfully. Use below sample command to run the container'
-echo 'docker run -d -p 3333:8080 --name nocodb-local nocodb-local '
+function log_message(){
+    if [[ ${ERROR} != "" ]]; 
+    then
+        >&2 echo "build failed, Please check build-local-docker-image.log for more details"
+        >&2 echo "ERROR: ${ERROR}"      
+        exit 1  
+    else 
+        echo 'docker image with tag "nocodb-local" built sussessfully. Use below sample command to run the container'
+        echo 'docker run -d -p 3333:8080 --name nocodb-local nocodb-local '
+    fi
+}
 
+echo "Info: Building nocodb-sdk" | tee ${LOG_FILE}
+build_sdk 1>> ${LOG_FILE} 2>> ${LOG_FILE}
+
+echo "Info: Building nc-gui" | tee -a ${LOG_FILE}
+build_gui  1>> ${LOG_FILE} 2>> ${LOG_FILE}
+
+echo "Info: copy nc-gui build to nocodb dir" | tee -a ${LOG_FILE}
+copy_gui_artifacts 1>> ${LOG_FILE} 2>> ${LOG_FILE}
+
+echo "Info: build nocodb, package nocodb-sdk and nc-gui" | tee -a ${LOG_FILE}
+package_nocodb 1>> ${LOG_FILE} 2>> ${LOG_FILE}
+
+if [[ ${ERROR} == "" ]]; then
+    echo "Info: building docker image" | tee -a ${LOG_FILE}
+    build_image 1>> ${LOG_FILE} 2>> ${LOG_FILE}
+fi
+
+log_message  | tee -a ${LOG_FILE}

--- a/packages/nocodb/Dockerfile.local
+++ b/packages/nocodb/Dockerfile.local
@@ -21,6 +21,7 @@ COPY ./public/favicon.ico ./docker/public/
 # install production dependencies,
 # reduce node_module size with modclean & removing sqlite deps,
 # package built code into app.tar.gz & add execute permission to start.sh
+RUN npm uninstall --save nocodb-sdk
 RUN npm ci --omit=dev --quiet \
     && npx modclean --patterns="default:*" --ignore="nc-lib-gui/**,dayjs/**,express-status-monitor/**,@azure/msal-node/dist/**" --run  \
     && rm -rf ./node_modules/sqlite3/deps \

--- a/packages/nocodb/webpack.local.config.js
+++ b/packages/nocodb/webpack.local.config.js
@@ -42,7 +42,6 @@ module.exports = {
     globalObject: "typeof self !== 'undefined' ? self : this",
   },
   node: {
-    fs: 'empty',
     __dirname: false,
   },
   plugins: [new webpack.EnvironmentPlugin(['EE'])],


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

1. modularised shell script "build-local-docker-image.sh". Breaking down into smaller functions. 
2. stdout all the messages to a dedicated file so future debugging becomes easier
3. npm uninstall nocodb-sdk is removed from here and its now happening in DockerFile. This will help avoiding an updated to package.json and package-lock.json in local git repo. 
4. fix module.exports.node from packages/nocodb/webpack.local.config.js. This was failing under certain versions of node

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
