### PR TITLE
Bug: Deleting a table/project with attachment columns doesn't delete them on filesystem

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -19,6 +19,7 @@ import Validator from 'validator';
 import { customAlphabet } from 'nanoid';
 import DOMPurify from 'isomorphic-dompurify';
 import { v4 as uuidv4 } from 'uuid';
+import type { XcFile } from '~/interface/IStorageAdapter';
 import type LookupColumn from '~/models/LookupColumn';
 import type { Knex } from 'knex';
 import type { XKnex } from '~/db/CustomKnex';
@@ -2264,6 +2265,11 @@ class BaseModelSqlv2 {
         {},
         { ignoreView: true, getHiddenColumn: true },
       );
+
+      const deletedXcFiles = Object.values(data)
+        .filter(Array.isArray)
+        .flatMap((value: Array<Array<XcFile>>) => value.flat());
+
       await this.beforeDelete(id, trx, cookie);
 
       const execQueries: ((trx: Knex.Transaction) => Promise<any>)[] = [];
@@ -2329,7 +2335,7 @@ class BaseModelSqlv2 {
       if (!_trx) await trx.commit();
 
       await this.afterDelete(data, trx, cookie);
-      return response;
+      return { data: response, deletedXcFiles };
     } catch (e) {
       console.log(e);
       if (!_trx) await trx.rollback();

--- a/packages/nocodb/src/helpers/deleteFolderRecursively.ts
+++ b/packages/nocodb/src/helpers/deleteFolderRecursively.ts
@@ -1,0 +1,27 @@
+import { existsSync, lstatSync, readdirSync, rmdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+export const deleteFolderRecursively = (directoryPath: string): void => {
+  if (!existsSync(directoryPath)) return;
+
+  const isRootDirectory = lstatSync(directoryPath).isDirectory();
+
+  if (!isRootDirectory) {
+    return unlinkSync(directoryPath);
+  }
+
+  const directoryFiles = readdirSync(directoryPath);
+
+  directoryFiles.forEach((file) => {
+    const currentFilePath = join(directoryPath, file);
+    const isDirectory = lstatSync(currentFilePath).isDirectory();
+
+    if (isDirectory) {
+      deleteFolderRecursively(currentFilePath);
+    } else {
+      unlinkSync(currentFilePath);
+    }
+  });
+
+  rmdirSync(directoryPath);
+};

--- a/packages/nocodb/src/helpers/index.ts
+++ b/packages/nocodb/src/helpers/index.ts
@@ -3,5 +3,6 @@ export * from './columnHelpers';
 export * from './apiHelpers';
 export * from './cacheHelpers';
 export * from './extractLimitAndOffset';
+export * from './deleteFolderRecursively';
 
 export { populateMeta };

--- a/packages/nocodb/src/modules/datas/datas.module.ts
+++ b/packages/nocodb/src/modules/datas/datas.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { MulterModule } from '@nestjs/platform-express';
 import multer from 'multer';
+import { AttachmentsService } from 'src/services/attachments.service';
 import { NC_ATTACHMENT_FIELD_SIZE } from '~/constants';
 import { DataTableController } from '~/controllers/data-table.controller';
 import { DataTableService } from '~/services/data-table.service';
@@ -51,6 +52,7 @@ export const dataModuleMetadata = {
     OldDatasService,
     PublicDatasService,
     PublicDatasExportService,
+    AttachmentsService,
   ],
   exports: [
     DatasService,

--- a/packages/nocodb/src/plugins/storage/Local.ts
+++ b/packages/nocodb/src/plugins/storage/Local.ts
@@ -6,6 +6,7 @@ import axios from 'axios';
 import { useAgent } from 'request-filtering-agent';
 import type { IStorageAdapterV2, XcFile } from 'nc-plugin';
 import type { Readable } from 'stream';
+import { deleteFolderRecursively } from '~/helpers';
 import { NcError } from '~/helpers/catchError';
 import { getToolDir } from '~/utils/nc-config';
 
@@ -99,9 +100,13 @@ export default class Local implements IStorageAdapterV2 {
     return fs.promises.readdir(destDir);
   }
 
-  // todo: implement
-  fileDelete(_path: string): Promise<any> {
-    return Promise.resolve(undefined);
+  async fileDelete(path: string): Promise<any> {
+    try {
+      const mediaDirectory = this.validateAndNormalisePath(path);
+      deleteFolderRecursively(mediaDirectory);
+    } catch (e) {
+      throw e;
+    }
   }
 
   public async fileRead(filePath: string): Promise<any> {

--- a/packages/nocodb/src/services/attachments.service.ts
+++ b/packages/nocodb/src/services/attachments.service.ts
@@ -3,6 +3,7 @@ import { AppEvents } from 'nocodb-sdk';
 import { Injectable } from '@nestjs/common';
 import { nanoid } from 'nanoid';
 import slash from 'slash';
+import type { XcFile } from '~/interface/IStorageAdapter';
 import { AppHooksService } from '~/services/app-hooks/app-hooks.service';
 import NcPluginMgrv2 from '~/helpers/NcPluginMgrv2';
 import Local from '~/plugins/storage/Local';
@@ -158,6 +159,22 @@ export class AttachmentsService {
       true,
     );
     return { img, type };
+  }
+
+  async fileDelete(path: string) {
+    const storageAdapter = new Local();
+    return storageAdapter.fileDelete(path);
+  }
+
+  async xcFilesDelete(files: XcFile[]) {
+    await Promise.all(
+      files.map((file) =>
+        this.fileDelete(
+          // In the DB, the file path is stored under 'download/'. However, for deletion, we use the write path located at 'nc/uploads'.
+          String(file.path).replace(/download/g, 'nc/uploads'),
+        ),
+      ),
+    );
   }
 
   sanitizeUrlPath(paths) {

--- a/packages/nocodb/src/services/datas.service.ts
+++ b/packages/nocodb/src/services/datas.service.ts
@@ -3,6 +3,7 @@ import { isSystemColumn } from 'nocodb-sdk';
 import * as XLSX from 'xlsx';
 import papaparse from 'papaparse';
 import { nocoExecute } from 'nc-help';
+import { AttachmentsService } from './attachments.service';
 import type { BaseModelSqlv2 } from '~/db/BaseModelSqlv2';
 import type { PathParams } from '~/modules/datas/helpers';
 import { getDbRows, getViewAndModelByAliasOrId } from '~/modules/datas/helpers';
@@ -16,7 +17,7 @@ import NcConnectionMgrv2 from '~/utils/common/NcConnectionMgrv2';
 export class DatasService {
   protected logger = new Logger(DatasService.name);
 
-  constructor() {}
+  constructor(protected readonly attachmentService: AttachmentsService) {}
 
   async dataList(
     param: PathParams & { query: any; disableOptimization?: boolean },
@@ -125,7 +126,15 @@ export class DatasService {
       }
     }
 
-    return await baseModel.delByPk(param.rowId, null, param.cookie);
+    const { data, deletedXcFiles } = await baseModel.delByPk(
+      param.rowId,
+      null,
+      param.cookie,
+    );
+
+    await this.attachmentService.xcFilesDelete(deletedXcFiles);
+
+    return data;
   }
 
   async getDataList(param: {
@@ -755,7 +764,15 @@ export class DatasService {
       dbDriver: await NcConnectionMgrv2.get(source),
     });
 
-    return await baseModel.delByPk(param.rowId, null, param.cookie);
+    const { data, deletedXcFiles } = await baseModel.delByPk(
+      param.rowId,
+      null,
+      param.cookie,
+    );
+
+    await this.attachmentService.xcFilesDelete(deletedXcFiles);
+
+    return data;
   }
 
   async relationDataDelete(param: {

--- a/packages/nocodb/src/services/tables.service.ts
+++ b/packages/nocodb/src/services/tables.service.ts
@@ -10,6 +10,7 @@ import {
 import { AppEvents } from 'nocodb-sdk';
 import { MetaDiffsService } from './meta-diffs.service';
 import { ColumnsService } from './columns.service';
+import { AttachmentsService } from './attachments.service';
 import type { MetaService } from '~/meta/meta.service';
 import type { LinkToAnotherRecordColumn, User, View } from '~/models';
 import type {
@@ -36,6 +37,7 @@ export class TablesService {
     protected readonly metaDiffService: MetaDiffsService,
     protected readonly appHooksService: AppHooksService,
     protected readonly columnsService: ColumnsService,
+    protected readonly attachmentsService: AttachmentsService,
   ) {}
 
   async tableUpdate(param: {
@@ -161,6 +163,8 @@ export class TablesService {
     const base = await Base.getWithInfo(table.base_id);
     const source = base.sources.find((b) => b.id === table.source_id);
 
+    const mediaDirectory = `nc/uploads/noco/${table.base_id}/${table.id}`;
+
     const relationColumns = table.columns.filter((c) => isLinksOrLTAR(c));
 
     if (relationColumns?.length && !source.isMeta()) {
@@ -228,6 +232,9 @@ export class TablesService {
       });
 
       result = await table.delete(ncMeta);
+
+      this.attachmentsService.fileDelete(mediaDirectory);
+
       await ncMeta.commit();
     } catch (e) {
       await ncMeta.rollback();


### PR DESCRIPTION
## Change Summary
#closes: https://github.com/nocodb/nocodb/issues/5919

Create a table with an attachments column. Then upload a file and delete the table or project. Check the folder /nc/uploads/noco/test/Sheet-1/[...]: the uploaded file is still there.


## Change type

- [x] Fix: Ensure Deletion of Attachments in Table/Project with Attachment Columns on Filesystem
## Test/ Verification

Provide summary of changes.
https://www.loom.com/share/6e6ed36c51c04fb683d6283293262029


---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.

