### PR TITLE
Add plugin setting for minio CDN endpoint support

### DIFF
--- a/packages/nocodb/src/plugins/mino/Minio.ts
+++ b/packages/nocodb/src/plugins/mino/Minio.ts
@@ -34,13 +34,7 @@ export default class Minio implements IStorageAdapterV2 {
       // call S3 to retrieve upload file to specified bucket
       this.minioClient
         .putObject(this.input?.bucket, key, fileStream, metaData)
-        .then(() => {
-          resolve(
-            `http${this.input.useSSL ? 's' : ''}://${this.input.endPoint}:${
-              this.input.port
-            }/${this.input.bucket}/${key}`,
-          );
-        })
+        .then(() => resolve(this.getFileUrl(key)))
         .catch(reject);
     });
   }
@@ -116,13 +110,7 @@ export default class Minio implements IStorageAdapterV2 {
           // call S3 to retrieve upload file to specified bucket
           this.minioClient
             .putObject(this.input?.bucket, key, response.data, metaData)
-            .then(() => {
-              resolve(
-                `http${this.input.useSSL ? 's' : ''}://${this.input.endPoint}:${
-                  this.input.port
-                }/${this.input.bucket}/${key}`,
-              );
-            })
+            .then(() => resolve(this.getFileUrl(key)))
             .catch(reject);
         })
         .catch((error) => {
@@ -144,5 +132,13 @@ export default class Minio implements IStorageAdapterV2 {
   // TODO - implement
   getDirectoryList(_path: string): Promise<string[]> {
     return Promise.resolve(undefined);
+  }
+
+  private getFileUrl(key: string): string {
+    let fileUrlPrefix = `http${this.input.useSSL ? 's' : ''}://${this.input.endPoint}:${this.input.port}`
+    if (this.input.cdnEndpoint) {
+      fileUrlPrefix = this.input.cdnEndpoint;
+    }
+    return `${fileUrlPrefix}/${key}`;
   }
 }

--- a/packages/nocodb/src/plugins/mino/index.ts
+++ b/packages/nocodb/src/plugins/mino/index.ts
@@ -23,6 +23,13 @@ const config: XcPluginConfig = {
         required: true,
       },
       {
+        key: 'cdnEndPoint',
+        label: 'Minio CDN Endpoint',
+        placeholder: 'https://example.com',
+        type: XcType.SingleLineText,
+        required: false,
+      },
+      {
         key: 'port',
         label: 'Port',
         placeholder: 'Port',


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)
For some well-known reasons, we usually do not use the standard endpoint/bucket/key mode to access resource files.

![image](https://github.com/nocodb/nocodb/assets/11485337/0058cc30-40c4-441a-9d47-38b15d304e62)
Solve this problem by adding a setting that will use the CDN address when necessary for resource display.
By applying this setting, it is possible to alleviate the implementation difficulties of some other compatible solutions.

Anything for maintainers to be made aware of
