### PR TITLE
fix(nc-gui): Hide Rename, Delete, Add record buttons when user doesn't have necessary permissions

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -766,7 +766,7 @@ const projectDelete = () => {
             </div>
           </NcMenuItem>
           <NcDivider />
-          <NcMenuItem v-if="isUIAllowed('table-delete')" class="!hover:bg-red-50" @click="tableDelete">
+          <NcMenuItem v-if="isUIAllowed('tableDelete')" class="!hover:bg-red-50" @click="tableDelete">
             <div class="nc-base-option-item flex gap-2 items-center text-red-600">
               <GeneralIcon icon="delete" />
               {{ $t('general.delete') }}

--- a/packages/nc-gui/components/smartsheet/Kanban.vue
+++ b/packages/nc-gui/components/smartsheet/Kanban.vue
@@ -513,7 +513,10 @@ const getRowId = (row: RowType) => {
                     </div>
                   </a-layout-header>
 
-                  <a-layout-content class="overflow-y-hidden mt-1" style="max-height: calc(100% - 11rem)">
+                  <a-layout-content
+                    class="overflow-y-hidden mt-1"
+                    :style="{ maxHeight: isUIAllowed('dataInsert') ? 'calc(100% - 11rem)' : 'calc(100% - 8rem)' }"
+                  >
                     <div :ref="kanbanListRef" class="nc-kanban-list h-full nc-scrollbar-dark-md" :data-stack-title="stack.title">
                       <!-- Draggable Record Card -->
                       <Draggable
@@ -665,6 +668,7 @@ const getRowId = (row: RowType) => {
                       </div>
 
                       <div
+                        v-if="isUIAllowed('dataInsert')"
                         class="flex flex-row w-full mt-3 justify-between items-center cursor-pointer bg-white px-4 py-2 rounded-lg border-gray-100 border-1 shadow-sm shadow-gray-100"
                         @click="
                           () => {

--- a/packages/nc-gui/lib/acl.ts
+++ b/packages/nc-gui/lib/acl.ts
@@ -34,8 +34,6 @@ const rolePermissions = {
       baseDelete: true,
       baseDuplicate: true,
       newUser: true,
-      tableRename: true,
-      tableDelete: true,
       viewCreateOrEdit: true,
       baseReorder: true,
     },


### PR DESCRIPTION
## Change Summary

- Hide Add record button when user doesn't have dataInsert permission. 
Button "Add record" opens form with disabled fields and you can't submit this form.

- Remove tableRename, tableDelete from org level role permissions for hiding Rename and Delete buttons in table context menu.
Hide buttons which perform actions that are not allowed by backend. 
Remove tableRename, tableDelete from org level because these permissions are not related to org level actions.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

I tested all the changes.

## Additional information / screenshots (optional)

<img width="1299" alt="Screenshot 2024-03-14 at 23 55 48" src="https://github.com/nocodb/nocodb/assets/162738418/6b843271-c657-4327-8610-36558ca7b3aa">
Added screenshot for first problem
