### PR TITLE
feat(nc-gui): relations in projectnode made modal

### DIFF
--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -6,11 +6,11 @@ import {
   EditColumnInj,
   EditModeInj,
   IsExpandedFormOpenInj,
+  ReadonlyInj,
   RowHeightInj,
   iconMap,
   inject,
   useVModel,
-  ReadonlyInj
 } from '#imports'
 
 const props = defineProps<{
@@ -139,9 +139,9 @@ onClickOutside(inputWrapperRef, (e) => {
           class="p-1 !pt-1 !pr-3 !border-0 !border-r-0 !focus:outline-transparent nc-scrollbar-md !text-black"
           :bordered="false"
           :auto-size="{ minRows: 20, maxRows: 20 }"
+          :disabled="readOnly"
           @keydown.stop
           @keydown.escape="isVisible = false"
-          :disabled="readOnly"
         />
       </div>
     </template>

--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -17,7 +17,6 @@ import {
 } from '#imports'
 import type { NcProject } from '#imports'
 import { useNuxtApp } from '#app'
-import Erd from '../settings/Erd.vue'
 
 const indicator = h(LoadingOutlined, {
   class: '!text-gray-400',
@@ -272,8 +271,7 @@ const onProjectClick = async (project: NcProject, ignoreNavigation?: boolean, to
 }
 
 function openErdView(base: BaseType) {
-  if (!base?.id) return
-  activeBaseId.value = base?.id
+  activeBaseId.value = base.id
   isErdModalOpen.value = !isErdModalOpen.value
 }
 
@@ -287,7 +285,7 @@ async function openProjectErdView(_project: ProjectType) {
   const project = projects.value.get(_project.id)
 
   const base = project?.bases?.[0]
-  if(!base) return
+  if (!base) return
   openErdView(base)
 }
 
@@ -732,13 +730,8 @@ const DlgProjectDuplicateOnOk = async (jobData: { id: string; project_id: string
     :on-ok="DlgProjectDuplicateOnOk"
   />
   <GeneralModal v-model:visible="isErdModalOpen" size="large">
-    <div
-      class="p-6"
-      :style="{
-        height: '80vh',
-      }"
-    >
-      <Erd :base-id="activeBaseId" />
+    <div class="p-6 h-[80vh]">
+      <LazyDashboardSettingsErd :base-id="activeBaseId" />
     </div>
   </GeneralModal>
 </template>

--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -17,6 +17,7 @@ import {
 } from '#imports'
 import type { NcProject } from '#imports'
 import { useNuxtApp } from '#app'
+import Erd from '../settings/Erd.vue'
 
 const indicator = h(LoadingOutlined, {
   class: '!text-gray-400',
@@ -48,6 +49,10 @@ useTabs()
 const editMode = ref(false)
 
 const tempTitle = ref('')
+
+const activeBaseId = ref('')
+
+const isErdModalOpen = ref<Boolean>(false)
 
 const { t } = useI18n()
 
@@ -267,7 +272,9 @@ const onProjectClick = async (project: NcProject, ignoreNavigation?: boolean, to
 }
 
 function openErdView(base: BaseType) {
-  navigateTo(`/nc/${base.project_id}/erd/${base.id}`)
+  if (!base?.id) return
+  activeBaseId.value = base?.id
+  isErdModalOpen.value = !isErdModalOpen.value
 }
 
 async function openProjectErdView(_project: ProjectType) {
@@ -280,8 +287,8 @@ async function openProjectErdView(_project: ProjectType) {
   const project = projects.value.get(_project.id)
 
   const base = project?.bases?.[0]
-  if (!base) return
-  navigateTo(`/nc/${base.project_id}/erd/${base.id}`)
+  if(!base) return
+  openErdView(base)
 }
 
 const reloadTables = async () => {
@@ -724,6 +731,16 @@ const DlgProjectDuplicateOnOk = async (jobData: { id: string; project_id: string
     :project="selectedProjectToDuplicate"
     :on-ok="DlgProjectDuplicateOnOk"
   />
+  <GeneralModal v-model:visible="isErdModalOpen" size="large">
+    <div
+      class="p-6"
+      :style="{
+        height: '80vh',
+      }"
+    >
+      <Erd :base-id="activeBaseId" />
+    </div>
+  </GeneralModal>
 </template>
 
 <style lang="scss" scoped>

--- a/packages/nc-gui/components/dashboard/settings/DataSources.vue
+++ b/packages/nc-gui/components/dashboard/settings/DataSources.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
 import Draggable from 'vuedraggable'
 import type { BaseType } from 'nocodb-sdk'
-import CreateBase from './data-sources/CreateBase.vue'
-import EditBase from './data-sources/EditBase.vue'
-import Metadata from './Metadata.vue'
-import UIAcl from './UIAcl.vue'
-import Erd from './Erd.vue'
-import BaseAudit from './BaseAudit.vue'
 import { ClientType, DataSourcesSubTab, storeToRefs, useCommandPalette, useNuxtApp, useProject } from '#imports'
 
 interface Props {
@@ -511,7 +505,11 @@ const isEditBaseModalOpen = computed({
       </div>
       <GeneralModal v-model:visible="isNewBaseModalOpen" size="medium">
         <div class="py-6 px-8">
-          <CreateBase :connection-type="clientType" @base-created="loadBases(true)" @close="isNewBaseModalOpen = false" />
+          <LazyDashboardSettingsDataSourcesCreateBase
+            :connection-type="clientType"
+            @base-created="loadBases(true)"
+            @close="isNewBaseModalOpen = false"
+          />
         </div>
       </GeneralModal>
       <GeneralModal v-model:visible="isErdModalOpen" size="large">
@@ -521,27 +519,31 @@ const isEditBaseModalOpen = computed({
             height: '80vh',
           }"
         >
-          <Erd :base-id="activeBaseId" />
+          <LazyDashboardSettingsErd :base-id="activeBaseId" />
         </div>
       </GeneralModal>
       <GeneralModal v-model:visible="isMetaDataModal" size="medium">
         <div class="p-6">
-          <Metadata :base-id="activeBaseId" @base-synced="loadBases(true)" />
+          <LazyDashboardSettingsMetadata :base-id="activeBaseId" @base-synced="loadBases(true)" />
         </div>
       </GeneralModal>
       <GeneralModal v-model:visible="isUIAclModalOpen" class="!w-[60rem]">
         <div class="p-6">
-          <UIAcl :base-id="activeBaseId" />
+          <LazyDashboardSettingsUIAcl :base-id="activeBaseId" />
         </div>
       </GeneralModal>
       <GeneralModal v-model:visible="isEditBaseModalOpen" size="medium">
         <div class="p-6">
-          <EditBase :base-id="activeBaseId" @base-updated="loadBases(true)" @close="isEditBaseModalOpen = false" />
+          <LazyDashboardSettingsDataSourcesEditBase
+            :base-id="activeBaseId"
+            @base-updated="loadBases(true)"
+            @close="isEditBaseModalOpen = false"
+          />
         </div>
       </GeneralModal>
       <GeneralModal v-model:visible="isBaseAuditModalOpen" class="!w-[70rem]">
         <div class="p-6">
-          <BaseAudit :base-id="activeBaseId" @close="isBaseAuditModalOpen = false" />
+          <LazyDashboardSettingsBaseAudit :base-id="activeBaseId" @close="isBaseAuditModalOpen = false" />
         </div>
       </GeneralModal>
       <GeneralDeleteModal v-model:visible="isDeleteBaseModalOpen" entity-name="base" :on-delete="deleteBase">

--- a/packages/nc-gui/components/erd/Flow.vue
+++ b/packages/nc-gui/components/erd/Flow.vue
@@ -19,6 +19,7 @@ const {
   $destroy,
   fitView,
   viewport,
+  setMaxZoom,
   onNodeDoubleClick,
   zoomIn: internalZoomIn,
   zoomOut: internalZoomOut,
@@ -56,6 +57,14 @@ watch(showSkeleton, async (isSkeleton) => {
       maxZoom: isSkeleton ? viewport.value.zoom : undefined,
     })
   })
+})
+
+watch(elements, (elements) => {
+  if (elements.length > 3) {
+    setMaxZoom(2)
+  } else {
+    setMaxZoom(1.25)
+  }
 })
 
 onScopeDispose($destroy)

--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -249,7 +249,11 @@ onUnmounted(() => {
         <LazyCellJson v-else-if="isJSON(column)" v-model="vModel" />
         <LazyCellText v-else v-model="vModel" />
         <div
-          v-if="(isLocked || (isPublic && readOnly && !isForm) || isSystemColumn(column)) && !isAttachment(column) && !isTextArea(column)"
+          v-if="
+            (isLocked || (isPublic && readOnly && !isForm) || isSystemColumn(column)) &&
+            !isAttachment(column) &&
+            !isTextArea(column)
+          "
           class="nc-locked-overlay"
         />
       </template>

--- a/packages/nc-gui/components/smartsheet/toolbar/Reload.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/Reload.vue
@@ -35,7 +35,7 @@ watch(isReloading, () => {
     >
       <component
         :is="iconMap.reload"
-        class="group-hover:(text-primary) h-4 nc-icon-reload"
+        class="group-hover:(text-primary) h-4 nc-icon-reload text-gray-400"
         :class="isReloading ? 'animate-spin' : ''"
         @click="onClick"
       />

--- a/packages/nc-gui/components/smartsheet/toolbar/ViewInfo.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ViewInfo.vue
@@ -28,7 +28,7 @@ const { activeTable } = storeToRefs(useTablesStore())
       {{ activeTable?.title }}
     </span>
 
-    <div class="px-2 text-gray-500">/</div>
+    <div class="px-2 text-gray-300">/</div>
     <LazyGeneralEmojiPicker :emoji="selectedView?.meta?.icon" readonly size="xsmall">
       <template #default>
         <GeneralViewIcon :meta="{ type: selectedView?.type }" class="min-w-4.5 text-lg flex" />


### PR DESCRIPTION
## Change Summary

* Relations opened from project node now opens as a modal.
* Project-Table name separator and reload icon made gray

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)