### PR TITLE
fix:  replace reference to missing env in docker-compose/traefik

### DIFF
--- a/docker-compose/traefik/docker-compose.yml
+++ b/docker-compose/traefik/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "--certificatesResolvers.letsencrypt.acme.dnsChallenge.resolvers=1.1.1.1:53,1.0.0.1:53"
     container_name: traefik
     environment: 
-      - "CF_DNS_API_TOKEN=${CLOUDFLARE_TOKEN}"
+      - "CF_DNS_API_TOKEN=${CF_DNS_API_TOKEN}"
     healthcheck: 
       retries: 3
       test: 


### PR DESCRIPTION
## Change Summary

The traefik `docker-compose.yml` references an env variable `CLOUDFLARE_TOKEN` that does not exist in the corresponding env file:

https://github.com/nocodb/nocodb/blob/develop/docker-compose/traefik/docker-compose.yml#L65

https://github.com/nocodb/nocodb/blob/develop/docker-compose/traefik/.env#L3

This PR replaces it with the correct env. I chose to update the compose file instead of the env file because the `CF_DNS_API_TOKEN` name is easier to google in order to figure out permissions needed for the token.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

`docker compose up` should result in traefik being able to acquire an SSL cert.

## Additional information / screenshots (optional)

-
