### PR TITLE
fix: project collaborators "Date Joined" is always "a few seconds ago"

### DIFF
--- a/packages/nocodb/src/models/ProjectUser.ts
+++ b/packages/nocodb/src/models/ProjectUser.ts
@@ -100,6 +100,7 @@ export default class ProjectUser {
         `${MetaTable.USERS}.roles as main_roles`,
         `${MetaTable.PROJECT_USERS}.project_id`,
         `${MetaTable.PROJECT_USERS}.roles as roles`,
+        `${MetaTable.PROJECT_USERS}.created_at as created_at`,
       )
       .offset(offset)
       .limit(limit);


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Add `${MetaTable.PROJECT_USERS}.created_at as created_at`  to getUsersList function.

## Additional information / screenshots (optional)
Before fix:
<img width="1079" alt="image" src="https://github.com/nocodb/nocodb/assets/5857025/8b6cce7c-23ce-4e95-9392-ed2d82a9c557">
After fix:
<img width="1093" alt="image" src="https://github.com/nocodb/nocodb/assets/5857025/89a1adb4-5ec5-4ee5-9522-2512ff67a3d9">


