### PR TITLE
fix: drop dtxp max length from column request schema

### DIFF
--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -1603,7 +1603,7 @@ export interface NormalColumnRequestType {
   /** Data Type Extra */
   dtx?: StringOrNullType;
   /** Data Type Extra Precision */
-  dtxp?: StringOrNullType | number;
+  dtxp?: string | number | null;
   /** Data Type Extra Scale */
   dtxs?: StringOrNullType | number;
   /** Numeric Precision */

--- a/packages/nocodb/src/schema/swagger.json
+++ b/packages/nocodb/src/schema/swagger.json
@@ -17834,10 +17834,13 @@
           "dtxp": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/StringOrNull"
+                "type": "string"
               },
               {
                 "type": "number"
+              },
+              {
+                "type": "null"
               }
             ],
             "description": "Data Type Extra Precision"


### PR DESCRIPTION
## Change Summary

Column dtxp property will be options for select columns which can be longer than 255 (StringOrNull type has 255 maxLength). We have no limit on option count, so it can exceed that limit which results with ajv schema error (TableReqType > NormalColumnRequestType > dtxp).

Note: it is already like this in ColumnType

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
