### PR TITLE
fix: use json as default content type for webhooks

### DIFF
--- a/packages/nocodb/src/helpers/webhookHelpers.ts
+++ b/packages/nocodb/src/helpers/webhookHelpers.ts
@@ -182,6 +182,18 @@ export async function handleHttpWebHook(
   prevData,
   newData,
 ): Promise<any> {
+  const contentType = apiMeta.headers?.find(
+    (header) => header.name?.toLowerCase() === 'content-type' && header.enabled,
+  );
+
+  if (!contentType) {
+    apiMeta.headers.push({
+      name: 'Content-Type',
+      enabled: true,
+      value: 'application/json',
+    });
+  }
+
   const req = axiosRequestMake(
     apiMeta,
     user,


### PR DESCRIPTION
## Change Summary

Closes #6746, #6822

- Add `Content-Type: application/json` header if not specified by user

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

