### PR TITLE
fix(nocodb): Fixed filtering boolean visual bug

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -225,7 +225,8 @@ defineExpose({
             />
             <span v-else :key="`${i}dummy`" />
 
-            <div :key="`${i}nested`" class="flex">
+            <span v-if="!i" class="flex items-center">{{ $t('labels.where') }}</span>
+            <div v-else :key="`${i}nested`" class="flex bob">
               <a-select
                 v-model:value="filter.logical_op"
                 :dropdown-match-select-width="false"


### PR DESCRIPTION
## Change Summary

See Issue #5648 for context. The changes I made should fix that and remove the dropdown from appearing on the first issue, thereby reducing confusion on why there's a boolean operator selector at the front of the filtering UI.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

When adding a filter group, this is what it looks like:

<img width="524" alt="Screen Shot 2023-05-22 at 6 04 53 PM" src="https://github.com/nocodb/nocodb/assets/75632283/a71a3930-41ff-4d34-b74b-f9bb70dc6e74">

Let's say I added a filter at the bottom of the filter group (or filter) and then deleted the top filter. The "Where" word will automatically update.

Before deleting top filter group:
<img width="577" alt="Screen Shot 2023-05-22 at 6 05 35 PM" src="https://github.com/nocodb/nocodb/assets/75632283/fea98e0a-5435-4411-b75e-10a7cc0f8477">

After deleting top filter group:
<img width="538" alt="Screen Shot 2023-05-22 at 6 05 53 PM" src="https://github.com/nocodb/nocodb/assets/75632283/082dabed-82f3-4d89-b171-9b72ea245722">

This applies to the nested ones as well.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
