### PR TITLE
Fixed bug when trying to open a row with a binary encoded uuid as PK

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -3966,17 +3966,21 @@ function _wherePk(primaryKeys: Column[], id) {
   const ids = (id + '').split('___');
   const where = {};
   for (let i = 0; i < primaryKeys.length; ++i) {
-    //Check if the id is a UUID and the column is binary(16)
-    const idAsUUID =
+    //Cast the id to string.
+    const idAsString = ids[i] + '';
+    // Check if the id is a UUID and the column is binary(16)
+    const isUUIDBinary16 =
       primaryKeys[i].ct === 'binary(16)' &&
-      ((ids[i] + '').length === 36 || (ids[i] + '').length === 32)
-        ? (ids[i] + '').length === 32
-          ? (ids[i] + '').replace(
-              /(.{8})(.{4})(.{4})(.{4})(.{12})/,
-              '$1-$2-$3-$4-$5',
-            )
-          : ids[i] + ''
-        : null;
+      (idAsString.length === 36 || idAsString.length === 32);
+    // If the id is a UUID and the column is binary(16), convert the id to a Buffer. Otherwise, return null to indicate that the id is not a UUID.
+    const idAsUUID = isUUIDBinary16
+      ? idAsString.length === 32
+        ? idAsString.replace(
+            /(.{8})(.{4})(.{4})(.{4})(.{12})/,
+            '$1-$2-$3-$4-$5',
+          )
+        : idAsString
+      : null;
 
     where[primaryKeys[i].column_name] = idAsUUID
       ? Buffer.from(idAsUUID.replace(/-/g, ''), 'hex')

--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -3966,7 +3966,21 @@ function _wherePk(primaryKeys: Column[], id) {
   const ids = (id + '').split('___');
   const where = {};
   for (let i = 0; i < primaryKeys.length; ++i) {
-    where[primaryKeys[i].column_name] = ids[i];
+    //Check if the id is a UUID and the column is binary(16)
+    const idAsUUID =
+      primaryKeys[i].ct === 'binary(16)' &&
+      ((ids[i] + '').length === 36 || (ids[i] + '').length === 32)
+        ? (ids[i] + '').length === 32
+          ? (ids[i] + '').replace(
+              /(.{8})(.{4})(.{4})(.{4})(.{12})/,
+              '$1-$2-$3-$4-$5',
+            )
+          : ids[i] + ''
+        : null;
+
+    where[primaryKeys[i].column_name] = idAsUUID
+      ? Buffer.from(idAsUUID.replace(/-/g, ''), 'hex')
+      : ids[i];
   }
   return where;
 }

--- a/packages/nocodb/src/db/conditionV2.ts
+++ b/packages/nocodb/src/db/conditionV2.ts
@@ -419,7 +419,7 @@ const parseConditionV2 = async (
                 ].includes(column.uidt)
               ) {
                 qb = qb.where(field, val);
-              } else if (column.ct == 'timestamp') {
+              } else if (column.ct === 'timestamp') {
                 qb = qb.whereRaw('DATE(??) = DATE(?)', [field, val]);
               } else {
                 // mysql is case-insensitive for strings, turn to case-sensitive

--- a/packages/nocodb/src/db/conditionV2.ts
+++ b/packages/nocodb/src/db/conditionV2.ts
@@ -419,6 +419,8 @@ const parseConditionV2 = async (
                 ].includes(column.uidt)
               ) {
                 qb = qb.where(field, val);
+              } else if (column.ct == 'timestamp') {
+                qb = qb.whereRaw('DATE(??) = DATE(?)', [field, val]);
               } else {
                 // mysql is case-insensitive for strings, turn to case-sensitive
                 qb = qb.whereRaw('BINARY ?? = ?', [field, val]);


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.
Added a check on the WherePK constructor to check if the data type on the db is binary(16) and if the pk is a valid uuid.
If it's a uuid then returns it as a Binary.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
