### PR TITLE
fix(nc-gui): add ellipsis and show full name on hover

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/FieldsMenu.vue
@@ -374,7 +374,12 @@ useMenuCloseOnEsc(open)
                   >
                     <div class="flex items-center -ml-0.75">
                       <component :is="getIcon(metaColumnById[field.fk_column_id])" />
-                      <span class="mt-0.65">{{ field.title }}</span>
+                      <NcTooltip :disabled="field.title.length < 30">
+                        <template #title>
+                          {{ field.title }}
+                        </template>
+                        <span class="mx-0.65 break-all line-clamp-1">{{ field.title }}</span>
+                      </NcTooltip>
                     </div>
 
                     <NcSwitch v-e="['a:fields:show-hide']" :checked="field.show" :disabled="field.isViewEssentialField" />


### PR DESCRIPTION
## Change Summary

My pull request resolves fields dropdown UI closes: #6781

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi-colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Handle longer text by adding text ellipsis using TailwindCSS and showing full name on hover using NcTooltip.

## Additional information/screenshots

Before
<img width="403" alt="before" src="https://github.com/nocodb/nocodb/assets/90052329/05a765cd-3615-482b-83dc-b111477e954a">

After
<img width="403" alt="after" src="https://github.com/nocodb/nocodb/assets/90052329/1cd90eac-cef9-49a8-99d3-17d3ed2af4cc">

Hover
<img width="403" alt="hover" src="https://github.com/nocodb/nocodb/assets/90052329/9645ef3d-d6b6-4ae0-b85d-40188e7d3c0d">

