### PR TITLE
Fixed: Reverse proxy by nocodb

### DIFF
--- a/packages/nc-gui/components/general/HelpAndSupport.vue
+++ b/packages/nc-gui/components/general/HelpAndSupport.vue
@@ -10,7 +10,7 @@ const { project } = storeToRefs(useProject())
 const route = useRoute()
 
 const openSwaggerLink = () => {
-  openLink(`/api/v1/db/meta/projects/${route.params.projectId}/swagger`, appInfo.value.ncSiteUrl)
+  openLink(`./api/v1/db/meta/projects/${route.params.projectId}/swagger`, appInfo.value.ncSiteUrl)
 }
 </script>
 

--- a/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
+++ b/packages/nc-gui/pages/[projectType]/[projectId]/index.vue
@@ -365,7 +365,7 @@ useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
                         v-if="isUIAllowed('apiDocs') && !isMobileMode"
                         v-e="['e:api-docs']"
                         class="nc-project-menu-item group"
-                        @click.stop="openLink(`/api/v1/db/meta/projects/${route.params.projectId}/swagger`, appInfo.ncSiteUrl)"
+                        @click.stop="openLink(`./api/v1/db/meta/projects/${route.params.projectId}/swagger`, appInfo.ncSiteUrl)"
                       >
                         <component :is="iconMap.json" class="group-hover:text-accent" />
                         {{ $t('activity.account.swagger') }}

