### PR TITLE
feat: confirmation request and default settings in the view sharing form

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/ShareView.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ShareView.vue
@@ -2,6 +2,7 @@
 import { ViewTypes } from 'nocodb-sdk'
 import { isString } from '@vueuse/core'
 import tinycolor from 'tinycolor2'
+import { Modal } from 'ant-design-vue'
 import {
   computed,
   extractSdkResponseErrorMsg,
@@ -40,7 +41,7 @@ const { isMobileMode } = useGlobal()
 
 let showShareModel = $ref(false)
 
-const passwordProtected = ref(false)
+const passwordProtected = ref(true)
 
 const shared = ref<SharedView>({ id: '', meta: {}, password: undefined })
 
@@ -100,9 +101,6 @@ const genShareLink = async () => {
     shared.value.meta = { ...shared.value.meta, groupingFieldColumn: groupingFieldColumn.value }
     await updateSharedViewMeta(true)
   }
-
-  passwordProtected.value = !!shared.value.password && shared.value.password !== ''
-
   showShareModel = true
 }
 
@@ -238,6 +236,18 @@ const copyIframeCode = async () => {
     }
   }
 }
+
+const displayConfirmationModal = () => {
+  Modal.confirm({
+    title: 'Are you sure about sharing this view?',
+    okText: 'Yes',
+    okType: 'Primary',
+    cancelText: 'No',
+    onOk() {
+      genShareLink()
+    },
+  })
+}
 </script>
 
 <template>
@@ -247,7 +257,7 @@ const copyIframeCode = async () => {
       v-e="['c:view:share']"
       outlined
       class="nc-btn-share-view nc-toolbar-btn"
-      @click="genShareLink"
+      @click="displayConfirmationModal"
     >
       <div class="flex items-center gap-1">
         <component :is="iconMap.share" />
@@ -367,7 +377,7 @@ const copyIframeCode = async () => {
             "
           >
             <!-- Allow Download -->
-            <a-checkbox v-model:checked="allowCSVDownload" data-testid="nc-modal-share-view__with-csv-download" class="!text-sm">
+            <a-checkbox data-testid="nc-modal-share-view__with-csv-download" class="!text-sm">
               {{ $t('labels.downloadAllowed') }}
             </a-checkbox>
           </div>


### PR DESCRIPTION
## Change Summary
#closes:  https://github.com/nocodb/nocodb/issues/5725

Describe the usecase for the feature
When you click on the "share view" button:

The view is shared without confirmation request
The view is shared by default without password
The view is downloadable by default
This default setting could be a problem regarding data privacy. Indeed, users do not realize that they have shared a view since there is no confirmation request. Moreover, the data would then be downloadable without password if you have the link.

Suggested Solution
The following behaviour would improve data privacy :
1) Show a confirmation request popup before the view sharing is effective
2) By default a password should be requested (the password checkbox should be activated by default)
3) The view should not be downloadable by default (the "download enabled" checkbox should be unchecked by default)


## Change type

- [x] feat: Confirmation request and default settings in the view sharing form

## Test/ Verification

Provide summary of changes.
https://www.loom.com/share/21bf30cc8ce042478fc040465cd943d8?sid=31d9ea7c-c403-4f35-b79c-e03c3626cea7


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
