### PR TITLE
fix(nocodb): model list cache

### DIFF
--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -138,7 +138,7 @@ export default class Model implements TableType {
 
     await NocoCache.appendToList(
       CacheScope.MODEL,
-      [projectId],
+      [projectId, baseId],
       `${CacheScope.MODEL}:${id}`,
     );
 

--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -169,7 +169,10 @@ export default class Model implements TableType {
     },
     ncMeta = Noco.ncMeta,
   ): Promise<Model[]> {
-    const cachedList = await NocoCache.getList(CacheScope.MODEL, [project_id]);
+    const cachedList = await NocoCache.getList(CacheScope.MODEL, [
+      project_id,
+      base_id,
+    ]);
     let { list: modelList } = cachedList;
     const { isNoneList } = cachedList;
     if (!isNoneList && !modelList.length) {
@@ -189,7 +192,11 @@ export default class Model implements TableType {
         model.meta = parseMetaProp(model);
       }
 
-      await NocoCache.setList(CacheScope.MODEL, [project_id], modelList);
+      await NocoCache.setList(
+        CacheScope.MODEL,
+        [project_id, base_id],
+        modelList,
+      );
     }
     modelList.sort(
       (a, b) =>


### PR DESCRIPTION
## Change Summary

Previously we only allowed one base so `base_id` wasn't included in the cache key. Since currently multiple bases are possible, hence this PR is to include it.

- closes: #5701
- closes: #5568

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