--- a/packages/nc-gui/plugins/jobs.ts
+++ b/packages/nc-gui/plugins/jobs.ts
@@ -16,6 +16,7 @@ export default defineNuxtPlugin(async (nuxtApp) => {
 
       socket = io(`${url.href}jobs`, {
         extraHeaders: { 'xc-auth': token },
+        path: `${url.pathname}socket.io`,
       })
 
       socket.on('connect_error', (e) => {

--- a/packages/nc-gui/plugins/jobs.ts
+++ b/packages/nc-gui/plugins/jobs.ts
@@ -13,10 +13,12 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       if (socket) socket.disconnect()
 
       const url = new URL(appInfo.ncSiteUrl, window.location.href.split(/[?#]/)[0])
+      let socketPath = url.pathname
+      socketPath += socketPath.endsWith("/") ? "socket.io" : "/socket.io"
 
       socket = io(`${url.href}jobs`, {
         extraHeaders: { 'xc-auth': token },
-        path: `${url.pathname}socket.io`,
+        path: socketPath,
       })
 
       socket.on('connect_error', (e) => {

--- a/packages/nc-gui/plugins/tele.ts
+++ b/packages/nc-gui/plugins/tele.ts
@@ -16,10 +16,11 @@ export default defineNuxtPlugin(async (nuxtApp) => {
     try {
       if (socket) socket.disconnect()
 
-      const url = new URL(appInfo.ncSiteUrl, window.location.href.split(/[?#]/)[0]).href
+      const url = new URL(appInfo.ncSiteUrl, window.location.href.split(/[?#]/)[0])
 
-      socket = io(url, {
+      socket = io(url.href, {
         extraHeaders: { 'xc-auth': token },
+        path: `${url.pathname}socket.io`,
       })
 
       socket.on('connect_error', () => {

--- a/packages/nc-gui/plugins/tele.ts
+++ b/packages/nc-gui/plugins/tele.ts
@@ -17,10 +17,12 @@ export default defineNuxtPlugin(async (nuxtApp) => {
       if (socket) socket.disconnect()
 
       const url = new URL(appInfo.ncSiteUrl, window.location.href.split(/[?#]/)[0])
+      let socketPath = url.pathname
+      socketPath += socketPath.endsWith("/") ? "socket.io" : "/socket.io"
 
       socket = io(url.href, {
         extraHeaders: { 'xc-auth': token },
-        path: `${url.pathname}socket.io`,
+        path: socketPath,
       })
 
       socket.on('connect_error', () => {

--- a/packages/nocodb/src/gateways/socket.gateway.ts
+++ b/packages/nocodb/src/gateways/socket.gateway.ts
@@ -14,12 +14,14 @@ function getHash(str) {
   return crypto.createHash('md5').update(str).digest('hex');
 }
 
+const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT}/`)
 @WebSocketGateway({
   cors: {
     origin: '*',
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
+  namespace: url.pathname,
 })
 @Injectable()
 export class SocketGateway implements OnModuleInit {

--- a/packages/nocodb/src/gateways/socket.gateway.ts
+++ b/packages/nocodb/src/gateways/socket.gateway.ts
@@ -16,9 +16,7 @@ function getHash(str) {
 
 const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
 let namespace = url.pathname
-if (!namespace.endsWith('/')) {
-  namespace = namespace + '/';
-}
+namespace += namespace.endsWith("/") ? "" : "/"
 
 @WebSocketGateway({
   cors: {
@@ -26,7 +24,7 @@ if (!namespace.endsWith('/')) {
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
-  namespace: namespace,
+  namespace,
 })
 @Injectable()
 export class SocketGateway implements OnModuleInit {

--- a/packages/nocodb/src/gateways/socket.gateway.ts
+++ b/packages/nocodb/src/gateways/socket.gateway.ts
@@ -15,13 +15,18 @@ function getHash(str) {
 }
 
 const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
+let namespace = url.pathname
+if (!namespace.endsWith('/')) {
+  namespace = namespace + '/';
+}
+
 @WebSocketGateway({
   cors: {
     origin: '*',
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
-  namespace: url.pathname,
+  namespace: namespace,
 })
 @Injectable()
 export class SocketGateway implements OnModuleInit {

--- a/packages/nocodb/src/gateways/socket.gateway.ts
+++ b/packages/nocodb/src/gateways/socket.gateway.ts
@@ -14,7 +14,7 @@ function getHash(str) {
   return crypto.createHash('md5').update(str).digest('hex');
 }
 
-const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT}/`)
+const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
 @WebSocketGateway({
   cors: {
     origin: '*',

--- a/packages/nocodb/src/modules/jobs/jobs.gateway.ts
+++ b/packages/nocodb/src/modules/jobs/jobs.gateway.ts
@@ -14,13 +14,14 @@ import { JobEvents } from '../../interface/Jobs';
 import type { OnModuleInit } from '@nestjs/common';
 import type { JobStatus } from '../../interface/Jobs';
 
+const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT}/`)
 @WebSocketGateway({
   cors: {
     origin: '*',
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
-  namespace: 'jobs',
+  namespace: `${url.pathname}jobs`,
 })
 export class JobsGateway implements OnModuleInit {
   constructor(@Inject('JobsService') private readonly jobsService) {}

--- a/packages/nocodb/src/modules/jobs/jobs.gateway.ts
+++ b/packages/nocodb/src/modules/jobs/jobs.gateway.ts
@@ -16,11 +16,7 @@ import type { JobStatus } from '../../interface/Jobs';
 
 const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
 let namespace = url.pathname
-if (!namespace.endsWith('/')) {
-  namespace = namespace + '/jobs';
-} else {
-  namespace = namespace + 'jobs';
-}
+namespace += namespace.endsWith("/") ? "jobs" : "/jobs"
 
 @WebSocketGateway({
   cors: {
@@ -28,7 +24,7 @@ if (!namespace.endsWith('/')) {
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
-  namespace: namespace,
+  namespace,
 })
 export class JobsGateway implements OnModuleInit {
   constructor(@Inject('JobsService') private readonly jobsService) {}

--- a/packages/nocodb/src/modules/jobs/jobs.gateway.ts
+++ b/packages/nocodb/src/modules/jobs/jobs.gateway.ts
@@ -15,13 +15,20 @@ import type { OnModuleInit } from '@nestjs/common';
 import type { JobStatus } from '../../interface/Jobs';
 
 const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
+let namespace = url.pathname
+if (!namespace.endsWith('/')) {
+  namespace = namespace + '/jobs';
+} else {
+  namespace = namespace + 'jobs';
+}
+
 @WebSocketGateway({
   cors: {
     origin: '*',
     allowedHeaders: ['xc-auth'],
     credentials: true,
   },
-  namespace: `${url.pathname}jobs`,
+  namespace: namespace,
 })
 export class JobsGateway implements OnModuleInit {
   constructor(@Inject('JobsService') private readonly jobsService) {}

--- a/packages/nocodb/src/modules/jobs/jobs.gateway.ts
+++ b/packages/nocodb/src/modules/jobs/jobs.gateway.ts
@@ -14,7 +14,7 @@ import { JobEvents } from '../../interface/Jobs';
 import type { OnModuleInit } from '@nestjs/common';
 import type { JobStatus } from '../../interface/Jobs';
 
-const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT}/`)
+const url = new URL(process.env.NC_PUBLIC_URL || `http://localhost:${process.env.PORT || '8080'}/`)
 @WebSocketGateway({
   cors: {
     origin: '*',


### PR DESCRIPTION
## Change Summary

- Fixed a socket error that occurred when using a reverse proxy.
  - Change socket request address to `appInfo.ncSiteUrl` base.
  - Change the socket namespace correctly.
- Request swagger url based on to `NC_PUBLIC_URL` environment variable.

This fix was implemented in response to the reported issue with the number #6147.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

1. set nginx.conf and run nginx
```
location /nocodb/dashboard {
    proxy_pass http://localhost:8080/nocodb/dashboard;

    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
}

location /nocodb/ {
    proxy_pass http://localhost:8080/;

    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    proxy_http_version 1.1;
}
```
2. run nocodb with environment variable
```bash
docker run -d -p 8080:8080 --name nocodb -e NC_PUBLIC_URL=http://localhost/nocodb/ -e NC_DASHBOARD_URL=/nocodb/dashboard nocodb-local
```
3. check request of socket in chrome devtool

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
