### PR TITLE
feat: import date/datetime filters from airtable

### DIFF
--- a/packages/nocodb/src/modules/jobs/jobs/at-import/at-import.processor.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/at-import/at-import.processor.ts
@@ -2012,8 +2012,8 @@ export class AtImportProcessor {
       '<=': 'lte',
       '>': 'gt',
       '>=': 'gte',
-      isEmpty: 'empty',
-      isNotEmpty: 'notempty',
+      isEmpty: 'blank',
+      isNotEmpty: 'notblank',
       contains: 'like',
       doesNotContain: 'nlike',
       isAnyOf: 'anyof',
@@ -2043,12 +2043,9 @@ export class AtImportProcessor {
         const ncFilters = [];
 
         // console.log(filter)
-        if (
-          datatype === UITypes.Date ||
-          datatype === UITypes.DateTime ||
-          datatype === UITypes.Links
-        ) {
-          // skip filters over data datatype
+        if (datatype === UITypes.Links) {
+          // skip filters for links; Link filters in NocoDB are only rollup counts
+          // where-as in airtable, filter can be textual
           updateMigrationSkipLog(
             await sMap.getNcNameFromAtId(viewId),
             colSchema.title,
@@ -2089,6 +2086,26 @@ export class AtImportProcessor {
               logical_op: f.conjunction,
               comparison_op: filterMap[filter.operator],
               value: await sMap.getNcNameFromAtId(filter.value),
+            };
+            ncFilters.push(fx);
+          }
+        } else if (datatype === UITypes.Date || datatype === UITypes.DateTime) {
+          if (filter.operator === 'isWithin') {
+            const fx = {
+              fk_column_id: columnId,
+              logical_op: f.conjunction,
+              comparison_op: filter.operator,
+              comparison_sub_op: filter.value?.mode,
+              value: filter.value?.numberOfDays,
+            };
+            ncFilters.push(fx);
+          } else {
+            const fx = {
+              fk_column_id: columnId,
+              logical_op: f.conjunction,
+              comparison_op: filterMap[filter.operator],
+              comparison_sub_op: filter.value?.mode,
+              value: filter.value?.exactDate,
             };
             ncFilters.push(fx);
           }


### PR DESCRIPTION
## Change Summary
During import, date/dateTime type filters were ignored as they were not supported earlier. @wingkwong had fixed date related filters, but it wasn't applied to airtable import earlier. 

## Change type
- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
