### PR TITLE
fix: duplicate formula column after alias change

### DIFF
--- a/packages/nc-gui/components/dlg/ColumnDuplicate.vue
+++ b/packages/nc-gui/components/dlg/ColumnDuplicate.vue
@@ -17,10 +17,6 @@ const dialogShow = useVModel(props, 'modelValue', emit)
 
 const { $e, $poller } = useNuxtApp()
 
-const basesStore = useBases()
-
-const { createProject: _createProject } = basesStore
-
 const { activeTable: _activeTable } = storeToRefs(useTablesStore())
 
 const reloadDataHook = inject(ReloadViewDataHookInj)
@@ -101,7 +97,9 @@ onKeyStroke('Enter', () => {
   }
 })
 
-const isEaster = ref(false)
+defineExpose({
+  duplicate: _duplicate,
+})
 </script>
 
 <template>
@@ -118,11 +116,9 @@ const isEaster = ref(false)
     @keydown.esc="dialogShow = false"
   >
     <div>
-      <div class="prose-xl font-bold self-center" @dblclick="isEaster = !isEaster">
-        {{ $t('general.duplicate') }} {{ $t('objects.column') }}
-      </div>
+      <div class="prose-xl font-bold self-center">{{ $t('general.duplicate') }} {{ $t('objects.column') }}</div>
 
-      <div class="mt-4">{{ $t('msg.warning.duplicateProject') }}</div>
+      <div class="mt-4">Are you sure you want to duplicate the field?</div>
 
       <div class="prose-md self-center text-gray-500 mt-4">{{ $t('title.advancedSettings') }}</div>
 

--- a/packages/nc-gui/components/smartsheet/header/Menu.vue
+++ b/packages/nc-gui/components/smartsheet/header/Menu.vue
@@ -111,8 +111,8 @@ const sortByColumn = async (direction: 'asc' | 'desc') => {
 }
 
 const isDuplicateDlgOpen = ref(false)
-const selectedColumnToDuplicate = ref<ColumnType>()
 const selectedColumnExtra = ref<any>()
+const duplicateDialogRef = ref<any>()
 
 const duplicateVirtualColumn = async () => {
   let columnCreatePayload = {}
@@ -165,7 +165,7 @@ const duplicateVirtualColumn = async () => {
 
 const openDuplicateDlg = async () => {
   if (!column?.value) return
-  if (column.value.uidt && [UITypes.Formula, UITypes.Lookup, UITypes.Rollup].includes(column.value.uidt as UITypes)) {
+  if (column.value.uidt && [UITypes.Lookup, UITypes.Rollup].includes(column.value.uidt as UITypes)) {
     duplicateVirtualColumn()
   } else {
     const gridViewColumnList = (await $api.dbViewColumn.list(view.value?.id as string)).list
@@ -186,8 +186,15 @@ const openDuplicateDlg = async () => {
         view_id: view.value!.id as string,
       },
     }
-    selectedColumnToDuplicate.value = column.value
-    isDuplicateDlgOpen.value = true
+
+    if (column.value.uidt === UITypes.Formula) {
+      nextTick(() => {
+        duplicateDialogRef?.value?.duplicate()
+      })
+    } else {
+      isDuplicateDlgOpen.value = true
+    }
+
     isOpen.value = false
   }
 }
@@ -373,9 +380,10 @@ const onInsertAfter = () => {
   </a-dropdown>
   <SmartsheetHeaderDeleteColumnModal v-model:visible="showDeleteColumnModal" />
   <DlgColumnDuplicate
-    v-if="selectedColumnToDuplicate"
+    v-if="column"
+    ref="duplicateDialogRef"
     v-model="isDuplicateDlgOpen"
-    :column="selectedColumnToDuplicate"
+    :column="column"
     :extra="selectedColumnExtra"
   />
 </template>

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/duplicate.processor.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/duplicate.processor.ts
@@ -3,7 +3,7 @@ import { Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
 import papaparse from 'papaparse';
 import debug from 'debug';
-import { isLinksOrLTAR } from 'nocodb-sdk';
+import { isLinksOrLTAR, isVirtualCol } from 'nocodb-sdk';
 import { Base, Column, Model, Source } from '~/models';
 import { BasesService } from '~/services/bases.service';
 import {
@@ -373,14 +373,16 @@ export class DuplicateProcessor {
     });
 
     // update cdf
-    await this.columnsService.columnUpdate({
-      columnId: findWithIdentifier(idMap, sourceColumn.id),
-      column: {
-        ...destColumn,
-        cdf: oldCdf,
-      },
-      user: req.user,
-    });
+    if (!isVirtualCol(destColumn)) {
+      await this.columnsService.columnUpdate({
+        columnId: findWithIdentifier(idMap, sourceColumn.id),
+        column: {
+          ...destColumn,
+          cdf: oldCdf,
+        },
+        user: req.user,
+      });
+    }
 
     this.debugLog(`job completed for ${job.id} (${JobTypes.DuplicateModel})`);
 

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
@@ -129,6 +129,17 @@ export class ExportService {
                 }
                 break;
               case 'formula':
+                // rewrite formula_raw with aliases
+                column.colOptions['formula_raw'] = column.colOptions[k].replace(
+                  /\{\{.*?\}\}/gm,
+                  (match) => {
+                    const col = model.columns.find(
+                      (c) => c.id === match.slice(2, -2),
+                    );
+                    return `{${col?.title}}`;
+                  },
+                );
+
                 column.colOptions[k] = column.colOptions[k].replace(
                   /(?<=\{\{).*?(?=\}\})/gm,
                   (match) => idMap.get(match),


### PR DESCRIPTION
## Change Summary

Re #6874

Formula column still keeps old titles inside **formula_raw** after column title change. This was causing duplicate to break. I replaced logic to derive formula_raw from formula (which uses column ids, we use this while rendering as well so it is not breaking after title change)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)