### PR TITLE
Add support for `URLENCODE` function

### DIFF
--- a/packages/noco-docs/docs/070.fields/040.field-types/060.formula/030.string-functions.md
+++ b/packages/noco-docs/docs/070.fields/040.field-types/060.formula/030.string-functions.md
@@ -216,6 +216,27 @@ URL(text)
 URL('https://www.example.com') => a clickable link for https://www.example.com
 ```
 
+## URLENCODE
+The URLENCODE function percent-encodes special characters in a string so it can
+be substituted as a query parameter into a URL.
+
+It is similar to JavaScript `encodeURIComponent()` function, except it encodes
+only characters that have a special meaning according to RFC 3986 section 2.2
+and also percent signs and spaces; other characters such as letters from
+non-Latin alphabets will not be encoded. Like `encodeURIComponent()`, it should
+be used only for encoding URL components, not whole URLs.
+
+#### Syntax
+```plaintext
+URLENCODE(text)
+```
+
+#### Sample
+```plaintext
+'https://example.com/q?param=' & URLENCODE('Hello, world')
+=> 'https://example.com/q?param=Hello%2C%20world'
+```
+
 
 ## Related Articles
 - [Numeric and Logical Operators](015.operators.md)

--- a/packages/nocodb-sdk/src/lib/formulaHelpers.ts
+++ b/packages/nocodb-sdk/src/lib/formulaHelpers.ts
@@ -1056,6 +1056,22 @@ export const formulas: Record<string, FormulaMeta> = {
     examples: ['URL("https://github.com/nocodb/nocodb")', 'URL({column1})'],
     returnType: FormulaDataTypes.STRING,
   },
+  URLENCODE: {
+    docsUrl:
+      'https://docs.nocodb.com/fields/field-types/formula/string-functions#urlencode',
+
+    validation: {
+      args: {
+        rqd: 1,
+        type: FormulaDataTypes.STRING,
+      },
+    },
+    description:
+      'Percent-encode the input parameter for use in URLs',
+    syntax: 'URLENCODE(str)',
+    examples: ['URLENCODE("Hello, world") => "Hello%2C%20world"', 'URLENCODE({column1})'],
+    returnType: FormulaDataTypes.STRING,
+  },
   WEEKDAY: {
     docsUrl:
       'https://docs.nocodb.com/fields/field-types/formula/date-functions#weekday',

--- a/packages/nocodb/src/db/functionMappings/commonFns.ts
+++ b/packages/nocodb/src/db/functionMappings/commonFns.ts
@@ -384,4 +384,15 @@ export default {
       builder: knex.raw(`(${valueBuilder} IS NOT NULL)${colAlias}`),
     };
   },
+  URLENCODE: async ({ fn, knex, pt, colAlias }: MapFnArgs) => {
+    const specialCharacters = '% :/?#[]@$&+,;=';
+    let str = (await fn(pt.arguments[0])).builder;
+    // Pass the characters as bound parameters to avoid problems with ? sign.
+    for (const c of specialCharacters) {
+      str = `REPLACE(${str}, ?, '${encodeURIComponent(c)}')`;
+    }
+    return {
+      builder: knex.raw(`${str} ${colAlias}`, specialCharacters.split('')),
+    };
+  },
 };

--- a/tests/playwright/tests/db/columns/columnFormula.spec.ts
+++ b/tests/playwright/tests/db/columns/columnFormula.spec.ts
@@ -143,6 +143,16 @@ const formulaDataByDbType = (context: NcContext, index: number) => {
         result: ['A Corua (La Corua)', 'Abha', 'Abu Dhabi', 'Acua', 'Ad...'],
         unSupDbType: ['sqlite3'],
       },
+      {
+        formula: 'URLENCODE({City})',
+        result: [
+          'A%20Corua%20(La%20Corua)',
+          'Abha',
+          'Abu%20Dhabi',
+          'Acua',
+          'Adana',
+        ],
+      },
     ];
   else
     return [


### PR DESCRIPTION
## Change Summary

This adds `URLENCODE` that percent-encodes special characters, so that column value can be safely substituted into URLs.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Tested on PostgreSQL. But it should work fine on other backends, too.