### PR TITLE
Fixed #5765 : form view do not extent text area

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -845,7 +845,7 @@ watch(view, (nextView) => {
 }
 
 .nc-input {
-  @apply appearance-none w-full !bg-white rounded px-2 py-2 my-2 border-solid border-1 border-primary border-opacity-50;
+  @apply appearance-none w-full !bg-white rounded px-2 py-2 my-2 border-solid border-1 border-primary border-opacity-50 overflow-auto;
 
   :deep(input) {
     @apply !px-1;

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
@@ -230,4 +230,8 @@ const onDecode = async (scannedCodeValue: string) => {
   @apply h-auto;
   @apply ml-1;
 }
+
+.nc-input {
+  @apply overflow-auto;
+}
 </style>


### PR DESCRIPTION
## Change Summary

-Addressed an issue where the 'nc-form-after-submit-msg' textarea in Nocodb was not extending correctly, leading to text overflow. The problem was resolved by adding the 'overflow-auto' property to the 'nc-input' class, ensuring that users can now enter and view large messages within the textarea.
-fixed #5765 

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

To test and verify: 
- create text field
- create form view
- create share link
- enter long text to the form using shared view

## Additional information / screenshots (optional)

![Screenshot (246)](https://github.com/nocodb/nocodb/assets/140178357/11c82eb3-8996-4963-a7f9-33ea478252fa)
