### PR TITLE
Fixed #5523 : Labeling columns with special characters causes form to break

### DIFF
--- a/packages/nc-gui/composables/useColumnCreateStore.ts
+++ b/packages/nc-gui/composables/useColumnCreateStore.ts
@@ -101,6 +101,14 @@ const [useProvideColumnCreateStore, useColumnCreateStore] = createInjectionState
               })
             },
           },
+          {
+            validator: (rule: any, value: any) => {
+              if (/[!@#$%^&*(),.?":{}|<>]/.test(value)) {
+                return Promise.reject(new Error('Special characters are not allowed in the column name.'))
+              }
+              return Promise.resolve()
+            },
+          },
           fieldLengthValidator(project.value?.bases?.[0].type || ClientType.MYSQL),
         ],
         uidt: [
@@ -215,11 +223,6 @@ const [useProvideColumnCreateStore, useColumnCreateStore] = createInjectionState
     const addOrUpdate = async (onSuccess: () => void, columnPosition?: Pick<ColumnReqType, 'column_order'>) => {
       try {
         if (!(await validate())) return
-        const specialCharsRegex = /[!@#$%^&*(),.?":{}|<>]/
-        if (specialCharsRegex.test(formState._rawValue.column_name)) {
-          message.warning('Special characters are not allowed in the column name.')
-          return
-        }
       } catch (e: any) {
         const errorMsgs = e.errorFields
           ?.map((e: any) => e.errors?.join(', '))

--- a/packages/nc-gui/composables/useColumnCreateStore.ts
+++ b/packages/nc-gui/composables/useColumnCreateStore.ts
@@ -215,6 +215,11 @@ const [useProvideColumnCreateStore, useColumnCreateStore] = createInjectionState
     const addOrUpdate = async (onSuccess: () => void, columnPosition?: Pick<ColumnReqType, 'column_order'>) => {
       try {
         if (!(await validate())) return
+        const specialCharsRegex = /[!@#$%^&*(),.?":{}|<>]/
+        if (specialCharsRegex.test(formState._rawValue.column_name)) {
+          message.warning('Special characters are not allowed in the column name.')
+          return
+        }
       } catch (e: any) {
         const errorMsgs = e.errorFields
           ?.map((e: any) => e.errors?.join(', '))


### PR DESCRIPTION
## Change Summary

Added a check for special characters in the field name using a regular expression. If the field name contains special characters, a warning message will be shown to the user, and the column creation will be canceled.
fixed #5523

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

To test and verify the fix:

Create a sheet
Label column "?@% ++ ()"
Save the column
Warning Message will popup: Special characters are not allowed in the column name.

## Additional information / screenshots (optional)

![Screenshot (253)](https://github.com/nocodb/nocodb/assets/140178357/3e5096e1-9976-43ca-a7cd-7206f4982549)



