### PR TITLE
Fix GitHub casing in Translation page

### DIFF
--- a/packages/noco-docs/docs/150.engineering/070.translation.md
+++ b/packages/noco-docs/docs/150.engineering/070.translation.md
@@ -9,7 +9,7 @@ tags: ['Engineering']
 
 ## How to add / edit translations ?
 
-### Using Github
+### Using GitHub
 - For English, make changes directly to [en.json](https://github.com/nocodb/nocodb/blob/develop/packages/nc-gui/lang/en.json) & commit to `develop`
 - For any other language, use `crowdin` option.
 


### PR DESCRIPTION
Fix GitHub casing in Translation page

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [x] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
