### PR TITLE
docs: Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Turns any MySQL, PostgreSQL, SQL Server, SQLite & MariaDB into a smart spreadshe
 
 # Quick try
 
+## One Click Deploy
+
+Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=nocodb):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=nocodb)
+
 ## Docker
 
 ```bash


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://nocodb-1533.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.
