### PR TITLE
fix(nc-gui): initWorker logic and remove unused code

### DIFF
--- a/packages/nc-gui/utils/workerUtils.ts
+++ b/packages/nc-gui/utils/workerUtils.ts
@@ -1,27 +1,16 @@
 import getCrossOriginWorkerURL from 'crossoriginworker'
 
-// Returns a blob:// URL which points
-// to a javascript file which will call
-// importScripts with the given URL
-export function getWorkerURL(url: string) {
-  const content = `importScripts( "${url}" );`
-  return URL.createObjectURL(new Blob([content], { type: 'text/javascript' }))
-}
-
 export async function initWorker(url: string) {
   let worker: Worker | null = null
   try {
-    const workerURL = await getCrossOriginWorkerURL(url)
-    worker = new Worker(workerURL)
-    // if (/^https?:\/\/'/.test(url)) {
-    //   // const worker_url = getWorkerURL(url)
-    //   // worker = new Worker(worker_url)
-    //   // URL.revokeObjectURL(worker_url)
-    // } else {
-    //   worker = new Worker(url, {
-    //     type: 'module',
-    //   })
-    // }
+    if (/^https?:\/\//.test(url)) {
+      const workerURL = await getCrossOriginWorkerURL(url)
+      worker = new Worker(workerURL)
+    } else {
+      worker = new Worker(url, {
+        type: 'module',
+      })
+    }
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
## Change Summary

- closes: #6720 

Previously, we were using `new Worker` for worker url. However, if we deploy to cloud, it would cause `XXX cannot be accessed from origin YYY`, since `app.nocodb.com` couldn't access `cdn.nocodb.com` due to CORS. In #6708, `crossoriginworker` was introduced which solves the above issue but it breaks the local case - `Cannot use import statement outside a module`.

This PR is simply to 

- cover both cloud & local cases
- and remove `getWorkerURL` since it is not in use.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Try the CDN url & local worker url for testing locally.