### PR TITLE
fix: Sync both filename and connection.filename when updating SQLite datasource

### DIFF
--- a/packages/nc-gui/components/dashboard/settings/data-sources/EditBase.vue
+++ b/packages/nc-gui/components/dashboard/settings/data-sources/EditBase.vue
@@ -222,6 +222,11 @@ const editBase = async () => {
 
     const config = { ...formState.value.dataSource, connection }
 
+    // todo: refactor and remove this duplicate path in config
+    if(config.client === ClientType.SQLITE && config.connection?.connection?.filename) {
+      config.connection.filename = config.connection.connection.filename;
+    }
+
     await api.source.update(base.value?.id, props.sourceId, {
       alias: formState.value.title,
       type: formState.value.dataSource.client,


### PR DESCRIPTION
## Change Summary

- Closes #7844

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
