### PR TITLE
Enhancement #5256 : better column datatype mapping during import

### DIFF
--- a/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
+++ b/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
@@ -83,7 +83,7 @@ export default class CSVTemplateAdapter {
   detectInitialUidt(v: string) {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
     const urlRegex = /^(ftp|http|https):\/\/[^ "]+$/
-    const phoneRegex = /\b(?:\+?\d{1,3}(?:[\s-]+\(\d+\))?)?[\s-]*(?:\d[\s-]*){6,14}\b/
+    const phoneRegex = /\+(9[976]\d|8[987530]\d|6[987]\d|5[90]\d|42\d|3[875]\d|2[98654321]\d|9[8543210]|8[6421]|6[6543210]|5[87654321]|4[987654310]|3[9643210]|2[70]|7|1)\d{1,14}$/
     if (phoneRegex.test(v)) return UITypes.PhoneNumber
     if (emailRegex.test(v)) return UITypes.Email
     if (urlRegex.test(v)) return UITypes.URL

--- a/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
+++ b/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
@@ -81,6 +81,17 @@ export default class CSVTemplateAdapter {
   }
 
   detectInitialUidt(v: string) {
+    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+    const urlRegex = /^(ftp|http|https):\/\/[^ "]+$/
+    const phoneRegex = /\b(?:\+?\d{1,3}(?:[\s-]+\(\d+\))?)?[\s-]*(?:\d[\s-]*){6,14}\b/
+    if (phoneRegex.test(v)) return UITypes.PhoneNumber
+    if (emailRegex.test(v)) return UITypes.Email
+    if (urlRegex.test(v)) return UITypes.URL
+    if (!isNaN(Number(v)) && !isNaN(parseFloat(v))) return UITypes.Number
+    if (validateDateWithUnknownFormat(v)) return UITypes.DateTime
+    if (['true', 'True', 'false', 'False', '1', '0', 'T', 'F', 'Y', 'N'].includes(v)) return UITypes.Checkbox
+    if (v.length > 20) return UITypes.LongText
+    return UITypes.SingleLineText
     if (!isNaN(Number(v)) && !isNaN(parseFloat(v))) return UITypes.Number
     if (validateDateWithUnknownFormat(v)) return UITypes.DateTime
     if (['true', 'True', 'false', 'False', '1', '0', 'T', 'F', 'Y', 'N'].includes(v)) return UITypes.Checkbox

--- a/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
+++ b/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
@@ -92,10 +92,6 @@ export default class CSVTemplateAdapter {
     if (['true', 'True', 'false', 'False', '1', '0', 'T', 'F', 'Y', 'N'].includes(v)) return UITypes.Checkbox
     if (v.length > 20) return UITypes.LongText
     return UITypes.SingleLineText
-    if (!isNaN(Number(v)) && !isNaN(parseFloat(v))) return UITypes.Number
-    if (validateDateWithUnknownFormat(v)) return UITypes.DateTime
-    if (['true', 'True', 'false', 'False', '1', '0', 'T', 'F', 'Y', 'N'].includes(v)) return UITypes.Checkbox
-    return UITypes.SingleLineText
   }
 
   detectColumnType(tableIdx: number, data: []) {

--- a/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
+++ b/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
@@ -83,8 +83,9 @@ export default class CSVTemplateAdapter {
   detectInitialUidt(v: string) {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
     const urlRegex = /^(ftp|http|https):\/\/[^ "]+$/
-    const phoneRegex = /\+(9[976]\d|8[987530]\d|6[987]\d|5[90]\d|42\d|3[875]\d|2[98654321]\d|9[8543210]|8[6421]|6[6543210]|5[87654321]|4[987654310]|3[9643210]|2[70]|7|1)\d{1,14}$/
-    if (phoneRegex.test(v)) return UITypes.PhoneNumber
+    const phoneRegex = /^\+(?:[0-9]?){1,3}[-.\s]?(?:\(\d+\)|[0-9]+[-.\s]?)*[0-9]+$/
+    const cleanedV = v.replace(/^'+/, '')
+    if (phoneRegex.test(cleanedV)) return UITypes.PhoneNumber
     if (emailRegex.test(v)) return UITypes.Email
     if (urlRegex.test(v)) return UITypes.URL
     if (!isNaN(Number(v)) && !isNaN(parseFloat(v))) return UITypes.Number

--- a/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
+++ b/packages/nc-gui/utils/parsers/CSVTemplateAdapter.ts
@@ -83,7 +83,7 @@ export default class CSVTemplateAdapter {
   detectInitialUidt(v: string) {
     const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
     const urlRegex = /^(ftp|http|https):\/\/[^ "]+$/
-    const phoneRegex = /^\+(?:[0-9]?){1,3}[-.\s]?(?:\(\d+\)|[0-9]+[-.\s]?)*[0-9]+$/
+    const phoneRegex = /^(\+\d{1,3}\s?)?(\(\d{1,}\)|\d{1,})[-.\s]?(\d{1,}[-.\s]?)*\d{1,}$/
     const cleanedV = v.replace(/^'+/, '')
     if (phoneRegex.test(cleanedV)) return UITypes.PhoneNumber
     if (emailRegex.test(v)) return UITypes.Email


### PR DESCRIPTION
## Change Summary

I made improvements to the code in the CSVTemplateAdapter class to enhance the detection of data types and improve template generation.
The changes include:
- Added additional checks for detecting phone numbers as UITypes.PhoneNumber.
- Modified conditions for detecting email and URL types as UITypes.Email and UITypes.URL, respectively.
- Implemented a length-based decision to detect long texts as UITypes.LongText specific for postal addresses or specific fields having a length more than 20 is considered as LongText, as LongText are detected when the length > 255 as per parserHelpers.
- enhanced #5256

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification
To test and verify the fix:

- Import a CSV file
- And select the Auto-Select Field Types
- Import the file, and you will see the correct field types. 

## Additional information / screenshots (optional)

![Screenshot (258)](https://github.com/nocodb/nocodb/assets/140178357/e4a27b4f-fb24-4ff0-8a0e-79f4ccbaeef3)
![Screenshot (259)](https://github.com/nocodb/nocodb/assets/140178357/90fa8b9c-71d6-452c-a606-7d0b886be78a)
