### PR TITLE
fix(nc-gui): long text expand in shared view

### DIFF
--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -136,7 +136,7 @@ onClickOutside(inputWrapperRef, (e) => {
           ref="inputRef"
           v-model:value="vModel"
           placeholder="Enter text"
-          class="p-1 !pt-1 !pr-3 !border-0 !border-r-0 !focus:outline-transparent nc-scrollbar-md"
+          class="p-1 !pt-1 !pr-3 !border-0 !border-r-0 !focus:outline-transparent nc-scrollbar-md !text-black"
           :bordered="false"
           :auto-size="{ minRows: 20, maxRows: 20 }"
           @keydown.stop

--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -10,6 +10,7 @@ import {
   iconMap,
   inject,
   useVModel,
+  ReadonlyInj
 } from '#imports'
 
 const props = defineProps<{
@@ -46,6 +47,8 @@ const inputWrapperRef = ref<HTMLElement | null>(null)
 const inputRef = ref<HTMLTextAreaElement | null>(null)
 
 const active = inject(ActiveCellInj, ref(false))
+
+const readOnly = inject(ReadonlyInj)
 
 watch(isVisible, () => {
   if (isVisible.value) {
@@ -138,6 +141,7 @@ onClickOutside(inputWrapperRef, (e) => {
           :auto-size="{ minRows: 20, maxRows: 20 }"
           @keydown.stop
           @keydown.escape="isVisible = false"
+          :disabled="readOnly"
         />
       </div>
     </template>

--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -249,7 +249,7 @@ onUnmounted(() => {
         <LazyCellJson v-else-if="isJSON(column)" v-model="vModel" />
         <LazyCellText v-else v-model="vModel" />
         <div
-          v-if="(isLocked || (isPublic && readOnly && !isForm) || isSystemColumn(column)) && !isAttachment(column)"
+          v-if="(isLocked || (isPublic && readOnly && !isForm) || isSystemColumn(column)) && !isAttachment(column) && !isTextArea(column)"
           class="nc-locked-overlay"
         />
       </template>


### PR DESCRIPTION
## Change Summary

Long text expand button enabled in shared view.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)