### PR TITLE
fix: trim leading and trailing spaces from column titles

### DIFF
--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -124,6 +124,11 @@ export class ColumnsService {
       param.column.column_name = sanitizeColumnName(param.column.column_name);
     }
 
+    // trim leading and trailing spaces from column title as knex trim them by default
+    if (param.column.title) {
+      param.column.title = param.column.title.trim();
+    }
+
     if (param.column.column_name) {
       // - 5 is a buffer for suffix
       let colName = param.column.column_name.slice(0, mxColumnLength - 5);
@@ -1066,6 +1071,11 @@ export class ColumnsService {
 
       if (!isVirtualCol(param.column)) {
         param.column.column_name = sanitizeColumnName(param.column.column_name);
+      }
+
+      // trim leading and trailing spaces from column title as knex trim them by default
+      if (param.column.title) {
+        param.column.title = param.column.title.trim();
       }
 
       if (param.column.column_name) {


### PR DESCRIPTION
## Change Summary

Knex trims leading and trailing spaces by default which ends up breaking our behavior (alias and title is different).
We will trim them on our side as well to match that behavior.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)