### PR TITLE
typo (lanuages => languages)

### DIFF
--- a/packages/noco-docs/content/en/setup-and-usages/languages.md
+++ b/packages/noco-docs/content/en/setup-and-usages/languages.md
@@ -6,7 +6,7 @@ category: 'Product'
 menuTitle: 'Languages'
 ---
 
-NocoDB supports multiple lanuages on dashboard. By default, English will be used. However, if you prefer to display in other languages, you can do the following steps to change the language.
+NocoDB supports multiple languages on dashboard. By default, English will be used. However, if you prefer to display in other languages, you can do the following steps to change the language.
 
 Open `Project Menu` (click on project name on left top to access Project menu)
 


### PR DESCRIPTION
## Change Summary

Small typo at https://docs.nocodb.com/setup-and-usages/languages/
lanuages => languages

## Change type
- [x] docs: (changes to the documentation)

## Test/ Verification
