### PR TITLE
fix: duplicate base/model

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -318,14 +318,14 @@ class BaseModelSqlv2 {
       sortArr?: Sort[];
       sort?: string | string[];
       fieldsSet?: Set<string>;
-      calendarLimitOverride?: number;
+      limitOverride?: number;
     } = {},
     options: {
       ignoreViewFilterAndSort?: boolean;
       ignorePagination?: boolean;
       validateFormula?: boolean;
       throwErrorIfInvalidParams?: boolean;
-      calendarLimitOverride?: number;
+      limitOverride?: number;
     } = {},
   ): Promise<any> {
     const {
@@ -333,7 +333,7 @@ class BaseModelSqlv2 {
       ignorePagination = false,
       validateFormula = false,
       throwErrorIfInvalidParams = false,
-      calendarLimitOverride,
+      limitOverride,
     } = options;
 
     const { where, fields, ...rest } = this._getListArgs(args as any);
@@ -439,12 +439,12 @@ class BaseModelSqlv2 {
       });
     }
 
-    // For calendar View, if calendarLimitOverride is provided, use it as limit for the query
+    // if limitOverride is provided, use it as limit for the query (for internal usage eg. calendar, export)
     if (!ignorePagination) {
-      if (!calendarLimitOverride) {
+      if (!limitOverride) {
         applyPaginate(qb, rest);
       } else {
-        applyPaginate(qb, { ...rest, limit: calendarLimitOverride });
+        applyPaginate(qb, { ...rest, limit: limitOverride });
       }
     }
     const proto = await this.getProto();

--- a/packages/nocodb/src/helpers/PagedResponse.ts
+++ b/packages/nocodb/src/helpers/PagedResponse.ts
@@ -11,6 +11,7 @@ export class PagedResponseImpl<T> {
       count?: number | string;
       l?: number;
       o?: number;
+      limitOverride?: number;
     } = {},
     additionalProps?: Record<string, any>,
   ) {

--- a/packages/nocodb/src/helpers/extractLimitAndOffset.ts
+++ b/packages/nocodb/src/helpers/extractLimitAndOffset.ts
@@ -15,6 +15,7 @@ export function extractLimitAndOffset(
     offset?: number | string;
     l?: number | string;
     o?: number | string;
+    limitOverride?: number;
   } = {},
 ) {
   const obj: {
@@ -39,6 +40,11 @@ export function extractLimitAndOffset(
   // skip any invalid offset, ignore negative and non-integer values
   const offset = +(args.offset || args.o) || 0;
   obj.offset = Math.max(Number.isInteger(offset) ? offset : 0, 0);
+
+  // override limit if provided
+  if (args.limitOverride) {
+    obj.limit = +args.limitOverride;
+  }
 
   return obj;
 }

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
@@ -611,6 +611,7 @@ export class ExportService {
           query: { limit, offset, fields },
           baseModel,
           ignoreViewFilterAndSort: true,
+          limitOverride: limit,
         })
         .then((result) => {
           try {
@@ -661,6 +662,7 @@ export class ExportService {
           query: { limit, offset, fields },
           baseModel,
           ignoreViewFilterAndSort: true,
+          limitOverride: limit,
         })
         .then((result) => {
           try {
@@ -681,7 +683,9 @@ export class ExportService {
                 offset + limit,
                 limit,
                 fields,
-              ).then(resolve);
+              )
+                .then(resolve)
+                .catch(reject);
             }
           } catch (e) {
             reject(e);

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
@@ -633,7 +633,9 @@ export class ExportService {
                 offset + limit,
                 limit,
                 fields,
-              ).then(resolve);
+              )
+                .then(resolve)
+                .catch(reject);
             }
           } catch (e) {
             reject(e);

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/export.service.ts
@@ -13,6 +13,7 @@ import NcPluginMgrv2 from '~/helpers/NcPluginMgrv2';
 import { NcError } from '~/helpers/catchError';
 import { DatasService } from '~/services/datas.service';
 import { Base, Hook, Model, Source } from '~/models';
+import { parseMetaProp } from '~/utils/modelUtils';
 
 @Injectable()
 export class ExportService {
@@ -220,10 +221,7 @@ export class ExportService {
                 break;
               case 'meta':
                 if (view.type === ViewTypes.KANBAN) {
-                  const meta = JSON.parse(view.view.meta as string) as Record<
-                    string,
-                    any
-                  >;
+                  const meta = parseMetaProp(view.view) as Record<string, any>;
                   for (const [k, v] of Object.entries(meta)) {
                     const colId = idMap.get(k as string);
                     for (const op of v) {

--- a/packages/nocodb/src/services/calendar-datas.service.ts
+++ b/packages/nocodb/src/services/calendar-datas.service.ts
@@ -56,7 +56,7 @@ export class CalendarDatasService {
       viewName: view.id,
       baseName: model.base_id,
       tableName: model.id,
-      calendarLimitOverride: 3000, // TODO: make this configurable in env
+      limitOverride: 3000, // TODO: make this configurable in env
     });
   }
 

--- a/packages/nocodb/src/services/datas.service.ts
+++ b/packages/nocodb/src/services/datas.service.ts
@@ -23,7 +23,7 @@ export class DatasService {
       query: any;
       disableOptimization?: boolean;
       ignorePagination?: boolean;
-      calendarLimitOverride?: number;
+      limitOverride?: number;
       throwErrorIfInvalidParams?: boolean;
     },
   ) {
@@ -43,7 +43,7 @@ export class DatasService {
       query: param.query,
       throwErrorIfInvalidParams: true,
       ignorePagination: param.ignorePagination,
-      calendarLimitOverride: param.calendarLimitOverride,
+      limitOverride: param.limitOverride,
     });
   }
 
@@ -153,7 +153,7 @@ export class DatasService {
     throwErrorIfInvalidParams?: boolean;
     ignoreViewFilterAndSort?: boolean;
     ignorePagination?: boolean;
-    calendarLimitOverride?: number;
+    limitOverride?: number;
   }) {
     const { model, view, query = {}, ignoreViewFilterAndSort = false } = param;
 
@@ -193,7 +193,7 @@ export class DatasService {
               ignoreViewFilterAndSort,
               throwErrorIfInvalidParams: param.throwErrorIfInvalidParams,
               ignorePagination: param.ignorePagination,
-              calendarLimitOverride: param.calendarLimitOverride,
+              limitOverride: param.limitOverride,
             }),
             {},
             listArgs,

--- a/packages/nocodb/src/services/datas.service.ts
+++ b/packages/nocodb/src/services/datas.service.ts
@@ -210,6 +210,7 @@ export class DatasService {
     ]);
     return new PagedResponseImpl(data, {
       ...query,
+      ...(param.limitOverride ? { limitOverride: param.limitOverride } : {}),
       count,
     });
   }


### PR DESCRIPTION
## Change Summary

- use parseMetaProp on export service
- rename calendarLimitOverride to limitOverride and reuse for export service
- add missing catch block for async call

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)