### PR TITLE
fix: text input overflow on focus

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -730,7 +730,7 @@ watch(view, (nextView) => {
                     <LazySmartsheetDivDataCell class="relative">
                       <LazySmartsheetCell
                         v-model="formState[element.title]"
-                        class="nc-input"
+                        class="nc-input truncate"
                         :class="`nc-form-input-${element.title.replaceAll(' ', '')}`"
                         :data-testid="`nc-form-input-${element.title.replaceAll(' ', '')}`"
                         :column="element"

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index.vue
@@ -120,10 +120,6 @@ p {
           }
         }
 
-        &.nc-cell-longtext {
-          @apply !p-0 pb-2px pr-2px;
-        }
-
         textarea {
           @apply px-4 py-2 rounded;
 

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
@@ -168,7 +168,6 @@ const onDecode = async (scannedCodeValue: string) => {
                         class="nc-input truncate"
                         :data-testid="`nc-form-input-cell-${field.label || field.title}`"
                         :class="`nc-form-input-${field.title?.replaceAll(' ', '')}`"
-                        :style="{ paddingLeft: '0.5rem !important' }"
                         :column="field"
                         :edit-enabled="editEnabled[index]"
                         @click="editEnabled[index] = true"

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
@@ -165,7 +165,7 @@ const onDecode = async (scannedCodeValue: string) => {
                       <LazySmartsheetCell
                         v-else
                         v-model="formState[field.title]"
-                        class="nc-input"
+                        class="nc-input truncate"
                         :data-testid="`nc-form-input-cell-${field.label || field.title}`"
                         :class="`nc-form-input-${field.title?.replaceAll(' ', '')}`"
                         :column="field"

--- a/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
+++ b/packages/nc-gui/pages/[projectType]/form/[viewId]/index/index.vue
@@ -168,6 +168,7 @@ const onDecode = async (scannedCodeValue: string) => {
                         class="nc-input truncate"
                         :data-testid="`nc-form-input-cell-${field.label || field.title}`"
                         :class="`nc-form-input-${field.title?.replaceAll(' ', '')}`"
+                        :style="{ paddingLeft: '0.5rem !important' }"
                         :column="field"
                         :edit-enabled="editEnabled[index]"
                         @click="editEnabled[index] = true"


### PR DESCRIPTION
## Change Summary

- closes #5909 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Before
<img width="1440" alt="Screenshot 2023-08-02 at 10 53 29 PM" src="https://github.com/nocodb/nocodb/assets/66205494/ffd78f27-0540-4d0d-a510-dfb723592309">

## After

<img width="1440" alt="Screenshot 2023-08-02 at 10 41 12 PM" src="https://github.com/nocodb/nocodb/assets/66205494/59b07420-3109-46df-9f46-ed8638a4960b">

### ONFOCUS
<img width="1440" alt="Screenshot 2023-08-02 at 10 40 47 PM" src="https://github.com/nocodb/nocodb/assets/66205494/6e8f8d9b-4b58-4d00-94c9-a96af4801919">
