### PR TITLE
fix: wrong mysql meta sync UI Data Type

### DIFF
--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMssql.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMssql.ts
@@ -590,7 +590,7 @@ class ModelXcMetaMssql extends BaseModelXcMeta {
       case 'set':
         return 'MultiSelect';
       case 'json':
-        return 'LongText';
+        return 'JSON';
       case 'blob':
         return 'LongText';
       case 'geometry':

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMysql.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMysql.ts
@@ -322,7 +322,7 @@ class ModelXcMetaMysql extends BaseModelXcMeta {
       case 'set':
         return 'MultiSelect';
       case 'json':
-        return 'LongText';
+        return 'JSON';
       case 'blob':
         return 'LongText';
       case 'geometry':

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaOracle.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaOracle.ts
@@ -370,7 +370,7 @@ class ModelXcMetaOracle extends BaseModelXcMeta {
       case 'set':
         return 'MultiSelect';
       case 'json':
-        return 'LongText';
+        return 'JSON';
     }
   }
 


### PR DESCRIPTION
## Change Summary
I found bug for Sync existing Data Sources specifically for Mysql Database.
If type of field in existing Database is JSON, we can't edit the json because invalid render. see the image below
![image](https://github.com/nocodb/nocodb/assets/24775167/1e9fb2f6-37c4-496f-8915-d388975ec25c)

it because wrong mapping UI Data Type in process Sync Meta Data Source.
this PR just change mapping UI Data type from this:
```
case 'json':
        return 'LongText';
```

to this

```
case 'json':
        return 'JSON';
```


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
Result of this changes look like this.
![image](https://github.com/nocodb/nocodb/assets/24775167/8cf45e62-9b75-464c-b620-f7dedaa04ee8)

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of