### PR TITLE
Nc feat(nc-gui): disable webhook bulk events while editing webhook

### DIFF
--- a/packages/nc-gui/components/webhook/Editor.vue
+++ b/packages/nc-gui/components/webhook/Editor.vue
@@ -79,7 +79,7 @@ let hookRef = reactive<
 const isBodyShownEasterEgg = ref(false)
 const isBodyShown = ref(hookRef.version === 'v1' || isEeUI)
 
-const urlTabKey = ref(isBodyShownEasterEgg.value && isBodyShown.value ? 'body' : 'params')
+const urlTabKey = ref<'params' | 'headers' | 'body'>('params')
 
 const apps: Record<string, any> = ref()
 
@@ -321,9 +321,6 @@ function setHook(newHook: HookType) {
       payload: notification.payload,
     },
   })
-  if (hookRef.version === 'v1' || isEeUI) {
-    urlTabKey.value = 'body'
-  }
 }
 
 function onEventChange() {
@@ -479,6 +476,13 @@ async function testWebhook() {
 
 const getDefaultHookName = (hooks: HookType[]) => {
   return extractNextDefaultName([...hooks.map((el) => el?.title || '')], defaultHookName)
+}
+
+const handleToggleEasterEgg = () => {
+  isBodyShownEasterEgg.value = !isBodyShownEasterEgg.value
+  if (!(isBodyShown.value && isBodyShownEasterEgg.value) && urlTabKey.value === 'body') {
+    urlTabKey.value = 'params'
+  }
 }
 
 watch(
@@ -658,7 +662,7 @@ onMounted(async () => {
                 size="large"
                 class="nc-select-hook-url-method"
                 dropdown-class-name="nc-dropdown-hook-notification-url-method"
-                @dblclick="isBodyShownEasterEgg = !isBodyShownEasterEgg"
+                @dblclick="handleToggleEasterEgg"
               >
                 <a-select-option v-for="(method, i) in methodList" :key="i" :value="method.title">
                   <div class="flex items-center gap-2 justify-between">
@@ -688,6 +692,14 @@ onMounted(async () => {
 
             <a-col :span="24">
               <NcTabs v-model:activeKey="urlTabKey" type="card" closeable="false" class="border-1 !pb-2 !rounded-lg">
+                <a-tab-pane key="params" :tab="$t('title.parameter')" force-render>
+                  <LazyApiClientParams v-model="hookRef.notification.payload.parameters" class="p-4" />
+                </a-tab-pane>
+
+                <a-tab-pane key="headers" :tab="$t('title.headers')" class="nc-tab-headers">
+                  <LazyApiClientHeaders v-model="hookRef.notification.payload.headers" class="!p-4" />
+                </a-tab-pane>
+
                 <a-tab-pane v-if="isBodyShown && isBodyShownEasterEgg" key="body" tab="Body">
                   <LazyMonacoEditor
                     v-model="hookRef.notification.payload.body"
@@ -695,14 +707,6 @@ onMounted(async () => {
                     :validate="false"
                     class="min-h-60 max-h-80"
                   />
-                </a-tab-pane>
-
-                <a-tab-pane key="params" :tab="$t('title.parameter')" force-render>
-                  <LazyApiClientParams v-model="hookRef.notification.payload.parameters" class="p-4" />
-                </a-tab-pane>
-
-                <a-tab-pane key="headers" :tab="$t('title.headers')" class="nc-tab-headers">
-                  <LazyApiClientHeaders v-model="hookRef.notification.payload.headers" class="!p-4" />
                 </a-tab-pane>
 
                 <!-- No in use at this moment -->

--- a/packages/nc-gui/components/webhook/Editor.vue
+++ b/packages/nc-gui/components/webhook/Editor.vue
@@ -592,7 +592,7 @@ onMounted(async () => {
                     :key="i"
                     class="capitalize"
                     :value="event.value.join(' ')"
-                    :disabled="hook && isBodyShown && ['bulkInsert', 'bulkUpdate', 'bulkDelete'].includes(event.value[1])"
+                    :disabled="hookRef.version === 'v1' && ['bulkInsert', 'bulkUpdate', 'bulkDelete'].includes(event.value[1])"
                   >
                     <div class="flex items-center gap-2 justify-between">
                       <div>{{ event.text.join(' ') }}</div>

--- a/packages/nc-gui/components/webhook/Editor.vue
+++ b/packages/nc-gui/components/webhook/Editor.vue
@@ -592,7 +592,7 @@ onMounted(async () => {
                     :key="i"
                     class="capitalize"
                     :value="event.value.join(' ')"
-                    :disabled="hook && ['bulkInsert', 'bulkUpdate', 'bulkDelete'].includes(event.value[1])"
+                    :disabled="hook && isBodyShown && ['bulkInsert', 'bulkUpdate', 'bulkDelete'].includes(event.value[1])"
                   >
                     <div class="flex items-center gap-2 justify-between">
                       <div>{{ event.text.join(' ') }}</div>

--- a/packages/nc-gui/components/webhook/Editor.vue
+++ b/packages/nc-gui/components/webhook/Editor.vue
@@ -323,11 +323,6 @@ function setHook(newHook: HookType) {
   })
   if (hookRef.version === 'v1' || isEeUI) {
     urlTabKey.value = 'body'
-    eventList.value = [
-      { text: ['After', 'Insert'], value: ['after', 'insert'] },
-      { text: ['After', 'Update'], value: ['after', 'update'] },
-      { text: ['After', 'Delete'], value: ['after', 'delete'] },
-    ]
   }
 }
 
@@ -592,7 +587,13 @@ onMounted(async () => {
                   class="nc-text-field-hook-event capitalize"
                   dropdown-class-name="nc-dropdown-webhook-event"
                 >
-                  <a-select-option v-for="(event, i) in eventList" :key="i" class="capitalize" :value="event.value.join(' ')">
+                  <a-select-option
+                    v-for="(event, i) in eventList"
+                    :key="i"
+                    class="capitalize"
+                    :value="event.value.join(' ')"
+                    :disabled="hook && ['bulkInsert', 'bulkUpdate', 'bulkDelete'].includes(event.value[1])"
+                  >
                     <div class="flex items-center gap-2 justify-between">
                       <div>{{ event.text.join(' ') }}</div>
                       <component


### PR DESCRIPTION
## Change Summary

- ref: #7913

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Adjusted webhook setting functionality to refine dropdown options available for selection.
	- Updated the `setHook` function in the `Editor.vue` file to improve user experience.
	- Simplified initialization logic for `urlTabKey` based on conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->