### PR TITLE
chore: Skip unnecessary computations based on the fields of dbRow.

### DIFF
--- a/packages/nocodb/src/modules/datas/helpers.ts
+++ b/packages/nocodb/src/modules/datas/helpers.ts
@@ -273,6 +273,8 @@ export async function getDbRows(param: {
 
       for (const column of view.model.columns) {
         if (isSystemColumn(column) && !view.show_system_fields) continue;
+        // eslint-disable-next-line no-prototype-builtins
+        if (!dbRow.hasOwnProperty(column.title)) continue;
         dbRow[column.title] = await serializeCellValue({
           value: row[column.title],
           column,

--- a/packages/nocodb/src/modules/datas/helpers.ts
+++ b/packages/nocodb/src/modules/datas/helpers.ts
@@ -268,13 +268,15 @@ export async function getDbRows(param: {
       break;
     }
 
+    const needSerializeColumns = view.model.columns.filter((column) => {
+      // eslint-disable-next-line no-prototype-builtins
+      return rows[0].hasOwnProperty(column.title);
+    });
+
     for (const row of rows) {
       const dbRow = { ...row };
 
-      for (const column of view.model.columns) {
-        if (isSystemColumn(column) && !view.show_system_fields) continue;
-        // eslint-disable-next-line no-prototype-builtins
-        if (!dbRow.hasOwnProperty(column.title)) continue;
+      for (const column of needSerializeColumns) {
         dbRow[column.title] = await serializeCellValue({
           value: row[column.title],
           column,


### PR DESCRIPTION
## Change Summary

When there is a table with 40 fields and 1000 rows of data, it will require performing 40*1000 times (excluding system fields, of course). However, if it's based on a view or specified fields, can these unnecessary operations be skipped?

## Change type

- [x] chore: Skip unnecessary computations based on the fields of dbRow.
