### PR TITLE
Fixed: form view do not extent text area

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -845,7 +845,7 @@ watch(view, (nextView) => {
 }
 
 .nc-input {
-  @apply appearance-none w-full !bg-white rounded px-2 py-2 my-2 border-solid border-1 border-primary border-opacity-50;
+  @apply appearance-none w-full h-auto min-h-40px !bg-white rounded px-2 py-2 my-2 border-solid border-1 border-primary border-opacity-50;
 
   :deep(input) {
     @apply !px-1;

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
@@ -122,6 +122,8 @@ p {
 
         &.nc-cell-longtext {
           @apply !p-0.5rem h-auto;
+          word-break: break-all;
+          white-space: pre-line;
         }
 
         textarea {

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
@@ -122,6 +122,8 @@ p {
 
         &.nc-cell-longtext {
           @apply !p-0 pb-2px pr-2px;
+          height: auto;
+          overflow: auto;
         }
 
         textarea {

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
@@ -121,13 +121,12 @@ p {
         }
 
         &.nc-cell-longtext {
-          @apply !p-0 pb-2px pr-2px;
-          height: auto;
-          overflow: auto;
+          @apply !p-0.5rem h-auto;
         }
 
         textarea {
           @apply px-4 py-2 rounded;
+          
 
           &:focus {
             box-shadow: none !important;


### PR DESCRIPTION
## Change Summary

An issue in Nocodb was addressed, specifically related to the 'nc-form-after-submit-msg' textarea. Previously, the textarea was not extending correctly, resulting in text overflow. To resolve this problem, we added overflow: auto; and height: auto; properties to the .nc-cell-longtext class. As a result, users can now comfortably enter and view large messages within the textarea. This fix was implemented in response to the reported issue with the number #5765.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification
1. create text field
2. create form view
3. create share link
4. enter long text to the form using shared view

## Additional information / screenshots (optional)
![textareaTEST](https://github.com/nocodb/nocodb/assets/88323900/327cc6b7-e6f2-43eb-83e4-13430fe6c30f)
