### PR TITLE
chore(deps): Add integrity for the xlsx tarball

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27501,7 +27501,7 @@ packages:
     dev: true
 
   '@cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz':
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz}
+    resolution: {integrity: sha512-8IfgFctB7fkvqkTGF2MnrDrC6vzE28Wcc1aSbdDQ+4/WFtzfS73YuapbuaPZwGqpR2e0EeDMIrFOJubQVLWFNA==, tarball: https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz}
     name: xlsx
     version: 0.19.3
     engines: {node: '>=0.8'}


### PR DESCRIPTION
## Change Summary

We are building nocodb using [pnpm2nix-nzbr][1], and that library requires all dependencies to have integrities.

And it's also more secure, since if someone hijacks that website and replaces that tarball with something malicious, pnpm will refuse to use that.

[1]: https://github.com/nzbr/pnpm2nix-nzbr

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

I have verified that `pnpm install` works. Also, `pnpm update` preserves the hash.

@vijayrathore8492 Please review.