### PR TITLE
ACL: move isPluginActive from CREATOR to VIEWER; fixes #7535

### DIFF
--- a/packages/nocodb/src/utils/acl.ts
+++ b/packages/nocodb/src/utils/acl.ts
@@ -255,6 +255,7 @@ const rolePermissions:
       passwordChange: true,
       baseList: true,
       testConnection: true,
+      isPluginActive: true,
     },
   },
   [OrgUserRoles.CREATOR]: {
@@ -267,7 +268,6 @@ const rolePermissions:
       userInviteResend: true,
       upload: true,
       uploadViaURL: true,
-      isPluginActive: true,
       baseCreate: true,
       duplicateSharedBase: true,
     },


### PR DESCRIPTION
## Change Summary

This change will enable VIEWER to receive emails, whenever new entry added via FORM
fixes #7535

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

I created two users: SUPER ADMIN and VIEWER:
- SUPER ADMIN created base, table and the form; also configured SMTP
- VIEWER opened FORM and enabled "E-mail me at ..." switch
- confirmed, that now there is no error and the switch state saved (if fails in `master`)
- confirmed, that email is actually sent
