### PR TITLE
feat: revise cache

### DIFF
--- a/packages/nocodb/src/cache/CacheMgr.ts
+++ b/packages/nocodb/src/cache/CacheMgr.ts
@@ -8,7 +8,6 @@ export default abstract class CacheMgr {
   ): Promise<any>;
   public abstract incrby(key: string, value: number): Promise<any>;
   public abstract del(key: string): Promise<any>;
-  public abstract getAll(pattern: string): Promise<any[]>;
   public abstract delAll(scope: string, pattern: string): Promise<any[]>;
   public abstract getList(
     scope: string,

--- a/packages/nocodb/src/cache/CacheMgr.ts
+++ b/packages/nocodb/src/cache/CacheMgr.ts
@@ -8,7 +8,6 @@ export default abstract class CacheMgr {
   ): Promise<any>;
   public abstract incrby(key: string, value: number): Promise<any>;
   public abstract del(key: string[] | string): Promise<any>;
-  public abstract delAll(scope: string, pattern: string): Promise<any[]>;
   public abstract getList(
     scope: string,
     list: string[],

--- a/packages/nocodb/src/cache/CacheMgr.ts
+++ b/packages/nocodb/src/cache/CacheMgr.ts
@@ -7,7 +7,7 @@ export default abstract class CacheMgr {
     seconds: number,
   ): Promise<any>;
   public abstract incrby(key: string, value: number): Promise<any>;
-  public abstract del(key: string): Promise<any>;
+  public abstract del(key: string[] | string): Promise<any>;
   public abstract delAll(scope: string, pattern: string): Promise<any[]>;
   public abstract getList(
     scope: string,

--- a/packages/nocodb/src/cache/NocoCache.ts
+++ b/packages/nocodb/src/cache/NocoCache.ts
@@ -57,11 +57,6 @@ export default class NocoCache {
     return this.client.del(`${this.prefix}:${key}`);
   }
 
-  public static async delAll(scope: string, pattern: string): Promise<any[]> {
-    if (this.cacheDisabled) return Promise.resolve([]);
-    return this.client.delAll(scope, pattern);
-  }
-
   public static async getList(
     scope: string,
     subKeys: string[],

--- a/packages/nocodb/src/cache/NocoCache.ts
+++ b/packages/nocodb/src/cache/NocoCache.ts
@@ -98,7 +98,7 @@ export default class NocoCache {
     direction: string,
   ): Promise<boolean> {
     if (this.cacheDisabled) return Promise.resolve(true);
-    return this.client.deepDel(scope, key, direction);
+    return this.client.deepDel(scope, `${this.prefix}:${key}`, direction);
   }
 
   public static async appendToList(

--- a/packages/nocodb/src/cache/NocoCache.ts
+++ b/packages/nocodb/src/cache/NocoCache.ts
@@ -54,6 +54,8 @@ export default class NocoCache {
 
   public static async del(key): Promise<boolean> {
     if (this.cacheDisabled) return Promise.resolve(true);
+    if (Array.isArray(key))
+      return this.client.del(key.map((k) => `${this.prefix}:${k}`));
     return this.client.del(`${this.prefix}:${key}`);
   }
 

--- a/packages/nocodb/src/cache/NocoCache.ts
+++ b/packages/nocodb/src/cache/NocoCache.ts
@@ -52,11 +52,6 @@ export default class NocoCache {
     return this.client.get(`${this.prefix}:${key}`, type);
   }
 
-  public static async getAll(pattern: string): Promise<any[]> {
-    if (this.cacheDisabled) return Promise.resolve([]);
-    return this.client.getAll(`${this.prefix}:${pattern}`);
-  }
-
   public static async del(key): Promise<boolean> {
     if (this.cacheDisabled) return Promise.resolve(true);
     return this.client.del(`${this.prefix}:${key}`);

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -159,17 +159,28 @@ export default class RedisCacheMgr extends CacheMgr {
     log(`RedisCacheMgr::getList: getting list with key ${key}`);
     const isNoneList = arr.length && arr.includes('NONE');
 
-    if (isNoneList) {
+    if (isNoneList || !arr.length) {
       return Promise.resolve({
         list: [],
         isNoneList,
       });
     }
 
+    log(`RedisCacheMgr::getList: getting list with keys ${arr}`);
+    const values = await this.client.mget(arr);
+
     return {
-      list: await Promise.all(
-        arr.map(async (k) => await this.get(k, CacheGetType.TYPE_OBJECT)),
-      ),
+      list: values.map((res) => {
+        try {
+          const o = JSON.parse(res);
+          if (typeof o === 'object') {
+            return o;
+          }
+        } catch (e) {
+          return res;
+        }
+        return res;
+      }),
       isNoneList,
     };
   }

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -44,7 +44,13 @@ export default class RedisCacheMgr extends CacheMgr {
   // @ts-ignore
   async del(key: string[] | string): Promise<any> {
     log(`RedisCacheMgr::del: deleting key ${key}`);
-    return this.client.del(Array.isArray(key) ? key : [key]);
+    if (Array.isArray(key)) {
+      if (key.length) {
+        return this.client.del(key);
+      }
+    } else if (key) {
+      return this.client.del(key);
+    }
   }
 
   // @ts-ignore
@@ -223,7 +229,6 @@ export default class RedisCacheMgr extends CacheMgr {
         if (list.length) {
           // set target list
           log(`RedisCacheMgr::deepDel: set key ${listKey}`);
-          await this.del(listKey);
           await this.set(listKey, list);
         }
       }
@@ -234,7 +239,7 @@ export default class RedisCacheMgr extends CacheMgr {
       // given a list key, delete all the children
       const listOfChildren = await this.get(key, CacheGetType.TYPE_ARRAY);
       // delete each child key
-      await Promise.all(listOfChildren.map(async (k) => await this.del(k)));
+      await this.del(listOfChildren);
       // delete list key
       return await this.del(key);
     } else {

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -1,7 +1,7 @@
 import debug from 'debug';
 import Redis from 'ioredis';
 import CacheMgr from './CacheMgr';
-import { CacheDelDirection, CacheGetType, CacheScope } from '~/utils/globals';
+import { CacheDelDirection, CacheGetType } from '~/utils/globals';
 
 const log = debug('nc:cache');
 
@@ -207,13 +207,6 @@ export default class RedisCacheMgr extends CacheMgr {
         const propValues = props.map((p) => o[p]);
         // e.g. nc:<orgs>:<scope>:<prop_value_1>:<prop_value_2>
         getKey = `${this.prefix}:${scope}:${propValues.join(':')}`;
-      } else {
-        // e.g. nc:<orgs>:<scope>:<model_id_1>
-        getKey = `${this.prefix}:${scope}:${o.id}`;
-        // special case - MODEL_ROLE_VISIBILITY
-        if (scope === CacheScope.MODEL_ROLE_VISIBILITY) {
-          getKey = `${this.prefix}:${scope}:${o.fk_view_id}:${o.role}`;
-        }
       }
       // set Get Key
       log(`RedisCacheMgr::setList: setting key ${getKey}`);

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -127,11 +127,6 @@ export default class RedisCacheMgr extends CacheMgr {
   }
 
   // @ts-ignore
-  async getAll(pattern: string): Promise<any> {
-    return this.client.hgetall(pattern);
-  }
-
-  // @ts-ignore
   async delAll(scope: string, pattern: string): Promise<any[]> {
     // Example: nc:<orgs>:model:*:<id>
     const keys = await this.client.keys(`${this.prefix}:${scope}:${pattern}`);

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -261,6 +261,7 @@ export default class RedisCacheMgr extends CacheMgr {
       log(`RedisCacheMgr::deepDel: remove key ${key}`);
       return await this.del(key);
     } else if (direction === CacheDelDirection.PARENT_TO_CHILD) {
+      key = /:list$/.test(key) ? key : `${key}:list`;
       // given a list key, delete all the children
       const listOfChildren = await this.get(key, CacheGetType.TYPE_ARRAY);
       // delete each child key

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -126,25 +126,6 @@ export default class RedisCacheMgr extends CacheMgr {
     return this.client.incrby(key, value);
   }
 
-  // @ts-ignore
-  async delAll(scope: string, pattern: string): Promise<any[]> {
-    // Example: nc:<orgs>:model:*:<id>
-    const keys = await this.client.keys(`${this.prefix}:${scope}:${pattern}`);
-    log(
-      `RedisCacheMgr::delAll: deleting all keys with pattern ${this.prefix}:${scope}:${pattern}`,
-    );
-    await Promise.all(
-      keys.map(async (k) => {
-        await this.deepDel(scope, k, CacheDelDirection.CHILD_TO_PARENT);
-      }),
-    );
-    return Promise.all(
-      keys.map(async (k) => {
-        await this.del(k);
-      }),
-    );
-  }
-
   async getList(
     scope: string,
     subKeys: string[],

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -42,9 +42,9 @@ export default class RedisCacheMgr extends CacheMgr {
   };
 
   // @ts-ignore
-  async del(key: string): Promise<any> {
+  async del(key: string[] | string): Promise<any> {
     log(`RedisCacheMgr::del: deleting key ${key}`);
-    return this.client.del(key);
+    return this.client.del(Array.isArray(key) ? key : [key]);
   }
 
   // @ts-ignore

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -1,7 +1,11 @@
 import debug from 'debug';
 import Redis from 'ioredis';
 import CacheMgr from './CacheMgr';
-import { CacheDelDirection, CacheGetType } from '~/utils/globals';
+import {
+  CacheDelDirection,
+  CacheGetType,
+  CacheListProp,
+} from '~/utils/globals';
 
 const log = debug('nc:cache');
 
@@ -90,6 +94,10 @@ export default class RedisCacheMgr extends CacheMgr {
       if (typeof value === 'object') {
         if (Array.isArray(value) && value.length) {
           return this.client.sadd(key, value);
+        }
+        const keyValue = await this.get(key, CacheGetType.TYPE_OBJECT);
+        if (keyValue) {
+          value = await this.prepareValue(value, this.getParents(keyValue));
         }
         return this.client.set(
           key,
@@ -195,9 +203,19 @@ export default class RedisCacheMgr extends CacheMgr {
         // e.g. nc:<orgs>:<scope>:<prop_value_1>:<prop_value_2>
         getKey = `${this.prefix}:${scope}:${propValues.join(':')}`;
       }
+      log(`RedisCacheMgr::setList: get key ${getKey}`);
+      // get Get Key
+      let value = await this.get(getKey, CacheGetType.TYPE_OBJECT);
+      if (value) {
+        log(`RedisCacheMgr::setList: preparing key ${getKey}`);
+        // prepare Get Key
+        value = await this.prepareValue(o, this.getParents(value), listKey);
+      } else {
+        value = await this.prepareValue(o, [], listKey);
+      }
       // set Get Key
       log(`RedisCacheMgr::setList: setting key ${getKey}`);
-      await this.set(getKey, JSON.stringify(o, this.getCircularReplacer()));
+      await this.set(getKey, JSON.stringify(value, this.getCircularReplacer()));
       // push Get Key to List
       listOfGetKeys.push(getKey);
     }
@@ -213,8 +231,9 @@ export default class RedisCacheMgr extends CacheMgr {
   ): Promise<boolean> {
     log(`RedisCacheMgr::deepDel: choose direction ${direction}`);
     if (direction === CacheDelDirection.CHILD_TO_PARENT) {
+      const childKey = await this.get(key, CacheGetType.TYPE_OBJECT);
       // given a child key, delete all keys in corresponding parent lists
-      const scopeList = await this.client.keys(`${this.prefix}:${scope}*list`);
+      const scopeList = this.getParents(childKey);
       for (const listKey of scopeList) {
         // get target list
         let list = (await this.get(listKey, CacheGetType.TYPE_ARRAY)) || [];
@@ -271,8 +290,75 @@ export default class RedisCacheMgr extends CacheMgr {
       list = [];
       await this.del(listKey);
     }
+
+    log(`RedisCacheMgr::appendToList: get key ${key}`);
+    // get Get Key
+    const value = await this.get(key, CacheGetType.TYPE_OBJECT);
+    log(`RedisCacheMgr::appendToList: preparing key ${key}`);
+    if (!value) {
+      console.error(`RedisCacheMgr::appendToList: value is empty for ${key}`);
+      await this.del(listKey);
+      return false;
+    }
+    // prepare Get Key
+    const preparedValue = await this.prepareValue(
+      value,
+      this.getParents(value),
+      listKey,
+    );
+    // set Get Key
+    log(`RedisCacheMgr::appendToList: setting key ${key}`);
+    await this.set(
+      key,
+      JSON.stringify(preparedValue, this.getCircularReplacer()),
+    );
+
     list.push(key);
     return this.set(listKey, list);
+  }
+
+  prepareValue(value, listKeys = [], newParent?) {
+    if (newParent) {
+      listKeys.push(newParent);
+    }
+
+    if (value && typeof value === 'object') {
+      value[CacheListProp] = listKeys;
+    } else if (value && typeof value === 'string') {
+      const keyHelper = value.split(CacheListProp);
+      if (listKeys.length) {
+        value = `${keyHelper[0]}${CacheListProp}${listKeys.join(',')}`;
+      }
+    } else if (value) {
+      console.error(
+        `RedisCacheMgr::prepareListKey: keyValue is not object or string`,
+        value,
+      );
+      throw new Error(
+        `RedisCacheMgr::prepareListKey: keyValue is not object or string`,
+      );
+    }
+    return value;
+  }
+
+  getParents(value) {
+    if (value && typeof value === 'object') {
+      if (CacheListProp in value) {
+        const listsForKey = value[CacheListProp];
+        if (listsForKey && listsForKey.length) {
+          return listsForKey;
+        }
+      }
+    } else if (value && typeof value === 'string') {
+      if (value.includes(CacheListProp)) {
+        const keyHelper = value.split(CacheListProp);
+        const listsForKey = keyHelper[1].split(',');
+        if (listsForKey.length) {
+          return listsForKey;
+        }
+      }
+    }
+    return [];
   }
 
   async destroy(): Promise<boolean> {

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -236,7 +236,6 @@ export default class RedisCacheMgr extends CacheMgr {
     key: string,
     direction: string,
   ): Promise<boolean> {
-    key = `${this.prefix}:${key}`;
     log(`RedisCacheMgr::deepDel: choose direction ${direction}`);
     if (direction === CacheDelDirection.CHILD_TO_PARENT) {
       // given a child key, delete all keys in corresponding parent lists

--- a/packages/nocodb/src/cache/RedisCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisCacheMgr.ts
@@ -307,8 +307,23 @@ export default class RedisCacheMgr extends CacheMgr {
     const value = await this.get(key, CacheGetType.TYPE_OBJECT);
     log(`RedisCacheMgr::appendToList: preparing key ${key}`);
     if (!value) {
+      // FALLBACK: this is to get rid of all keys that would be effected by this (should never happen)
       console.error(`RedisCacheMgr::appendToList: value is empty for ${key}`);
-      await this.del(listKey);
+      const allParents = [];
+      // get all children
+      const listValues = await this.getList(scope, subListKeys);
+      // get all parents from children
+      listValues.list.forEach((v) => {
+        allParents.push(...this.getParents(v));
+      });
+      // remove duplicates
+      const uniqueParents = [...new Set(allParents)];
+      // delete all parents and children
+      await Promise.all(
+        uniqueParents.map(async (p) => {
+          await this.deepDel(scope, p, CacheDelDirection.PARENT_TO_CHILD);
+        }),
+      );
       return false;
     }
     // prepare Get Key

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -2,7 +2,7 @@ import debug from 'debug';
 import Redis from 'ioredis-mock';
 import CacheMgr from './CacheMgr';
 import type IORedis from 'ioredis';
-import { CacheDelDirection, CacheGetType, CacheScope } from '~/utils/globals';
+import { CacheDelDirection, CacheGetType } from '~/utils/globals';
 const log = debug('nc:cache');
 
 export default class RedisMockCacheMgr extends CacheMgr {
@@ -205,13 +205,6 @@ export default class RedisMockCacheMgr extends CacheMgr {
         const propValues = props.map((p) => o[p]);
         // e.g. nc:<orgs>:<scope>:<prop_value_1>:<prop_value_2>
         getKey = `${this.prefix}:${scope}:${propValues.join(':')}`;
-      } else {
-        // e.g. nc:<orgs>:<scope>:<model_id_1>
-        getKey = `${this.prefix}:${scope}:${o.id}`;
-        // special case - MODEL_ROLE_VISIBILITY
-        if (scope === CacheScope.MODEL_ROLE_VISIBILITY) {
-          getKey = `${this.prefix}:${scope}:${o.fk_view_id}:${o.role}`;
-        }
       }
       // set Get Key
       log(`RedisMockCacheMgr::setList: setting key ${getKey}`);

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -234,7 +234,6 @@ export default class RedisMockCacheMgr extends CacheMgr {
     key: string,
     direction: string,
   ): Promise<boolean> {
-    key = `${this.prefix}:${key}`;
     log(`RedisMockCacheMgr::deepDel: choose direction ${direction}`);
     if (direction === CacheDelDirection.CHILD_TO_PARENT) {
       // given a child key, delete all keys in corresponding parent lists

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -124,11 +124,6 @@ export default class RedisMockCacheMgr extends CacheMgr {
   }
 
   // @ts-ignore
-  async getAll(pattern: string): Promise<any> {
-    return this.client.hgetall(pattern);
-  }
-
-  // @ts-ignore
   async delAll(scope: string, pattern: string): Promise<any[]> {
     // Example: nc:<orgs>:model:*:<id>
     const keys = await this.client.keys(`${this.prefix}:${scope}:${pattern}`);

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -35,9 +35,9 @@ export default class RedisMockCacheMgr extends CacheMgr {
   };
 
   // @ts-ignore
-  async del(key: string): Promise<any> {
+  async del(key: string[] | string): Promise<any> {
     log(`RedisMockCacheMgr::del: deleting key ${key}`);
-    return this.client.del(key);
+    return this.client.del(Array.isArray(key) ? key : [key]);
   }
 
   // @ts-ignore

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -37,7 +37,13 @@ export default class RedisMockCacheMgr extends CacheMgr {
   // @ts-ignore
   async del(key: string[] | string): Promise<any> {
     log(`RedisMockCacheMgr::del: deleting key ${key}`);
-    return this.client.del(Array.isArray(key) ? key : [key]);
+    if (Array.isArray(key)) {
+      if (key.length) {
+        return this.client.del(key);
+      }
+    } else if (key) {
+      return this.client.del(key);
+    }
   }
 
   // @ts-ignore
@@ -220,7 +226,6 @@ export default class RedisMockCacheMgr extends CacheMgr {
         if (list.length) {
           // set target list
           log(`RedisMockCacheMgr::deepDel: set key ${listKey}`);
-          await this.del(listKey);
           await this.set(listKey, list);
         }
       }
@@ -231,7 +236,7 @@ export default class RedisMockCacheMgr extends CacheMgr {
       // given a list key, delete all the children
       const listOfChildren = await this.get(key, CacheGetType.TYPE_ARRAY);
       // delete each child key
-      await Promise.all(listOfChildren.map(async (k) => await this.del(k)));
+      await this.del(listOfChildren);
       // delete list key
       return await this.del(key);
     } else {

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -123,26 +123,6 @@ export default class RedisMockCacheMgr extends CacheMgr {
     return this.client.incrby(key, value);
   }
 
-  // @ts-ignore
-  async delAll(scope: string, pattern: string): Promise<any[]> {
-    // Example: nc:<orgs>:model:*:<id>
-    const keys = await this.client.keys(`${this.prefix}:${scope}:${pattern}`);
-    log(
-      `RedisMockCacheMgr::delAll: deleting all keys with pattern ${this.prefix}:${scope}:${pattern}`,
-    );
-    await Promise.all(
-      keys.map(
-        async (k) =>
-          await this.deepDel(scope, k, CacheDelDirection.CHILD_TO_PARENT),
-      ),
-    );
-    return Promise.all(
-      keys.map(async (k) => {
-        await this.del(k);
-      }),
-    );
-  }
-
   async getList(
     scope: string,
     subKeys: string[],

--- a/packages/nocodb/src/cache/RedisMockCacheMgr.ts
+++ b/packages/nocodb/src/cache/RedisMockCacheMgr.ts
@@ -259,6 +259,7 @@ export default class RedisMockCacheMgr extends CacheMgr {
       log(`RedisMockCacheMgr::deepDel: remove key ${key}`);
       return await this.del(key);
     } else if (direction === CacheDelDirection.PARENT_TO_CHILD) {
+      key = /:list$/.test(key) ? key : `${key}:list`;
       // given a list key, delete all the children
       const listOfChildren = await this.get(key, CacheGetType.TYPE_ARRAY);
       // delete each child key

--- a/packages/nocodb/src/models/ApiToken.ts
+++ b/packages/nocodb/src/models/ApiToken.ts
@@ -33,12 +33,14 @@ export default class ApiToken implements ApiTokenType {
       token,
       fk_user_id: apiToken.fk_user_id,
     });
-    await NocoCache.appendToList(
-      CacheScope.API_TOKEN,
-      [],
-      `${CacheScope.API_TOKEN}:${token}`,
-    );
-    return this.getByToken(token);
+    return this.getByToken(token).then(async (apiToken) => {
+      await NocoCache.appendToList(
+        CacheScope.API_TOKEN,
+        [],
+        `${CacheScope.API_TOKEN}:${token}`,
+      );
+      return apiToken;
+    });
   }
 
   static async list(userId: string, ncMeta = Noco.ncMeta) {

--- a/packages/nocodb/src/models/Base.ts
+++ b/packages/nocodb/src/models/Base.ts
@@ -63,12 +63,6 @@ export default class Base implements BaseType {
       insertObj,
     );
 
-    await NocoCache.appendToList(
-      CacheScope.PROJECT,
-      [],
-      `${CacheScope.PROJECT}:${baseId}`,
-    );
-
     for (const source of base.sources) {
       await Source.createBase(
         {
@@ -81,7 +75,14 @@ export default class Base implements BaseType {
     }
 
     await NocoCache.del(CacheScope.INSTANCE_META);
-    return this.getWithInfo(baseId, ncMeta);
+    return this.getWithInfo(baseId, ncMeta).then(async (base) => {
+      await NocoCache.appendToList(
+        CacheScope.PROJECT,
+        [],
+        `${CacheScope.PROJECT}:${baseId}`,
+      );
+      return base;
+    });
   }
 
   static async list(

--- a/packages/nocodb/src/models/Base.ts
+++ b/packages/nocodb/src/models/Base.ts
@@ -175,7 +175,10 @@ export default class Base implements BaseType {
         await NocoCache.set(`${CacheScope.PROJECT}:${baseId}`, baseData);
       }
       if (baseData?.uuid) {
-        await NocoCache.set(`${CacheScope.PROJECT}:${baseData.uuid}`, baseId);
+        await NocoCache.set(
+          `${CacheScope.PROJECT_ALIAS}:${baseData.uuid}`,
+          baseId,
+        );
       }
     } else {
       if (baseData?.deleted) {
@@ -200,16 +203,15 @@ export default class Base implements BaseType {
     const key = `${CacheScope.PROJECT}:${baseId}`;
     const o = await NocoCache.get(key, CacheGetType.TYPE_OBJECT);
     if (o) {
-      // delete <scope>:<id>
-      await NocoCache.del(`${CacheScope.PROJECT}:${baseId}`);
-      await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${baseId}`);
       // delete <scope>:<title>
-      await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${o.title}`);
       // delete <scope>:<uuid>
-      await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${o.uuid}`);
       // delete <scope>:ref:<titleOfId>
-      await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:ref:${o.title}`);
-      await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:ref:${o.id}`);
+      await NocoCache.del([
+        `${CacheScope.PROJECT_ALIAS}:${o.title}`,
+        `${CacheScope.PROJECT_ALIAS}:${o.uuid}`,
+        `${CacheScope.PROJECT_ALIAS}:ref:${o.title}`,
+        `${CacheScope.PROJECT_ALIAS}:ref:${o.id}`,
+      ]);
     }
 
     await NocoCache.del(CacheScope.INSTANCE_META);
@@ -258,16 +260,22 @@ export default class Base implements BaseType {
       // update data
       // new uuid is generated
       if (o.uuid && updateObj.uuid && o.uuid !== updateObj.uuid) {
-        await NocoCache.del(`${CacheScope.PROJECT}:${o.uuid}`);
-        await NocoCache.set(`${CacheScope.PROJECT}:${updateObj.uuid}`, baseId);
+        await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${o.uuid}`);
+        await NocoCache.set(
+          `${CacheScope.PROJECT_ALIAS}:${updateObj.uuid}`,
+          baseId,
+        );
       }
       // disable shared base
       if (o.uuid && updateObj.uuid === null) {
-        await NocoCache.del(`${CacheScope.PROJECT}:${o.uuid}`);
+        await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${o.uuid}`);
       }
       if (o.title && updateObj.title && o.title !== updateObj.title) {
-        await NocoCache.del(`${CacheScope.PROJECT}:${o.title}`);
-        await NocoCache.set(`${CacheScope.PROJECT}:${updateObj.title}`, baseId);
+        await NocoCache.del(`${CacheScope.PROJECT_ALIAS}:${o.title}`);
+        await NocoCache.set(
+          `${CacheScope.PROJECT_ALIAS}:${updateObj.title}`,
+          baseId,
+        );
       }
       o = { ...o, ...updateObj };
 
@@ -311,12 +319,14 @@ export default class Base implements BaseType {
 
     if (base) {
       // delete <scope>:<uuid>
-      await NocoCache.del(`${CacheScope.PROJECT}:${base.uuid}`);
       // delete <scope>:<title>
-      await NocoCache.del(`${CacheScope.PROJECT}:${base.title}`);
       // delete <scope>:ref:<titleOfId>
-      await NocoCache.del(`${CacheScope.PROJECT}:ref:${base.title}`);
-      await NocoCache.del(`${CacheScope.PROJECT}:ref:${base.id}`);
+      await NocoCache.del([
+        `${CacheScope.PROJECT_ALIAS}:${base.uuid}`,
+        `${CacheScope.PROJECT_ALIAS}:${base.title}`,
+        `${CacheScope.PROJECT_ALIAS}:ref:${base.title}`,
+        `${CacheScope.PROJECT_ALIAS}:ref:${base.id}`,
+      ]);
     }
 
     await NocoCache.deepDel(

--- a/packages/nocodb/src/models/Column.ts
+++ b/packages/nocodb/src/models/Column.ts
@@ -499,10 +499,6 @@ export default class Column<T = any> implements ColumnType {
     );
   }
 
-  public static async clear({ id }) {
-    await NocoCache.delAll(CacheScope.COLUMN, `*${id}*`);
-  }
-
   public static async list(
     {
       fk_model_id,

--- a/packages/nocodb/src/models/Column.ts
+++ b/packages/nocodb/src/models/Column.ts
@@ -854,7 +854,6 @@ export default class Column<T = any> implements ColumnType {
         `${CacheScope.GRID_VIEW_COLUMN}:${gridViewColumnId}`,
         CacheDelDirection.CHILD_TO_PARENT,
       );
-      await NocoCache.del(`${CacheScope.GRID_VIEW_COLUMN}:${col.id}`);
     }
 
     // Form View Columns
@@ -871,7 +870,6 @@ export default class Column<T = any> implements ColumnType {
         `${CacheScope.FORM_VIEW_COLUMN}:${formViewColumnId}`,
         CacheDelDirection.CHILD_TO_PARENT,
       );
-      await NocoCache.del(`${CacheScope.FORM_VIEW_COLUMN}:${col.id}`);
     }
 
     // Kanban View Columns
@@ -888,7 +886,6 @@ export default class Column<T = any> implements ColumnType {
         `${CacheScope.KANBAN_VIEW_COLUMN}:${kanbanViewColumnId}`,
         CacheDelDirection.CHILD_TO_PARENT,
       );
-      await NocoCache.del(`${CacheScope.KANBAN_VIEW_COLUMN}:${col.id}`);
     }
 
     // Gallery View Column
@@ -905,7 +902,6 @@ export default class Column<T = any> implements ColumnType {
         `${CacheScope.GALLERY_VIEW_COLUMN}:${galleryViewColumnId}`,
         CacheDelDirection.CHILD_TO_PARENT,
       );
-      await NocoCache.del(`${CacheScope.GALLERY_VIEW_COLUMN}:${col.id}`);
     }
 
     // Get LTAR columns in which current column is referenced as foreign key

--- a/packages/nocodb/src/models/FormViewColumn.ts
+++ b/packages/nocodb/src/models/FormViewColumn.ts
@@ -99,18 +99,14 @@ export default class FormViewColumn implements FormColumnType {
 
     await NocoCache.set(`${CacheScope.FORM_VIEW_COLUMN}:${fk_column_id}`, id);
 
-    // if cache is not present skip pushing it into the list to avoid unexpected behaviour
-    const { list } = await NocoCache.getList(CacheScope.FORM_VIEW_COLUMN, [
-      column.fk_view_id,
-    ]);
-
-    if (list?.length)
+    return this.get(id, ncMeta).then(async (viewColumn) => {
       await NocoCache.appendToList(
         CacheScope.FORM_VIEW_COLUMN,
         [column.fk_view_id],
         `${CacheScope.FORM_VIEW_COLUMN}:${id}`,
       );
-    return this.get(id, ncMeta);
+      return viewColumn;
+    });
   }
 
   public static async list(

--- a/packages/nocodb/src/models/GalleryViewColumn.ts
+++ b/packages/nocodb/src/models/GalleryViewColumn.ts
@@ -78,25 +78,20 @@ export default class GalleryViewColumn {
       id,
     );
 
-    // if cache is not present skip pushing it into the list to avoid unexpected behaviour
-    const { list } = await NocoCache.getList(CacheScope.GALLERY_VIEW_COLUMN, [
-      column.fk_view_id,
-    ]);
-
-    if (list?.length)
-      await NocoCache.appendToList(
-        CacheScope.GALLERY_VIEW_COLUMN,
-        [column.fk_view_id],
-        `${CacheScope.GALLERY_VIEW_COLUMN}:${id}`,
-      );
-
     // on new view column, delete any optimised single query cache
     {
       const view = await View.get(column.fk_view_id, ncMeta);
       await View.clearSingleQueryCache(view.fk_model_id, [view]);
     }
 
-    return this.get(id, ncMeta);
+    return this.get(id, ncMeta).then(async (viewColumn) => {
+      await NocoCache.appendToList(
+        CacheScope.GALLERY_VIEW_COLUMN,
+        [column.fk_view_id],
+        `${CacheScope.GALLERY_VIEW_COLUMN}:${id}`,
+      );
+      return viewColumn;
+    });
   }
 
   public static async list(

--- a/packages/nocodb/src/models/Hook.ts
+++ b/packages/nocodb/src/models/Hook.ts
@@ -161,13 +161,14 @@ export default class Hook implements HookType {
       insertObj,
     );
 
-    await NocoCache.appendToList(
-      CacheScope.HOOK,
-      [hook.fk_model_id],
-      `${CacheScope.HOOK}:${id}`,
-    );
-
-    return this.get(id, ncMeta);
+    return this.get(id, ncMeta).then(async (hook) => {
+      await NocoCache.appendToList(
+        CacheScope.HOOK,
+        [hook.fk_model_id],
+        `${CacheScope.HOOK}:${id}`,
+      );
+      return hook;
+    });
   }
 
   public static async update(

--- a/packages/nocodb/src/models/HookFilter.ts
+++ b/packages/nocodb/src/models/HookFilter.ts
@@ -100,40 +100,45 @@ export default class Filter {
     if (!value) {
       /* get from db */
       value = await ncMeta.metaGet2(null, null, MetaTable.FILTER_EXP, id);
-      // pushing calls for Promise.all
-      const p = [];
+
       /* store in redis */
-      p.push(NocoCache.set(key, value));
-      /* append key to relevant lists */
-      p.push(
-        NocoCache.appendToList(CacheScope.FILTER_EXP, [filter.fk_view_id], key),
-      );
-      if (filter.fk_parent_id) {
+      await NocoCache.set(key, value).then(async () => {
+        /* append key to relevant lists */
+        const p = [];
         p.push(
           NocoCache.appendToList(
             CacheScope.FILTER_EXP,
-            [filter.fk_view_id, filter.fk_parent_id],
+            [filter.fk_view_id],
             key,
           ),
         );
-        p.push(
-          NocoCache.appendToList(
-            CacheScope.FILTER_EXP,
-            [filter.fk_parent_id],
-            key,
-          ),
-        );
-      }
-      if (filter.fk_column_id) {
-        p.push(
-          NocoCache.appendToList(
-            CacheScope.FILTER_EXP,
-            [filter.fk_column_id],
-            key,
-          ),
-        );
-      }
-      await Promise.all(p);
+        if (filter.fk_parent_id) {
+          p.push(
+            NocoCache.appendToList(
+              CacheScope.FILTER_EXP,
+              [filter.fk_view_id, filter.fk_parent_id],
+              key,
+            ),
+          );
+          p.push(
+            NocoCache.appendToList(
+              CacheScope.FILTER_EXP,
+              [filter.fk_parent_id],
+              key,
+            ),
+          );
+        }
+        if (filter.fk_column_id) {
+          p.push(
+            NocoCache.appendToList(
+              CacheScope.FILTER_EXP,
+              [filter.fk_column_id],
+              key,
+            ),
+          );
+        }
+        await Promise.all(p);
+      });
     }
     return new Filter(value);
   }

--- a/packages/nocodb/src/models/KanbanViewColumn.ts
+++ b/packages/nocodb/src/models/KanbanViewColumn.ts
@@ -72,13 +72,14 @@ export default class KanbanViewColumn implements KanbanColumnType {
 
     await NocoCache.set(`${CacheScope.KANBAN_VIEW_COLUMN}:${fk_column_id}`, id);
 
-    await NocoCache.appendToList(
-      CacheScope.KANBAN_VIEW_COLUMN,
-      [column.fk_view_id],
-      `${CacheScope.KANBAN_VIEW_COLUMN}:${id}`,
-    );
-
-    return this.get(id, ncMeta);
+    return this.get(id, ncMeta).then(async (kanbanViewColumn) => {
+      await NocoCache.appendToList(
+        CacheScope.KANBAN_VIEW_COLUMN,
+        [column.fk_view_id],
+        `${CacheScope.KANBAN_VIEW_COLUMN}:${id}`,
+      );
+      return kanbanViewColumn;
+    });
   }
 
   public static async list(

--- a/packages/nocodb/src/models/LookupColumn.ts
+++ b/packages/nocodb/src/models/LookupColumn.ts
@@ -38,19 +38,21 @@ export default class LookupColumn implements LookupType {
 
     await ncMeta.metaInsert2(null, null, MetaTable.COL_LOOKUP, insertObj);
 
-    await NocoCache.appendToList(
-      CacheScope.COL_LOOKUP,
-      [data.fk_lookup_column_id],
-      `${CacheScope.COL_LOOKUP}:${data.fk_column_id}`,
-    );
+    return this.read(data.fk_column_id, ncMeta).then(async (lookupColumn) => {
+      await NocoCache.appendToList(
+        CacheScope.COL_LOOKUP,
+        [data.fk_lookup_column_id],
+        `${CacheScope.COL_LOOKUP}:${data.fk_column_id}`,
+      );
 
-    await NocoCache.appendToList(
-      CacheScope.COL_LOOKUP,
-      [data.fk_relation_column_id],
-      `${CacheScope.COL_LOOKUP}:${data.fk_column_id}`,
-    );
+      await NocoCache.appendToList(
+        CacheScope.COL_LOOKUP,
+        [data.fk_relation_column_id],
+        `${CacheScope.COL_LOOKUP}:${data.fk_column_id}`,
+      );
 
-    return this.read(data.fk_column_id, ncMeta);
+      return lookupColumn;
+    });
   }
 
   public static async read(columnId: string, ncMeta = Noco.ncMeta) {

--- a/packages/nocodb/src/models/MapViewColumn.ts
+++ b/packages/nocodb/src/models/MapViewColumn.ts
@@ -66,18 +66,14 @@ export default class MapViewColumn {
 
     await NocoCache.set(`${CacheScope.MAP_VIEW_COLUMN}:${fk_column_id}`, id);
 
-    // if cache is not present skip pushing it into the list to avoid unexpected behaviour
-    const { list } = await NocoCache.getList(CacheScope.MAP_VIEW_COLUMN, [
-      column.fk_view_id,
-    ]);
-    if (list?.length)
+    return this.get(id, ncMeta).then(async (viewCol) => {
       await NocoCache.appendToList(
         CacheScope.MAP_VIEW_COLUMN,
         [column.fk_view_id],
         `${CacheScope.MAP_VIEW_COLUMN}:${id}`,
       );
-
-    return this.get(id, ncMeta);
+      return viewCol;
+    });
   }
 
   public static async list(

--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -146,20 +146,6 @@ export default class Model implements TableType {
       MetaTable.MODELS,
       insertObj,
     );
-    if (sourceId) {
-      await NocoCache.appendToList(
-        CacheScope.MODEL,
-        [baseId, sourceId],
-        `${CacheScope.MODEL}:${id}`,
-      );
-    }
-    // cater cases where sourceId is not required
-    // e.g. xcVisibilityMetaGet
-    await NocoCache.appendToList(
-      CacheScope.MODEL,
-      [baseId],
-      `${CacheScope.MODEL}:${id}`,
-    );
 
     const view = await View.insert(
       {
@@ -175,7 +161,23 @@ export default class Model implements TableType {
       await Column.insert({ ...column, fk_model_id: id, view } as any, ncMeta);
     }
 
-    return this.getWithInfo({ id }, ncMeta);
+    return this.getWithInfo({ id }, ncMeta).then(async (model) => {
+      if (sourceId) {
+        await NocoCache.appendToList(
+          CacheScope.MODEL,
+          [baseId, sourceId],
+          `${CacheScope.MODEL}:${id}`,
+        );
+      }
+      // cater cases where sourceId is not required
+      // e.g. xcVisibilityMetaGet
+      await NocoCache.appendToList(
+        CacheScope.MODEL,
+        [baseId],
+        `${CacheScope.MODEL}:${id}`,
+      );
+      return model;
+    });
   }
 
   public static async list(

--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -275,11 +275,6 @@ export default class Model implements TableType {
     return modelList.map((m) => new Model(m));
   }
 
-  public static async clear({ id }: { id: string }): Promise<void> {
-    await NocoCache.delAll(CacheScope.MODEL, `*${id}*`);
-    await Column.clearList({ fk_model_id: id });
-  }
-
   public static async get(id: string, ncMeta = Noco.ncMeta): Promise<Model> {
     let modelData =
       id &&

--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -213,6 +213,8 @@ export default class Model implements TableType {
         [base_id, source_id],
         modelList,
       );
+
+      await NocoCache.setList(CacheScope.MODEL, [base_id], modelList);
     }
     modelList.sort(
       (a, b) =>
@@ -496,8 +498,13 @@ export default class Model implements TableType {
     );
     await ncMeta.metaDelete(null, null, MetaTable.MODELS, this.id);
 
-    await NocoCache.del(`${CacheScope.MODEL}:${this.base_id}:${this.id}`);
-    await NocoCache.del(`${CacheScope.MODEL}:${this.base_id}:${this.title}`);
+    // delete alias cache
+    await NocoCache.del([
+      `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.id}`,
+      `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.source_id}:${this.id}`,
+      `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.title}`,
+      `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.source_id}:${this.title}`,
+    ]);
     return true;
   }
 
@@ -635,12 +642,12 @@ export default class Model implements TableType {
     }
 
     // delete alias cache
-    await NocoCache.del(
-      `${CacheScope.MODEL}:${oldModel.base_id}:${oldModel.source_id}:${oldModel.title}`,
-    );
-    await NocoCache.del(
-      `${CacheScope.MODEL}:${oldModel.base_id}:${oldModel.title}`,
-    );
+    await NocoCache.del([
+      `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.id}`,
+      `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.source_id}:${oldModel.id}`,
+      `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.title}`,
+      `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.source_id}:${oldModel.title}`,
+    ]);
 
     // set meta
     const res = await ncMeta.metaUpdate(

--- a/packages/nocodb/src/models/ModelRoleVisibility.ts
+++ b/packages/nocodb/src/models/ModelRoleVisibility.ts
@@ -36,7 +36,12 @@ export default class ModelRoleVisibility implements ModelRoleVisibilityType {
         null,
         MetaTable.MODEL_ROLE_VISIBILITY,
       );
-      await NocoCache.setList(CacheScope.MODEL_ROLE_VISIBILITY, [baseId], data);
+      await NocoCache.setList(
+        CacheScope.MODEL_ROLE_VISIBILITY,
+        [baseId],
+        data,
+        ['fk_view_id', 'role'],
+      );
     }
     return data?.map((baseData) => new ModelRoleVisibility(baseData));
   }

--- a/packages/nocodb/src/models/ModelRoleVisibility.ts
+++ b/packages/nocodb/src/models/ModelRoleVisibility.ts
@@ -114,12 +114,7 @@ export default class ModelRoleVisibility implements ModelRoleVisibilityType {
     return await ModelRoleVisibility.delete(this.fk_view_id, this.role);
   }
   static async delete(fk_view_id: string, role: string) {
-    await NocoCache.deepDel(
-      CacheScope.MODEL_ROLE_VISIBILITY,
-      `${CacheScope.MODEL_ROLE_VISIBILITY}:${fk_view_id}:${role}`,
-      CacheDelDirection.CHILD_TO_PARENT,
-    );
-    return await Noco.ncMeta.metaDelete(
+    const res = await Noco.ncMeta.metaDelete(
       null,
       null,
       MetaTable.MODEL_ROLE_VISIBILITY,
@@ -128,6 +123,12 @@ export default class ModelRoleVisibility implements ModelRoleVisibilityType {
         role,
       },
     );
+    await NocoCache.deepDel(
+      CacheScope.MODEL_ROLE_VISIBILITY,
+      `${CacheScope.MODEL_ROLE_VISIBILITY}:${fk_view_id}:${role}`,
+      CacheDelDirection.CHILD_TO_PARENT,
+    );
+    return res;
   }
 
   static async insert(

--- a/packages/nocodb/src/models/ModelRoleVisibility.ts
+++ b/packages/nocodb/src/models/ModelRoleVisibility.ts
@@ -155,15 +155,7 @@ export default class ModelRoleVisibility implements ModelRoleVisibilityType {
       insertObj,
     );
 
-    const key = `${CacheScope.MODEL_ROLE_VISIBILITY}:${body.fk_view_id}:${body.role}`;
-
     insertObj.id = result.id;
-
-    await NocoCache.appendToList(
-      CacheScope.MODEL_ROLE_VISIBILITY,
-      [insertObj.base_id],
-      key,
-    );
 
     return this.get(
       {
@@ -171,6 +163,14 @@ export default class ModelRoleVisibility implements ModelRoleVisibilityType {
         role: body.role,
       },
       ncMeta,
-    );
+    ).then(async (modelRoleVisibility) => {
+      const key = `${CacheScope.MODEL_ROLE_VISIBILITY}:${body.fk_view_id}:${body.role}`;
+      await NocoCache.appendToList(
+        CacheScope.MODEL_ROLE_VISIBILITY,
+        [insertObj.base_id],
+        key,
+      );
+      return modelRoleVisibility;
+    });
   }
 }

--- a/packages/nocodb/src/models/RollupColumn.ts
+++ b/packages/nocodb/src/models/RollupColumn.ts
@@ -38,19 +38,21 @@ export default class RollupColumn implements RollupType {
     ]);
     await ncMeta.metaInsert2(null, null, MetaTable.COL_ROLLUP, insertObj);
 
-    await NocoCache.appendToList(
-      CacheScope.COL_ROLLUP,
-      [data.fk_rollup_column_id],
-      `${CacheScope.COL_ROLLUP}:${data.fk_column_id}`,
-    );
+    return this.read(data.fk_column_id, ncMeta).then(async (rollupColumn) => {
+      await NocoCache.appendToList(
+        CacheScope.COL_ROLLUP,
+        [data.fk_rollup_column_id],
+        `${CacheScope.COL_ROLLUP}:${data.fk_column_id}`,
+      );
 
-    await NocoCache.appendToList(
-      CacheScope.COL_ROLLUP,
-      [data.fk_relation_column_id],
-      `${CacheScope.COL_ROLLUP}:${data.fk_column_id}`,
-    );
+      await NocoCache.appendToList(
+        CacheScope.COL_ROLLUP,
+        [data.fk_relation_column_id],
+        `${CacheScope.COL_ROLLUP}:${data.fk_column_id}`,
+      );
 
-    return this.read(data.fk_column_id, ncMeta);
+      return rollupColumn;
+    });
   }
 
   public static async read(columnId: string, ncMeta = Noco.ncMeta) {

--- a/packages/nocodb/src/models/SelectOption.ts
+++ b/packages/nocodb/src/models/SelectOption.ts
@@ -34,13 +34,14 @@ export default class SelectOption implements SelectOptionType {
       insertObj,
     );
 
-    await NocoCache.appendToList(
-      CacheScope.COL_SELECT_OPTION,
-      [data.fk_column_id],
-      `${CacheScope.COL_SELECT_OPTION}:${id}`,
-    );
-
-    return this.get(id, ncMeta);
+    return this.get(id, ncMeta).then(async (selectOption) => {
+      await NocoCache.appendToList(
+        CacheScope.COL_SELECT_OPTION,
+        [data.fk_column_id],
+        `${CacheScope.COL_SELECT_OPTION}:${id}`,
+      );
+      return selectOption;
+    });
   }
 
   public static async bulkInsert(
@@ -68,12 +69,12 @@ export default class SelectOption implements SelectOptionType {
     );
 
     for (const d of bulkData) {
+      await NocoCache.set(`${CacheScope.COL_SELECT_OPTION}:${d.id}`, d);
       await NocoCache.appendToList(
         CacheScope.COL_SELECT_OPTION,
         [d.fk_column_id],
         `${CacheScope.COL_SELECT_OPTION}:${d.id}`,
       );
-      await NocoCache.set(`${CacheScope.COL_SELECT_OPTION}:${d.id}`, d);
     }
 
     return true;

--- a/packages/nocodb/src/models/Sort.ts
+++ b/packages/nocodb/src/models/Sort.ts
@@ -91,7 +91,6 @@ export default class Sort {
           order: 'asc',
         },
       });
-      await NocoCache.delAll(CacheScope.SORT, `${sortObj.fk_view_id}:*`);
       await NocoCache.setList(CacheScope.SORT, [sortObj.fk_view_id], sortList);
     } else {
       await NocoCache.appendToList(

--- a/packages/nocodb/src/models/Sort.ts
+++ b/packages/nocodb/src/models/Sort.ts
@@ -92,27 +92,28 @@ export default class Sort {
         },
       });
       await NocoCache.setList(CacheScope.SORT, [sortObj.fk_view_id], sortList);
-    } else {
-      await NocoCache.appendToList(
-        CacheScope.SORT,
-        [sortObj.fk_view_id],
-        `${CacheScope.SORT}:${row.id}`,
-      );
-
-      await NocoCache.appendToList(
-        CacheScope.SORT,
-        [sortObj.fk_column_id],
-        `${CacheScope.SORT}:${row.id}`,
-      );
     }
-
     // on insert, delete any optimised single query cache
     {
       const view = await View.get(row.fk_view_id, ncMeta);
       await View.clearSingleQueryCache(view.fk_model_id, [view]);
     }
 
-    return this.get(row.id, ncMeta);
+    return this.get(row.id, ncMeta).then(async (sort) => {
+      if (!sortObj.push_to_top) {
+        await NocoCache.appendToList(
+          CacheScope.SORT,
+          [sortObj.fk_view_id],
+          `${CacheScope.SORT}:${row.id}`,
+        );
+        await NocoCache.appendToList(
+          CacheScope.SORT,
+          [sortObj.fk_column_id],
+          `${CacheScope.SORT}:${row.id}`,
+        );
+      }
+      return sort;
+    });
   }
 
   public getColumn(): Promise<Column> {

--- a/packages/nocodb/src/models/Sort.ts
+++ b/packages/nocodb/src/models/Sort.ts
@@ -183,12 +183,14 @@ export default class Sort {
 
   public static async delete(sortId: string, ncMeta = Noco.ncMeta) {
     const sort = await this.get(sortId, ncMeta);
+
+    await ncMeta.metaDelete(null, null, MetaTable.SORT, sortId);
+
     await NocoCache.deepDel(
       CacheScope.SORT,
       `${CacheScope.SORT}:${sortId}`,
       CacheDelDirection.CHILD_TO_PARENT,
     );
-    await ncMeta.metaDelete(null, null, MetaTable.SORT, sortId);
 
     // on delete, delete any optimised single query cache
     if (sort?.fk_view_id) {

--- a/packages/nocodb/src/models/Source.ts
+++ b/packages/nocodb/src/models/Source.ts
@@ -423,11 +423,6 @@ export default class Source implements SourceType {
     for (const model of models) {
       await model.delete(ncMeta, true);
     }
-    await NocoCache.deepDel(
-      CacheScope.BASE,
-      `${CacheScope.BASE}:${this.id}`,
-      CacheDelDirection.CHILD_TO_PARENT,
-    );
 
     const syncSources = await SyncSource.list(this.base_id, this.id, ncMeta);
     for (const syncSource of syncSources) {
@@ -436,7 +431,15 @@ export default class Source implements SourceType {
 
     await NcConnectionMgrv2.deleteAwait(this);
 
-    return await ncMeta.metaDelete(null, null, MetaTable.BASES, this.id);
+    const res = await ncMeta.metaDelete(null, null, MetaTable.BASES, this.id);
+
+    await NocoCache.deepDel(
+      CacheScope.BASE,
+      `${CacheScope.BASE}:${this.id}`,
+      CacheDelDirection.CHILD_TO_PARENT,
+    );
+
+    return res;
   }
 
   async softDelete(ncMeta = Noco.ncMeta, { force }: { force?: boolean } = {}) {
@@ -461,8 +464,6 @@ export default class Source implements SourceType {
       `${CacheScope.BASE}:${this.id}`,
       CacheDelDirection.CHILD_TO_PARENT,
     );
-
-    await NocoCache.del(`${CacheScope.BASE}:${this.id}`);
   }
 
   async getModels(ncMeta = Noco.ncMeta) {

--- a/packages/nocodb/src/models/User.ts
+++ b/packages/nocodb/src/models/User.ts
@@ -147,10 +147,7 @@ export default class User implements UserType {
   }
 
   static async isFirst(ncMeta = Noco.ncMeta) {
-    const isFirst = !(await NocoCache.getAll(`${CacheScope.USER}:*`))?.length;
-    if (isFirst)
-      return !(await ncMeta.metaGet2(null, null, MetaTable.USERS, {}));
-    return false;
+    return !(await ncMeta.metaGet2(null, null, MetaTable.USERS, {}));
   }
 
   public static async count(

--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -1106,27 +1106,29 @@ export default class View implements ViewType {
     await ncMeta.metaDelete(null, null, columnTable, {
       fk_view_id: viewId,
     });
+    await ncMeta.metaDelete(null, null, table, {
+      fk_view_id: viewId,
+    });
+    await ncMeta.metaDelete(null, null, MetaTable.VIEWS, viewId);
     await NocoCache.deepDel(
       tableScope,
       `${tableScope}:${viewId}`,
       CacheDelDirection.CHILD_TO_PARENT,
     );
-    await ncMeta.metaDelete(null, null, table, {
-      fk_view_id: viewId,
-    });
     await NocoCache.deepDel(
       columnTableScope,
       `${columnTableScope}:${viewId}`,
       CacheDelDirection.CHILD_TO_PARENT,
     );
-    await ncMeta.metaDelete(null, null, MetaTable.VIEWS, viewId);
     await NocoCache.deepDel(
       CacheScope.VIEW,
       `${CacheScope.VIEW}:${viewId}`,
       CacheDelDirection.CHILD_TO_PARENT,
     );
-    await NocoCache.del(`${CacheScope.VIEW}:${view.fk_model_id}:${view.title}`);
-    await NocoCache.del(`${CacheScope.VIEW}:${view.fk_model_id}:${view.id}`);
+    await NocoCache.del([
+      `${CacheScope.VIEW_ALIAS}:${view.fk_model_id}:${view.title}`,
+      `${CacheScope.VIEW_ALIAS}:${view.fk_model_id}:${view.id}`,
+    ]);
 
     // on update, delete any optimised single query cache
     await View.clearSingleQueryCache(view.fk_model_id, [view]);

--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -1520,24 +1520,20 @@ export default class View implements ViewType {
       });
     }
 
-    // clear cache for each view
-    await Promise.all([
-      ...viewsList.map(async (view) => {
-        await NocoCache.del(
-          `${CacheScope.SINGLE_QUERY}:${modelId}:${view.id}:queries`,
-        );
-        await NocoCache.del(
-          `${CacheScope.SINGLE_QUERY}:${modelId}:${view.id}:read`,
-        );
-      }),
-      (async () => {
-        await NocoCache.del(
-          `${CacheScope.SINGLE_QUERY}:${modelId}:default:queries`,
-        );
-        await NocoCache.del(
-          `${CacheScope.SINGLE_QUERY}:${modelId}:default:read`,
-        );
-      })(),
-    ]);
+    const deleteKeys = [];
+
+    for (const view of viewsList) {
+      deleteKeys.push(
+        `${CacheScope.SINGLE_QUERY}:${modelId}:${view.id}:queries`,
+        `${CacheScope.SINGLE_QUERY}:${modelId}:${view.id}:read`,
+      );
+    }
+
+    deleteKeys.push(
+      `${CacheScope.SINGLE_QUERY}:${modelId}:default:queries`,
+      `${CacheScope.SINGLE_QUERY}:${modelId}:default:read`,
+    );
+
+    await NocoCache.del(deleteKeys);
   }
 }

--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -319,12 +319,6 @@ export default class View implements ViewType {
       insertObj,
     );
 
-    await NocoCache.appendToList(
-      CacheScope.VIEW,
-      [view.fk_model_id],
-      `${CacheScope.VIEW}:${view_id}`,
-    );
-
     let columns: any[] = await (
       await Model.getByIdOrName({ id: view.fk_model_id }, ncMeta)
     ).getColumns(ncMeta);
@@ -506,7 +500,14 @@ export default class View implements ViewType {
       ncMeta,
     );
 
-    return View.get(view_id, ncMeta);
+    return View.get(view_id, ncMeta).then(async (v) => {
+      await NocoCache.appendToList(
+        CacheScope.VIEW,
+        [view.fk_model_id],
+        `${CacheScope.VIEW}:${view_id}`,
+      );
+      return v;
+    });
   }
 
   static async insertColumnToAllViews(

--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -175,6 +175,8 @@ export enum CacheDelDirection {
   CHILD_TO_PARENT = 'CHILD_TO_PARENT',
 }
 
+export const CacheListProp = '__nc_list__';
+
 export const GROUPBY_COMPARISON_OPS = <const>[
   // these are used for groupby
   'gb_eq',


### PR DESCRIPTION
## Change Summary

- deprecate getAll and delAll (they were using `KEYS pattern` which we would like to avoid)
- add bulk del support (less number of calls to Redis)
- set before all appendToList calls (we make use of existing child key so this is a must now)
- keep list of parents on child object
  - extra operations for functions
    - set: get existing __nc_list__ if any and keep it for new value 
    - appendToList: get existing __nc_list__ if any & append list being appended and set child
    - setList: get existing __nc_list__ if any & append list being set and set child
- use list of parents to delete CHILD_TO_PARENT
- use mget for getList (less number of calls to Redis)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
