### PR TITLE
make volume optional

### DIFF
--- a/charts/nocodb/templates/deployment.yaml
+++ b/charts/nocodb/templates/deployment.yaml
@@ -33,9 +33,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.storage.enabled }}
           volumeMounts:
             - name: {{ include "nocodb.fullname" . }}
               mountPath: /usr/app/data
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "nocodb.fullname" . }}
@@ -67,7 +69,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.storage.enabled }}
       volumes:
         - name: {{ include "nocodb.fullname" . }}
           persistentVolumeClaim:
             claimName: {{ include "nocodb.fullname" . }}
+      {{- end }}

--- a/charts/nocodb/templates/pvc.yaml
+++ b/charts/nocodb/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.storage.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -12,3 +13,4 @@ spec:
   accessModes:
     {{- default (toYaml .Values.storage.accessModes) "- ReadWriteMany" | nindent 4 }}
   volumeMode: Filesystem
+{{ end }}

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -86,6 +86,7 @@ extraSecretEnvs:
   NC_DB: "mysql2://mysql:3306?u=nocodb&p=secretPass&d=nocodb"
 
 storage:
+  enabled: true
   size: 3Gi
   storageClassName: ""
 

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -86,6 +86,9 @@ extraSecretEnvs:
   NC_DB: "mysql2://mysql:3306?u=nocodb&p=secretPass&d=nocodb"
 
 storage:
+  # If disabled, another persistent storage should be configured for attachments to work.
+  # We recommend setting NC_S3_BUCKET_NAME and other NC_S3* environment variables.
+  # Refer documentation for more details.
   enabled: true
   size: 3Gi
   storageClassName: ""


### PR DESCRIPTION
## Change Summary

Make the Kubernetes volume optional, enabled by default

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [X] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


