### PR TITLE
fix(docs): related topics links in table operations

### DIFF
--- a/packages/noco-docs/docs/060.table-operations/020.field-operations.md
+++ b/packages/noco-docs/docs/060.table-operations/020.field-operations.md
@@ -34,11 +34,9 @@ For Gallery View & Kanban View, you can change the cover field by clicking on th
 ![Change cover field](/img/v2/table-operations/change-cover-image.png)
 
 ### Related topics
-- [Filter](filter)
-- [Sort](sort)
-- [GroupBy](group-by)
-- [Row height](row-height)
-- [Quick Search](search)
-- [Download](download)
-
-
+- [Filter](/table-operations/filter)
+- [Sort](/table-operations/sort)
+- [GroupBy](/table-operations/group-by)
+- [Row Height](/table-operations/row-height)
+- [Quick Search](/table-operations/search)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/030.filter.md
+++ b/packages/noco-docs/docs/060.table-operations/030.filter.md
@@ -50,9 +50,9 @@ NocoDB currently supports various types of filters for corresponding fields. Ple
 [Filter Matrix](https://docs.google.com/spreadsheets/d/e/2PACX-1vTpCNKtA-szaXUKJEO5uuSIRnzUOK793MKnyBz9m2rQcwn7HqK19jPHeER-IIRWH9X56J78wfxXZuuv/pubhtml?gid=427284630&amp;single=true&amp;widget=true&amp;headers=false)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Sort](sort)
-- [GroupBy](group-by)
-- [Row height](row-height)
-- [Quick Search](search)
-- [Download](download)
+- [Field Operations](/table-operations/field-operations)
+- [Sort](/table-operations/sort)
+- [GroupBy](/table-operations/group-by)
+- [Row Height](/table-operations/row-height)
+- [Quick Search](/table-operations/search)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/040.sort.md
+++ b/packages/noco-docs/docs/060.table-operations/040.sort.md
@@ -34,9 +34,9 @@ Field configured at the top will be used for the first-level sorting, followed b
 ![Delete Sorting](/img/v2/table-operations/sort-4.png)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Filter](filter)
-- [GroupBy](group-by)
-- [record height](row-height)
-- [Quick Search](search)
-- [Download](download)
+- [Field Operations](/table-operations/field-operations)
+- [Filter](/table-operations/filter)
+- [GroupBy](/table-operations/group-by)
+- [Row Height](/table-operations/row-height)
+- [Quick Search](/table-operations/search)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/050.group-by.md
+++ b/packages/noco-docs/docs/060.table-operations/050.group-by.md
@@ -39,9 +39,9 @@ To disable `Group By` and return to the standard spreadsheet grid view, you must
 ![Group By](/img/v2/table-operations/group-by-delete.png)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Filter](filter)
-- [Sort](sort)
-- [Row height](row-height)
-- [Quick Search](search)
-- [Download](download)
+- [Field Operations](/table-operations/field-operations)
+- [Filter](/table-operations/filter)
+- [Sort](/table-operations/sort)
+- [Row Height](/table-operations/row-height)
+- [Quick Search](/table-operations/search)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/060.row-height.md
+++ b/packages/noco-docs/docs/060.table-operations/060.row-height.md
@@ -24,9 +24,9 @@ NocoDB offers users the flexibility to adjust the display height of records with
 ![Extra](/img/v2/table-operations/row-height-5.png)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Filter](filter)
-- [Sort](sort)
-- [GroupBy](group-by)
-- [Quick Search](search)
-- [Download](download)
+- [Field Operations](/table-operations/field-operations)
+- [Filter](/table-operations/filter)
+- [Sort](/table-operations/sort)
+- [GroupBy](/table-operations/group-by)
+- [Quick Search](/table-operations/search)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/070.search.md
+++ b/packages/noco-docs/docs/060.table-operations/070.search.md
@@ -14,10 +14,9 @@ NocoDB offers a quick search feature that allows you to search for records by fi
 ![image](/img/v2/table-operations/table-search.png)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Filter](filter)
-- [Sort](sort)
-- [GroupBy](group-by)
-- [record height](row-height)
-- [Download](download)
-
+- [Field Operations](/table-operations/field-operations)
+- [Filter](/table-operations/filter)
+- [Sort](/table-operations/sort)
+- [GroupBy](/table-operations/group-by)
+- [Row Height](/table-operations/row-height)
+- [Download](/table-operations/download)

--- a/packages/noco-docs/docs/060.table-operations/080.download.md
+++ b/packages/noco-docs/docs/060.table-operations/080.download.md
@@ -17,9 +17,9 @@ To export data from NocoDB, follow these steps:
 ![Export](/img/v2/table-operations/download.png)
 
 ### Related topics
-- [Field operations](field-operations)
-- [Filter](filter)
-- [Sort](sort)
-- [GroupBy](group-by)
-- [record height](row-height)
-- [Quick Search](search)
+- [Field Operations](/table-operations/field-operations)
+- [Filter](/table-operations/filter)
+- [Sort](/table-operations/sort)
+- [GroupBy](/table-operations/group-by)
+- [Row Height](/table-operations/row-height)
+- [Quick Search](/table-operations/search)


### PR DESCRIPTION
## Change Summary

- if there is a slash at the end, the current links would redirect to the wrong path.
- For example,
  - Go to `https://docs.nocodb.com/table-operations/field-operations/#change-cover-field-gallerykanban-view`
  - Click any link in related topics

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
