### PR TITLE
fix: language name correction for ko

### DIFF
--- a/packages/nc-gui/lib/enums.ts
+++ b/packages/nc-gui/lib/enums.ts
@@ -41,7 +41,7 @@ export enum Language {
   id = 'Bahasa Indonesia',
   it = 'Italiano',
   ja = '日本語',
-  ko = '한국인',
+  ko = '한국어',
   lv = 'Latviešu',
   nl = 'Nederlandse',
   no = 'Norsk',


### PR DESCRIPTION
## Change Summary

The word `한국인` means the Korean people, so in this case, '한국어' is correct, which means the language of Korea.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

https://en.wikipedia.org/wiki/Korean_language

## Additional information / screenshots (optional)


