### PR TITLE
fix: Update project base config encryption with proper secret key

### DIFF
--- a/packages/nocodb/src/models/Base.ts
+++ b/packages/nocodb/src/models/Base.ts
@@ -91,6 +91,7 @@ export default class Base implements BaseType {
     base: BaseType & {
       id: string;
       projectId: string;
+      skipReorder?: boolean;
     },
     ncMeta = Noco.ncMeta,
   ) {
@@ -144,7 +145,8 @@ export default class Base implements BaseType {
     // call before reorder to update cache
     const returnBase = await this.get(oldBase.id, ncMeta);
 
-    await this.reorderBases(base.projectId, returnBase.id, ncMeta);
+    if (!base.skipReorder)
+      await this.reorderBases(base.projectId, returnBase.id, ncMeta);
 
     return returnBase;
   }

--- a/packages/nocodb/src/services/app-init.service.ts
+++ b/packages/nocodb/src/services/app-init.service.ts
@@ -35,7 +35,7 @@ export const appInitServiceProvider: Provider = {
     metaService: MetaService,
     eventEmitter: IEventEmitter,
   ) => {
-    process.env.NC_VERSION = '0105004';
+    process.env.NC_VERSION = '0107004';
 
     await NocoCache.init();
 

--- a/packages/nocodb/src/version-upgrader/NcUpgrader.ts
+++ b/packages/nocodb/src/version-upgrader/NcUpgrader.ts
@@ -13,6 +13,7 @@ import ncProjectUpgraderV2_0090000 from './ncProjectUpgraderV2_0090000';
 import ncProjectEnvUpgrader0011045 from './ncProjectEnvUpgrader0011045';
 import ncProjectEnvUpgrader from './ncProjectEnvUpgrader';
 import ncHookUpgrader from './ncHookUpgrader';
+import ncProjectConfigUpgrader from './ncProjectConfigUpgrader';
 import type { MetaService } from '../meta/meta.service';
 import type { NcConfig } from '../interface/config';
 
@@ -48,6 +49,7 @@ export default class NcUpgrader {
         { name: '0105002', handler: ncStickyColumnUpgrader },
         { name: '0105003', handler: ncFilterUpgrader_0105003 },
         { name: '0105004', handler: ncHookUpgrader },
+        { name: '0107004', handler: ncProjectConfigUpgrader },
       ];
       if (!(await ctx.ncMeta.knexConnection?.schema?.hasTable?.('nc_store'))) {
         return;

--- a/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
+++ b/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
@@ -42,6 +42,7 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
           id: base.id,
           projectId: base.project_id,
           config,
+          skipReorder: true,
         },
         ncMeta,
       ),

--- a/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
+++ b/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
@@ -1,0 +1,47 @@
+import CryptoJS from 'crypto-js';
+import { Base } from '../models';
+import { MetaTable } from '../utils/globals';
+import type { NcUpgraderCtx } from './NcUpgrader';
+
+const TEMP_KEY = 'temporary-key';
+
+// In version 0.107.0 we were used a temporary fallback secret key for JWT token encryption and project base config encryption.
+// So any project created in version 0.107.0 won't be able to decrypt the project base config.
+// So we need to update the project base config with the new secret key.
+// Get all the project bases and update the project config with the new secret key.
+export default async function ({ ncMeta }: NcUpgraderCtx) {
+  const actions = [];
+
+  // Get all the project bases
+  const bases = await ncMeta.metaList2(null, null, MetaTable.BASES);
+
+  // Update the base config with the new secret key if we could decrypt the base config with the fallback secret key
+  for (const base of bases) {
+    let config;
+
+    // Try to decrypt the base config with the fallback secret key
+    // if we could decrypt the base config with the fallback secret key then we will update the base config with the new secret key
+    // otherwise we will skip the base config update since it is already encrypted with the new secret key
+    try {
+      config = JSON.parse(
+        CryptoJS.AES.decrypt(base.config, TEMP_KEY).toString(CryptoJS.enc.Utf8),
+      );
+    } catch (e) {
+      continue;
+    }
+
+    if (!config) {
+      continue;
+    }
+
+    // Update the base config with the new secret key
+    actions.push(
+      Base.updateBase(base.id, {
+        id: base.id,
+        projectId: base.project_id,
+        config: base.config,
+      }),
+    );
+  }
+  await Promise.all(actions);
+}

--- a/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
+++ b/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
@@ -26,27 +26,23 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
       config = JSON.parse(
         CryptoJS.AES.decrypt(base.config, TEMP_KEY).toString(CryptoJS.enc.Utf8),
       );
+
+      // Update the base config with the new secret key
+      actions.push(
+        Base.updateBase(
+          base.id,
+          {
+            id: base.id,
+            projectId: base.project_id,
+            config,
+            skipReorder: true,
+          },
+          ncMeta,
+        ),
+      );
     } catch (e) {
-      continue;
+      // ignore the error
     }
-
-    if (!config) {
-      continue;
-    }
-
-    // Update the base config with the new secret key
-    actions.push(
-      Base.updateBase(
-        base.id,
-        {
-          id: base.id,
-          projectId: base.project_id,
-          config,
-          skipReorder: true,
-        },
-        ncMeta,
-      ),
-    );
   }
   await Promise.all(actions);
 }

--- a/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
+++ b/packages/nocodb/src/version-upgrader/ncProjectConfigUpgrader.ts
@@ -36,11 +36,15 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
 
     // Update the base config with the new secret key
     actions.push(
-      Base.updateBase(base.id, {
-        id: base.id,
-        projectId: base.project_id,
-        config: base.config,
-      }),
+      Base.updateBase(
+        base.id,
+        {
+          id: base.id,
+          projectId: base.project_id,
+          config,
+        },
+        ncMeta,
+      ),
     );
   }
   await Promise.all(actions);


### PR DESCRIPTION
## Change Summary

This pull request addresses an encryption issue introduced in version 0.107.0. In that version, a temporary fallback secret key was used for JWT token encryption and project base config encryption, causing projects created in 0.107.0 to be unable to decrypt their project base config.

To resolve this issue, this PR updates(using an upgrader) the project base config encryption by using the correct secret key. By updating the encryption, we ensure that all projects created from version 0.107.0 onwards can successfully decrypt their project base config.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Create a project using 0.107.0
- Add an external datasource
- Now connect the same source to our latest version and it may fail to extract config
- test on this branch or PR build with the same `NC_DB`

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
