### PR TITLE
Fixed #6151 : File name extends the area on CSV import

### DIFF
--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -929,7 +929,7 @@ function handleCheckAllRecord(event: CheckboxChangeEvent, tableName: string) {
 
 <style scoped lang="scss">
 .template-collapse {
-  @apply bg-white;
+  @apply bg-white overflow-auto;
 }
 
 .template-form {

--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -749,7 +749,7 @@ function handleCheckAllRecord(event: CheckboxChangeEvent, tableName: string) {
               </a-form-item>
               <span v-else class="font-weight-bold text-lg flex items-center gap-2" @click="setEditableTn(tableIdx, true)">
                 <component :is="iconMap.table" class="text-primary" />
-                {{ table.table_name }}
+                {{ table.table_name.length > 52 ? table.table_name.slice(0,52)+".." : table.table_name }}
               </span>
             </template>
 
@@ -929,7 +929,7 @@ function handleCheckAllRecord(event: CheckboxChangeEvent, tableName: string) {
 
 <style scoped lang="scss">
 .template-collapse {
-  @apply bg-white overflow-auto;
+  @apply bg-white;
 }
 
 .template-form {


### PR DESCRIPTION
## Change Summary

Added overflow property to a class template collapse. fixes #6151 

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

1. Import a CSV file with a large filename.
2. You could see that a scroll effect comes at the bottom to see the full file name, and the name resides in the box.

## Additional information / screenshots (optional)


![Screenshot (270)](https://github.com/nocodb/nocodb/assets/140178357/32ce1799-ecac-4311-bcf5-1ca939be03c5)
