### PR TITLE
fix(renovate): remove onlyNpm & enable it again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:base",
     ":dependencyDashboard",
-    ":onlyNpm",
     ":prConcurrentLimit20",
     ":autodetectPinVersions",
     ":label(renovate)",
@@ -62,5 +61,5 @@
   "assignees": [
     "wingkwong"
   ],
-  "enabled": false
+  "enabled": true
 }


### PR DESCRIPTION
## Change Summary

- `onlyNpm` has been merged to default preset. We don't need to extend anymore.
- closes: #6993 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
