### PR TITLE
fix(nocodb):use is-inside-container to account ffor non-docker container runtime

### DIFF
--- a/packages/nocodb/package-lock.json
+++ b/packages/nocodb/package-lock.json
@@ -63,7 +63,7 @@
         "inflection": "^1.12.0",
         "ioredis": "^4.28.5",
         "ioredis-mock": "^7.1.0",
-        "is-docker": "^2.2.1",
+        "is-inside-container": "^1.0.0",
         "isomorphic-dompurify": "^0.19.0",
         "jsep": "^1.3.6",
         "jsonfile": "^6.1.0",
@@ -10328,6 +10328,37 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -26259,6 +26290,21 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "requires": {
+        "is-docker": "^3.0.0"
+      },
+      "dependencies": {
+        "is-docker": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+          "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="
+        }
       }
     },
     "is-interactive": {

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -94,7 +94,7 @@
     "inflection": "^1.12.0",
     "ioredis": "^4.28.5",
     "ioredis-mock": "^7.1.0",
-    "is-docker": "^2.2.1",
+    "is-inside-container": "^1.0.0",
     "isomorphic-dompurify": "^0.19.0",
     "jsep": "^1.3.6",
     "jsonfile": "^6.1.0",

--- a/packages/nocodb/src/controllers/projects.controller.ts
+++ b/packages/nocodb/src/controllers/projects.controller.ts
@@ -12,7 +12,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import isDocker from 'is-docker';
+import isDocker from 'is-inside-container';
 import { ProjectReqType } from 'nocodb-sdk';
 import { GlobalGuard } from '../guards/global/global.guard';
 import { PagedResponseImpl } from '../helpers/PagedResponse';

--- a/packages/nocodb/src/middlewares/public/public.middleware.ts
+++ b/packages/nocodb/src/middlewares/public/public.middleware.ts
@@ -1,7 +1,7 @@
 import path, { join } from 'path';
 import { Injectable } from '@nestjs/common';
 import express from 'express';
-import isDocker from 'is-docker';
+import isDocker from 'is-inside-container';
 import type { NestMiddleware } from '@nestjs/common';
 
 @Injectable()


### PR DESCRIPTION
## Change Summary

- In non-docker container runtime, we are still seeing the issue where the swagger API views are not properly loaded after #5693 . Using https://github.com/sindresorhus/is-inside-container instead of `is-docker` to account for both docker and non-docker container runtimes.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
