### PR TITLE
fix: Avoid getting unnecessary system column if getHiddenColumn is defined

### DIFF
--- a/packages/nocodb/src/helpers/getAst.ts
+++ b/packages/nocodb/src/helpers/getAst.ts
@@ -130,23 +130,25 @@ const getAst = async ({
       ).ast;
     }
     let isRequested;
+
     if (getHiddenColumn) {
       isRequested =
         !isSystemColumn(col) ||
         col.column_name === 'created_at' ||
         col.column_name === 'updated_at' ||
         col.pk;
-    } else {
+    } else if (allowedCols && (!includePkByDefault || !col.pk)) {
       isRequested =
-        allowedCols && (!includePkByDefault || !col.pk)
-          ? allowedCols[col.id] &&
-            (!isSystemColumn(col) || view.show_system_fields || col.pv) &&
-            (!fields?.length || fields.includes(col.title)) &&
-            value
-          : fields?.length
-          ? fields.includes(col.title) && value
-          : value;
+        allowedCols[col.id] &&
+        (!isSystemColumn(col) || view.show_system_fields || col.pv) &&
+        (!fields?.length || fields.includes(col.title)) &&
+        value;
+    } else if (fields?.length) {
+      isRequested = fields.includes(col.title) && value;
+    } else {
+      isRequested = value;
     }
+
     if (isRequested || col.pk) await extractDependencies(col, dependencyFields);
 
     return {

--- a/packages/nocodb/src/helpers/getAst.ts
+++ b/packages/nocodb/src/helpers/getAst.ts
@@ -18,7 +18,7 @@ const getAst = async ({
     nested: { ...(query?.nested || {}) },
     fieldsSet: new Set(),
   },
-  getHiddenColumn = false,
+  getHiddenColumn = query?.['getHiddenColumn'],
 }: {
   query?: RequestQuery;
   extractOnlyPrimaries?: boolean;


### PR DESCRIPTION
## Change Summary

- Avoid getting unnecessary system column(HM relation to junction table) if getHiddenColumn is defined

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
