### PR TITLE
refactor: Remove duplicated code in models

### DIFF
--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/BaseModelXcMeta.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/BaseModelXcMeta.ts
@@ -101,12 +101,11 @@ abstract class BaseModelXcMeta extends BaseRender {
       belongsTo: this.ctx.belongsTo,
       db_type: this.ctx.db_type,
       type: this.ctx.type,
-
-      v: this.getVitualColumns(),
+      v: this.getVirtualColumns(),
     };
   }
 
-  public getVitualColumns(): any[] {
+  public getVirtualColumns(): any[] {
     // todo: handle duplicate relation
     const virtualColumns = [
       ...(this.ctx.hasMany || []).map((hm) => {
@@ -137,6 +136,52 @@ abstract class BaseModelXcMeta extends BaseRender {
 
   public mapDefaultDisplayValue(columnsArr: any[]): void {
     mapDefaultDisplayValue(columnsArr);
+  }
+
+  /**
+   *
+   * @param args
+   * @param args.columns
+   * @param args.relations
+   * @returns {string}
+   * @private
+   */
+  protected renderXcColumns(args) {
+    let str = '[\r\n';
+
+    for (let i = 0; i < args.columns.length; ++i) {
+      str += `{\r\n`;
+      str += `cn: '${args.columns[i].cn}',\r\n`;
+      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
+      str += `dt: '${args.columns[i].dt}',\r\n`;
+      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
+
+      if (args.columns[i].cdf) {
+        str += `default: "${args.columns[i].cdf}",\r\n`;
+        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
+      }
+
+      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
+
+      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
+
+      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
+
+      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
+
+      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
+
+      str += `validate: {
+                func: [],
+                args: [],
+                msg: []
+              },`;
+      str += `},\r\n`;
+    }
+
+    str += ']\r\n';
+
+    return str;
   }
 }
 

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMssql.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMssql.ts
@@ -25,7 +25,7 @@ class ModelXcMetaMssql extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -54,53 +54,6 @@ class ModelXcMetaMssql extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   _getAbstractType(column) {

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMysql.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaMysql.ts
@@ -25,7 +25,7 @@ class ModelXcMetaMysql extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -55,52 +55,6 @@ class ModelXcMetaMysql extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   /* getXcColumnsObject(args) {

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaOracle.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaOracle.ts
@@ -25,7 +25,7 @@ class ModelXcMetaOracle extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -55,52 +55,6 @@ class ModelXcMetaOracle extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   /* getXcColumnsObject(args) {

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
@@ -25,7 +25,7 @@ class ModelXcMetaPg extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -54,52 +54,6 @@ class ModelXcMetaPg extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   _getAbstractType(column) {

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaSnowflake.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaSnowflake.ts
@@ -25,7 +25,7 @@ class ModelXcMetaSnowflake extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -54,52 +54,6 @@ class ModelXcMetaSnowflake extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   _getAbstractType(column) {

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaSqlite.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaSqlite.ts
@@ -25,7 +25,7 @@ class ModelXcMetaSqlite extends BaseModelXcMeta {
 
     /* for complex code provide a func and args - do derivation within the func cbk */
     data.columns = {
-      func: this._renderXcColumns.bind(this),
+      func: this.renderXcColumns.bind(this),
       args: {
         tn: this.ctx.tn,
         columns: this.ctx.columns,
@@ -54,52 +54,6 @@ class ModelXcMetaSqlite extends BaseModelXcMeta {
     };
 
     return data;
-  }
-
-  /**
-   *
-   * @param args
-   * @param args.columns
-   * @param args.relations
-   * @returns {string}
-   * @private
-   */
-  _renderXcColumns(args) {
-    let str = '[\r\n';
-
-    for (let i = 0; i < args.columns.length; ++i) {
-      str += `{\r\n`;
-      str += `cn: '${args.columns[i].cn}',\r\n`;
-      str += `type: '${this._getAbstractType(args.columns[i])}',\r\n`;
-      str += `dt: '${args.columns[i].dt}',\r\n`;
-      if (args.columns[i].rqd) str += `rqd: ${args.columns[i].rqd},\r\n`;
-
-      if (args.columns[i].cdf) {
-        str += `default: "${args.columns[i].cdf}",\r\n`;
-        str += `columnDefault: "${args.columns[i].cdf}",\r\n`;
-      }
-
-      if (args.columns[i].un) str += `un: ${args.columns[i].un},\r\n`;
-
-      if (args.columns[i].pk) str += `pk: ${args.columns[i].pk},\r\n`;
-
-      if (args.columns[i].ai) str += `ai: ${args.columns[i].ai},\r\n`;
-
-      if (args.columns[i].dtxp) str += `dtxp: "${args.columns[i].dtxp}",\r\n`;
-
-      if (args.columns[i].dtxs) str += `dtxs: ${args.columns[i].dtxs},\r\n`;
-
-      str += `validate: {
-                func: [],
-                args: [],
-                msg: []
-              },`;
-      str += `},\r\n`;
-    }
-
-    str += ']\r\n';
-
-    return str;
   }
 
   protected _getAbstractType(column) {

--- a/packages/nocodb/src/version-upgrader/v1-legacy/BaseApiBuilder.ts
+++ b/packages/nocodb/src/version-upgrader/v1-legacy/BaseApiBuilder.ts
@@ -373,7 +373,7 @@ export default abstract class BaseApiBuilder<T extends Noco> {
         dir: '',
         ctx,
         filename: '',
-      }).getVitualColumns();
+      }).getVirtualColumns();
       // set default display values
       ModelXcMetaFactory.create(
         this.connectionConfig,


### PR DESCRIPTION
## Change Summary

This PR removes duplicated code in the database models. Method `renderXcColumns` was duplicated in all database models, so the easiest way to fix duplication move it to the parent class.


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
