### PR TITLE
fix: augment #app rather than #app/nuxt

### DIFF
--- a/packages/nc-gui/nuxt-shim.d.ts
+++ b/packages/nc-gui/nuxt-shim.d.ts
@@ -3,7 +3,7 @@ import type { UseGlobalReturn } from './composables/useGlobal/types'
 import type { NocoI18n } from './lib'
 import type { TabType } from './composables'
 
-declare module '#app/nuxt' {
+declare module '#app' {
   interface NuxtApp {
     $api: BaseAPI<any>
     /** {@link import('./plugins/tele') Telemetry} */


### PR DESCRIPTION
## Change Summary

We're seeing some cases where when users augment `#app/nuxt` rather than `#app`, they can lose type support once the (future default) typescript module resolution of 'bundler' is enabled. This PR shouldn't cause any issues for you but it might prevent issues in future.

related: https://github.com/nuxt/nuxt/issues/24193

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
