### PR TITLE
chore: logic for replacing version

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -92,7 +92,7 @@ jobs:
           export NODE_OPTIONS="--max_old_space_size=16384"
           NOCODB_SDK_PKG_NAME=nocodb-sdk-daily
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} targetVersion=${{ github.event.inputs.tag || inputs.tag }} node scripts/bumpNocodbSdkVersion.js &&
-          pnpm --filter=${NOCODB_SDK_PKG_NAME} install --ignore-scripts --no-frozen-lockfile && pnpm --filter=${NOCODB_SDK_PKG_NAME} run build &&
+          pnpm --filter=${NOCODB_SDK_PKG_NAME} install --ignore-scripts --no-frozen-lockfile --ignore-workspace && pnpm --filter=${NOCODB_SDK_PKG_NAME} run build &&
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} node scripts/upgradeNocodbSdk.js &&
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} targetVersion=${{ github.event.inputs.tag || inputs.tag }} node scripts/bumpNcGuiVersion.js &&
           pnpm --filter=nc-gui install --ignore-scripts --no-frozen-lockfile &&

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -61,7 +61,7 @@ jobs:
           fi
           echo $NOCODB_SDK_PKG_NAME
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} targetVersion=${{ github.event.inputs.tag || inputs.tag }} node scripts/bumpNocodbSdkVersion.js &&
-          pnpm --filter=${NOCODB_SDK_PKG_NAME} install --ignore-scripts --no-frozen-lockfile && pnpm --filter=${NOCODB_SDK_PKG_NAME} run build && pnpm --filter=${NOCODB_SDK_PKG_NAME} publish --no-git-checks &&
+          pnpm --filter=${NOCODB_SDK_PKG_NAME} install --ignore-scripts --no-frozen-lockfile --ignore-workspace && pnpm --filter=${NOCODB_SDK_PKG_NAME} run build && pnpm --filter=${NOCODB_SDK_PKG_NAME} publish --no-git-checks &&
           sleep 90 &&
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} node scripts/upgradeNocodbSdk.js &&
           targetEnv=${{ github.event.inputs.targetEnv || inputs.targetEnv }} targetVersion=${{ github.event.inputs.tag || inputs.tag }} node scripts/bumpNcGuiVersion.js &&

--- a/scripts/upgradeNocodbSdk.js
+++ b/scripts/upgradeNocodbSdk.js
@@ -22,7 +22,8 @@ const replacePackageVersion = (filePath) => {
     return new Promise((resolve, reject) => {
         return fs.readFile(filePath, 'utf8', function (err, data) {
             if (err) return reject(err)
-            var result = data.replace(/workspace:\^/g, nocodbSdkPackage.version);
+            const rgx = new RegExp(`"${nocodbSdkPackage.name}": "(.*)"`, "g");
+            var result = data.replace(rgx, `"${nocodbSdkPackage.name}": "${nocodbSdkPackage.version}"`);
             return fs.writeFile(filePath, result, 'utf8', function (err) {
                 if (err) return reject(err)
                 return resolve()

--- a/scripts/upgradeNocodbSdk.js
+++ b/scripts/upgradeNocodbSdk.js
@@ -22,7 +22,7 @@ const replacePackageVersion = (filePath) => {
     return new Promise((resolve, reject) => {
         return fs.readFile(filePath, 'utf8', function (err, data) {
             if (err) return reject(err)
-            const rgx = new RegExp(`"${nocodbSdkPackage.name}": "(.*)"`, "g");
+            const rgx = new RegExp(`"${nocodbSdkPackage.name}": ".*"`, "g");
             var result = data.replace(rgx, `"${nocodbSdkPackage.name}": "${nocodbSdkPackage.version}"`);
             return fs.writeFile(filePath, result, 'utf8', function (err) {
                 if (err) return reject(err)


### PR DESCRIPTION
## Change Summary

- Depending on `workspace: ^` we need to manually push that change to master after release, we can instead use package name to replace the version
(see rn after the release master have versions instead of workspace: ^)
- Add --ignore-workspace for pnpm install of nocodb-sdk as we need to publish before bumping other packages

## Change type

- [x] chore: (updating grunt tasks etc; no production code change)
