### PR TITLE
feat: add install:local-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "start:mysql": "docker-compose -f ./tests/playwright/scripts/docker-compose-mysql-playwright.yml up -d",
     "stop:mysql": "docker-compose -f ./tests/playwright/scripts/docker-compose-mysql-playwright.yml down",
     "start:pg": "docker-compose -f ./tests/playwright/scripts/docker-compose-pg.yml up -d",
-    "stop:pg": "docker-compose -f ./tests/playwright/scripts/docker-compose-pg.yml down"
+    "stop:pg": "docker-compose -f ./tests/playwright/scripts/docker-compose-pg.yml down",
+    "install:local-sdk": "node scripts/installLocalSdk.js"
   },
   "dependencies": {
     "express": "^4.18.1",

--- a/scripts/installLocalSdk.js
+++ b/scripts/installLocalSdk.js
@@ -1,0 +1,42 @@
+const { exec } = require('child_process');
+const path = require('path');
+const sdkPath = path.join(__dirname, '..', 'packages', 'nocodb-sdk');
+const guiPath = path.join(__dirname, '..', 'packages', 'nc-gui');
+const nocodbPath = path.join(__dirname, '..', 'packages', 'nocodb');
+
+exec(`cd ${sdkPath} && npm i && npm run build`, (err, stdout, stderr) => {
+    if (err) {
+      console.error(`Error installing dependencies and building nocodb-sdk: ${err}`);
+      return;
+    }
+    
+    console.log(`Dependencies installed and nocodb-sdk built: ${stdout}`);
+
+    const guiPromise = new Promise((resolve, reject) => {
+      exec(`cd ${guiPath} && npm i ${sdkPath}`, (err, stdout, stderr) => {
+        if (err) {
+          reject(`Error installing dependencies for nc-gui: ${err}`);
+        } else {
+          resolve(`Dependencies installed for nc-gui: ${stdout}`);
+        }
+      });
+    });
+  
+    const nocodbPromise = new Promise((resolve, reject) => {
+      exec(`cd ${nocodbPath} && npm i ${sdkPath}`, (err, stdout, stderr) => {
+        if (err) {
+          reject(`Error installing dependencies for nocodb: ${err}`);
+        } else {
+          resolve(`Dependencies installed for nocodb: ${stdout}`);
+        }
+      });
+    });
+
+    Promise.all([guiPromise, nocodbPromise])
+      .then((results) => {
+        console.log(results.join('\n'));
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  });


### PR DESCRIPTION
## Change Summary

- one command to install and build sdk, and install local sdk for frontend and backend.

```
npm run install:local-sdk
```

- used after release / include in github action in the future.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)