### PR TITLE
Add -OutFile flag to Windows download commands in 010.installation.md

### DIFF
--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
@@ -8,8 +8,8 @@ keywords : ['NocoDB installation', 'NocoDB docker installation', 'NocoDB nodejs 
 Simple installation - takes about three minutes!
 
 ## Prerequisites
-- [Docker](https://www.docker.com/get-started) or [Node.js](https://nodejs.org/en/download) ( > v18.x ) 
-    
+- [Docker](https://www.docker.com/get-started) or [Node.js](https://nodejs.org/en/download) ( > v18.x )
+
 ## Quick try
 
 ### Docker
@@ -107,7 +107,7 @@ docker-compose up -d
 </TabItem>
 </Tabs>
 
-:::tip 
+:::tip
 To persist data in docker you can mount volume at `/usr/app/data/` since 0.10.6. In older version mount at `/usr/src/app`.
 If you plan to input some special characters, you may need to change the character set and collation yourself when creating the database. Please check out the examples for [MySQL Docker Compose](https://github.com/nocodb/nocodb/issues/1313#issuecomment-1046625974).
 :::
@@ -121,7 +121,7 @@ You can run below command if you need an interactive configuration.
 npx create-nocodb-app
 ```
 
-#### Preview: 
+#### Preview:
 
 <img width="587" alt="image" src="https://user-images.githubusercontent.com/35857179/161526235-5ee0d592-0105-4a57-aa53-b1048dca6aad.png" />
 
@@ -179,7 +179,7 @@ curl http://get.nocodb.com/linux-arm64 -o nocodb -L \
 <TabItem value="Windows (x64)" label="Windows (x64)">
 
 ```bash
-iwr http://get.nocodb.com/win-x64.exe
+iwr http://get.nocodb.com/win-x64.exe -OutFile "Noco-win-x64.exe"
 .\Noco-win-x64.exe
 ```
 
@@ -187,7 +187,7 @@ iwr http://get.nocodb.com/win-x64.exe
 <TabItem value="Windows (arm64)" label="Windows (arm64)">
 
 ```bash
-iwr http://get.nocodb.com/win-arm64.exe
+iwr http://get.nocodb.com/win-arm64.exe -OutFile "Noco-win-x64.exe"
 .\Noco-win-arm64.exe
 ```
 
@@ -212,23 +212,23 @@ npm start
 <details>
   <summary>Click to Expand</summary>
 
-  #### Create ECS Cluster
+#### Create ECS Cluster
 
   ```
   aws ecs create-cluster \
   --cluster-name <YOUR_ECS_CLUSTER>
   ```
 
-  #### Create Log group
+#### Create Log group
 
   ```
   aws logs create-log-group \
   --log-group-name /ecs/<YOUR_APP_NAME>/<YOUR_CONTAINER_NAME>
   ```
 
-  #### Create ECS Task Definiton
+#### Create ECS Task Definiton
 
-  Every time you create it, it will add a new version. If it is not existing, the version will be 1. 
+Every time you create it, it will add a new version. If it is not existing, the version will be 1.
 
   ```bash
   aws ecs register-task-definition \
@@ -239,7 +239,7 @@ npm start
 This json file defines the container specification. You can define secrets such as NC_DB and environment variables here.
 :::
 
-  Here's the sample Task Definition
+Here's the sample Task Definition
 
   ```json
   {
@@ -281,7 +281,7 @@ This json file defines the container specification. You can define secrets such 
   }
   ```
 
-  #### Create ECS Service
+#### Create ECS Service
 
   ```bash
   aws ecs create-service \
@@ -298,7 +298,7 @@ This json file defines the container specification. You can define secrets such 
 
 :::tip
 
-If your service fails to start, you may check the logs in ECS console or in Cloudwatch. Generally it fails due to the connection between ECS container and NC_DB. Make sure the security groups have the correct inbound and outbound rules.  
+If your service fails to start, you may check the logs in ECS console or in Cloudwatch. Generally it fails due to the connection between ECS container and NC_DB. Make sure the security groups have the correct inbound and outbound rules.
 
 :::
 
@@ -309,9 +309,9 @@ If your service fails to start, you may check the logs in ECS console or in Clou
 <details>
   <summary>Click to Expand</summary>
 
-  #### Pull NocoDB Image on Cloud Shell
+#### Pull NocoDB Image on Cloud Shell
 
-  Since Cloud Run only supports images from Google Container Registry (GCR) or Artifact Registry, we need to pull NocoDB image, tag it and push it in GCP using Cloud Shell. Here are some sample commands which you can execute in Cloud Shell.
+Since Cloud Run only supports images from Google Container Registry (GCR) or Artifact Registry, we need to pull NocoDB image, tag it and push it in GCP using Cloud Shell. Here are some sample commands which you can execute in Cloud Shell.
 
   ```bash
   # pull latest NocoDB image
@@ -324,7 +324,7 @@ If your service fails to start, you may check the logs in ECS console or in Clou
   docker push gcr.io/<MY_PROJECT_ID>/nocodb/nocodb:latest
   ```
 
-  #### Deploy NocoDB on Cloud Run
+#### Deploy NocoDB on Cloud Run
 
   ```bash
   gcloud run deploy --image=gcr.io/<MY_PROJECT_ID>/nocodb/nocodb:latest \
@@ -340,40 +340,40 @@ If your service fails to start, you may check the logs in ECS console or in Clou
 <details>
   <summary>Click to Expand</summary>
 
-  #### Create Apps
+#### Create Apps
 
-  On Home page, Click on Create icon & Select Apps (Deploy your code).
+On Home page, Click on Create icon & Select Apps (Deploy your code).
 
-  ![Screenshot 2022-02-19 at 12 17 43 PM](https://user-images.githubusercontent.com/86527202/154790558-f8fe5580-5a58-412c-9c2e-145587712bf2.png)
+![Screenshot 2022-02-19 at 12 17 43 PM](https://user-images.githubusercontent.com/86527202/154790558-f8fe5580-5a58-412c-9c2e-145587712bf2.png)
 
-  #### Choose Source: Docker Hub
+#### Choose Source: Docker Hub
 
-  ![Screenshot 2022-02-19 at 12 22 01 PM](https://user-images.githubusercontent.com/86527202/154790563-b5b6d5b4-0bdc-4718-8cea-0a7ee52f283b.png)
+![Screenshot 2022-02-19 at 12 22 01 PM](https://user-images.githubusercontent.com/86527202/154790563-b5b6d5b4-0bdc-4718-8cea-0a7ee52f283b.png)
 
-  #### Choose Source: Repository
+#### Choose Source: Repository
 
-  Configure Source Repository as `nocodb/nocodb`. Optionally you can pick release tag if you are interested in specific NocoDB version.
+Configure Source Repository as `nocodb/nocodb`. Optionally you can pick release tag if you are interested in specific NocoDB version.
 
-  ![Screenshot 2022-02-19 at 12 23 11 PM](https://user-images.githubusercontent.com/86527202/154790564-1dcb5e33-3a57-471a-a44c-835a410a0cb7.png)
+![Screenshot 2022-02-19 at 12 23 11 PM](https://user-images.githubusercontent.com/86527202/154790564-1dcb5e33-3a57-471a-a44c-835a410a0cb7.png)
 
-  #### [Optional] Additional Configurations
+#### [Optional] Additional Configurations
 
-  ![Screenshot 2022-02-19 at 12 24 44 PM](https://user-images.githubusercontent.com/86527202/154790565-c0234b2e-ad50-4042-90b6-4f8798f1d585.png)
+![Screenshot 2022-02-19 at 12 24 44 PM](https://user-images.githubusercontent.com/86527202/154790565-c0234b2e-ad50-4042-90b6-4f8798f1d585.png)
 
-  #### Name your web service
-  Pick a name for your NocoDB application. This name will become part of URL subsequently
-  Pick nearest Region for cloud hosting
-  ![Screenshot 2022-02-19 at 12 28 11 PM](https://user-images.githubusercontent.com/86527202/154790567-a6e65e4e-9aa0-4edb-998e-da8803ad6e23.png)
+#### Name your web service
+Pick a name for your NocoDB application. This name will become part of URL subsequently
+Pick nearest Region for cloud hosting
+![Screenshot 2022-02-19 at 12 28 11 PM](https://user-images.githubusercontent.com/86527202/154790567-a6e65e4e-9aa0-4edb-998e-da8803ad6e23.png)
 
-  #### Finalize and Launch
+#### Finalize and Launch
 
-  - Select hosting plan for your NocoDB application
+- Select hosting plan for your NocoDB application
 
-  - Click "Launch APP"
-  
-  ![Screenshot 2022-02-19 at 12 29 23 PM](https://user-images.githubusercontent.com/86527202/154790570-62044713-5cca-4d06-82ec-f3cc257218a1.png)
+- Click "Launch APP"
 
-  Application will be build & URL will be live in a minute! The URL will be something like https://simply-nocodb-rsyir.ondigitalocean.app/
+![Screenshot 2022-02-19 at 12 29 23 PM](https://user-images.githubusercontent.com/86527202/154790570-62044713-5cca-4d06-82ec-f3cc257218a1.png)
+
+Application will be build & URL will be live in a minute! The URL will be something like https://simply-nocodb-rsyir.ondigitalocean.app/
 
 </details>
 
@@ -382,27 +382,27 @@ If your service fails to start, you may check the logs in ECS console or in Clou
 <details>
   <summary>Click to Expand</summary>
 
-  #### Navigate to App Store
+#### Navigate to App Store
 
-  Log into Cloudron and select App Store
+Log into Cloudron and select App Store
 
-  ![image](https://user-images.githubusercontent.com/35857179/194700146-aae90503-a8fd-4bc5-8397-39f0bc279606.png)
+![image](https://user-images.githubusercontent.com/35857179/194700146-aae90503-a8fd-4bc5-8397-39f0bc279606.png)
 
-  #### Search NocoDB
+#### Search NocoDB
 
-  ![image](https://user-images.githubusercontent.com/35857179/194700181-b5303919-70b8-4cf8-bebe-7e75aca601f3.png)
+![image](https://user-images.githubusercontent.com/35857179/194700181-b5303919-70b8-4cf8-bebe-7e75aca601f3.png)
 
-  #### Click Install
+#### Click Install
 
-  ![image](https://user-images.githubusercontent.com/35857179/194700192-d702f5c2-2afa-45c5-9823-4ebe9e141b01.png)
+![image](https://user-images.githubusercontent.com/35857179/194700192-d702f5c2-2afa-45c5-9823-4ebe9e141b01.png)
 
-  #### Configure NocoDB
+#### Configure NocoDB
 
-  ![image](https://user-images.githubusercontent.com/35857179/194700230-c35e934f-bd93-4948-8f31-935483b30571.png)
+![image](https://user-images.githubusercontent.com/35857179/194700230-c35e934f-bd93-4948-8f31-935483b30571.png)
 
-  #### Go to My App and Launch NocoDB
+#### Go to My App and Launch NocoDB
 
-  ![image](https://user-images.githubusercontent.com/35857179/194700464-50098cb1-bf94-42bb-a63a-cc0aad671913.png)
+![image](https://user-images.githubusercontent.com/35857179/194700464-50098cb1-bf94-42bb-a63a-cc0aad671913.png)
 
 </details>
 
@@ -411,17 +411,17 @@ If your service fails to start, you may check the logs in ECS console or in Clou
 <details>
   <summary>Click to Expand</summary>
 
-  #### Login and Click One-Click Apps / Databases 
+#### Login and Click One-Click Apps / Databases
 
-  ![image](https://user-images.githubusercontent.com/35857179/194701420-7fe5c396-a488-456c-98de-6f2ee1151fc5.png)
+![image](https://user-images.githubusercontent.com/35857179/194701420-7fe5c396-a488-456c-98de-6f2ee1151fc5.png)
 
-  #### Search NocoDB
+#### Search NocoDB
 
-  ![image](https://user-images.githubusercontent.com/35857179/194701537-63e7efc5-013b-4ca9-8659-56e9d536e7d0.png)
+![image](https://user-images.githubusercontent.com/35857179/194701537-63e7efc5-013b-4ca9-8659-56e9d536e7d0.png)
 
-  #### Configure NocoDB and Deploy
+#### Configure NocoDB and Deploy
 
-  ![image](https://user-images.githubusercontent.com/35857179/194701576-19519df5-2aa4-435d-8fc6-7bc684b9cfe1.png)
+![image](https://user-images.githubusercontent.com/35857179/194701576-19519df5-2aa4-435d-8fc6-7bc684b9cfe1.png)
 
 </details>
 
@@ -430,15 +430,15 @@ If your service fails to start, you may check the logs in ECS console or in Clou
 <details>
   <summary>Click to Expand</summary>
 
-  #### Navigate to Templates
+#### Navigate to Templates
 
-  Go to [Templates](https://railway.app/templates), Search NocoDB and click Deploy
+Go to [Templates](https://railway.app/templates), Search NocoDB and click Deploy
 
-  ![image](https://user-images.githubusercontent.com/35857179/194702833-1bea22ee-6dfa-4024-ac27-e33fe56e5500.png)
+![image](https://user-images.githubusercontent.com/35857179/194702833-1bea22ee-6dfa-4024-ac27-e33fe56e5500.png)
 
-  #### Configure NocoDB and Deploy
+#### Configure NocoDB and Deploy
 
-  ![image](https://user-images.githubusercontent.com/35857179/194702960-149393fe-b00f-4d84-9e54-22cb7616ba44.png)
+![image](https://user-images.githubusercontent.com/35857179/194702960-149393fe-b00f-4d84-9e54-22cb7616ba44.png)
 
 </details>
 

--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
@@ -187,7 +187,7 @@ iwr http://get.nocodb.com/win-x64.exe -OutFile "Noco-win-x64.exe"
 <TabItem value="Windows (arm64)" label="Windows (arm64)">
 
 ```bash
-iwr http://get.nocodb.com/win-arm64.exe -OutFile "Noco-win-x64.exe"
+iwr http://get.nocodb.com/win-arm64.exe -OutFile "Noco-win-arm64.exe"
 .\Noco-win-arm64.exe
 ```
 


### PR DESCRIPTION
## Change Summary

This commit updates the installation documentation for Windows users, **adding the missing -OutFile flag** to the PowerShell commands. This ensures the executable files for NocoDB are **correctly downloaded and saved** in the user's working directory, enhancing the installation experience and preventing potential confusion or errors during setup.

## Change type

- [- ] ~~feat: (new feature for the user, not a new feature for build script)~~
- [- ] ~~fix: (bug fix for the user, not a fix to a build script)~~
- [x] **docs: (changes to the documentation)**
- [ -] ~~style: (formatting, missing semi colons, etc; no production code change)~~
- [ -] ~~refactor: (refactoring production code, eg. renaming a variable)~~
- [- ] ~~test: (adding missing tests, refactoring tests; no production code change)~~
- [- ] ~~chore: (updating grunt tasks etc; no production code change)~~

## Test/ Verification

The proposed changes were tested on a Windows environment to ensure that the updated commands function as intended. With the inclusion of the -OutFile flag, the executable files for NocoDB are now correctly downloaded and saved in the working directory, as verified through manual testing.

## Additional information / screenshots (optional)

This update aims to enhance the clarity and usability of the installation instructions for Windows users, aligning with NocoDB's commitment to providing a smooth and user-friendly setup experience.
