### PR TITLE
fix: avoid flushing redis when cloud init

### DIFF
--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -14,7 +14,7 @@ export default class RedisCacheMgr extends CacheMgr {
     this.client = new Redis(config);
 
     // avoid flushing db in worker container
-    if (process.env.NC_WORKER_CONTAINER !== 'true') {
+    if (process.env.NC_WORKER_CONTAINER !== 'true' &&  process.env.NC_CLOUD !== 'true') {
       // flush the existing db with selected key (Default: 0)
       this.client.flushdb();
     }


### PR DESCRIPTION
## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
