### PR TITLE
Update app store link to latest doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Access Dashboard using: [http://localhost:8080/dashboard](http://localhost:8080/
 
 ### App Store for Workflow Automations
 
-We provide different integrations in three main categories. See <a href="https://docs.nocodb.com/setup-and-usages/account-settings#app-store" target="_blank">App Store</a> for details.
+We provide different integrations in three main categories. See <a href="https://docs.nocodb.com/account-settings/oss-specific-details/#app-store" target="_blank">App Store</a> for details.
 
 - ⚡ &nbsp;Chat: Slack, Discord, Mattermost, and etc
 - ⚡ &nbsp;Email: AWS SES, SMTP, MailerSend, and etc


### PR DESCRIPTION
## Change Summary

The current link to app store in the README points to an outdated page. Update it to the latest doc.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Changed the link to App store in main README.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
