### PR TITLE
Nc fix(nc-gui): Use `control` key instead of `ctrl` from useMagicKeys 

### DIFF
--- a/packages/nc-gui/components/dashboard/Sidebar/TopSection.vue
+++ b/packages/nc-gui/components/dashboard/Sidebar/TopSection.vue
@@ -6,7 +6,7 @@ const { isUIAllowed } = useRoles()
 
 const { appInfo } = useGlobal()
 
-const { meta: metaKey, ctrlKey } = useMagicKeys()
+const { meta: metaKey, control } = useMagicKeys()
 
 const { isWorkspaceLoading, isWorkspaceSettingsPageOpened } = storeToRefs(workspaceStore)
 
@@ -17,7 +17,7 @@ const { isSharedBase } = storeToRefs(baseStore)
 const isCreateProjectOpen = ref(false)
 
 const navigateToSettings = () => {
-  const cmdOrCtrl = isMac() ? metaKey.value : ctrlKey.value
+  const cmdOrCtrl = isMac() ? metaKey.value : control.value
 
   // TODO: Handle cloud case properly
   navigateToWorkspaceSettings('', cmdOrCtrl)

--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -73,7 +73,7 @@ const { orgRoles, isUIAllowed } = useRoles()
 
 useTabs()
 
-const { meta: metaKey, ctrlKey } = useMagicKeys()
+const { meta: metaKey, control } = useMagicKeys()
 
 const { refreshCommandPalette } = useCommandPalette()
 
@@ -261,7 +261,7 @@ const onProjectClick = async (base: NcProject, ignoreNavigation?: boolean, toggl
   if (!base) {
     return
   }
-  const cmdOrCtrl = isMac() ? metaKey.value : ctrlKey.value
+  const cmdOrCtrl = isMac() ? metaKey.value : control.value
 
   if (!toggleIsExpanded && !cmdOrCtrl) $e('c:base:open')
 

--- a/packages/nc-gui/components/dashboard/TreeView/TableNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/TableNode.vue
@@ -39,7 +39,7 @@ useTableNew({
   baseId: base.value.id!,
 })
 
-const { meta: metaKey, ctrlKey } = useMagicKeys()
+const { meta: metaKey, control } = useMagicKeys()
 
 const baseRole = inject(ProjectRoleInj)
 provide(SidebarTableInj, table)
@@ -108,7 +108,7 @@ const onExpand = async () => {
 }
 
 const onOpenTable = async () => {
-  if (isMac() ? metaKey.value : ctrlKey.value) {
+  if (isMac() ? metaKey.value : control.value) {
     await _openTable(table.value, true)
     return
   }

--- a/packages/nc-gui/components/dashboard/TreeView/ViewsNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ViewsNode.vue
@@ -53,7 +53,7 @@ const { activeView } = storeToRefs(useViewsStore())
 
 const { getMeta } = useMetas()
 
-const { meta: metaKey, ctrlKey } = useMagicKeys()
+const { meta: metaKey, control } = useMagicKeys()
 
 const table = computed(() => props.table)
 const injectedTable = ref(table.value)
@@ -89,7 +89,7 @@ const onClick = useDebounceFn(() => {
 const handleOnClick = () => {
   if (isEditing.value || isStopped.value) return
 
-  const cmdOrCtrl = isMac() ? metaKey.value : ctrlKey.value
+  const cmdOrCtrl = isMac() ? metaKey.value : control.value
 
   if (cmdOrCtrl) {
     emits('changeView', vModel.value)

--- a/packages/nc-gui/components/smartsheet/column/LinkedToAnotherRecordOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/LinkedToAnotherRecordOptions.vue
@@ -62,7 +62,7 @@ const oneToOneEnabled = ref(false)
     <div class="border-2 p-6">
       <a-form-item v-bind="validateInfos.type" class="nc-ltar-relation-type">
         <a-radio-group v-model:value="vModel.type" name="type" v-bind="validateInfos.type" class="!flex flex-col gap-2">
-          <a-radio @dblclick="oneToOneEnabled = !oneToOneEnabled" value="hm">{{ $t('title.hasMany') }}</a-radio>
+          <a-radio value="hm" @dblclick="oneToOneEnabled = !oneToOneEnabled">{{ $t('title.hasMany') }}</a-radio>
           <a-radio value="mm">{{ $t('title.manyToMany') }}</a-radio>
           <a-radio v-if="oneToOneEnabled" value="oo">{{ $t('title.oneToOne') }}</a-radio>
         </a-radio-group>

--- a/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
@@ -51,7 +51,6 @@ const {
   unlink,
   row,
   headerDisplayValue,
-  resetChildrenExcludedOffsetCount,
 } = useLTARStoreOrThrow()
 
 const { addLTARRef, isNew, removeLTARRef, state: rowState } = useSmartsheetRowStoreOrThrow()
@@ -101,9 +100,6 @@ watch(
         loadChildrenList()
       }
       loadChildrenExcludedList(rowState.value)
-    }
-    if (!nextVal) {
-      resetChildrenExcludedOffsetCount()
     }
   },
   {
@@ -259,11 +255,6 @@ onUnmounted(() => {
   childrenExcludedListPagination.query = ''
   window.removeEventListener('keydown', linkedShortcuts)
 })
-
-const onFilterChange = () => {
-  childrenExcludedListPagination.page = 1
-  resetChildrenExcludedOffsetCount()
-}
 </script>
 
 <template>

--- a/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
@@ -51,6 +51,7 @@ const {
   unlink,
   row,
   headerDisplayValue,
+  resetChildrenExcludedOffsetCount,
 } = useLTARStoreOrThrow()
 
 const { addLTARRef, isNew, removeLTARRef, state: rowState } = useSmartsheetRowStoreOrThrow()
@@ -100,6 +101,9 @@ watch(
         loadChildrenList()
       }
       loadChildrenExcludedList(rowState.value)
+    }
+    if (!nextVal) {
+      resetChildrenExcludedOffsetCount()
     }
   },
   {
@@ -255,6 +259,11 @@ onUnmounted(() => {
   childrenExcludedListPagination.query = ''
   window.removeEventListener('keydown', linkedShortcuts)
 })
+
+const onFilterChange = () => {
+  childrenExcludedListPagination.page = 1
+  resetChildrenExcludedOffsetCount()
+}
 </script>
 
 <template>

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -550,6 +550,10 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
       })
     })
 
+    const resetChildrenExcludedOffsetCount = () => {
+      childrenExcludedOffsetCount.value = 0
+    }
+
     return {
       relatedTableMeta,
       loadRelatedTableMeta,

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -283,8 +283,8 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         }
       } catch (e: any) {
         // temporary fix to handle when offset is beyond limit
-        if(await extractSdkResponseErrorMsg(e) === 'Offset is beyond the total number of records'){
-          childrenExcludedListPagination.page = 0;
+        if ((await extractSdkResponseErrorMsg(e)) === 'Offset is beyond the total number of records') {
+          childrenExcludedListPagination.page = 0
           return loadChildrenExcludedList(activeState)
         }
 
@@ -549,10 +549,6 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         isChildrenListLoading.value[index] = false
       })
     })
-
-    const resetChildrenExcludedOffsetCount = () => {
-      childrenExcludedOffsetCount.value = 0
-    }
 
     return {
       relatedTableMeta,

--- a/packages/nc-gui/store/views.ts
+++ b/packages/nc-gui/store/views.ts
@@ -28,7 +28,7 @@ export const useViewsStore = defineStore('viewsStore', () => {
 
   const { activeWorkspaceId } = storeToRefs(useWorkspace())
 
-  const { meta: metaKey, ctrlKey } = useMagicKeys()
+  const { meta: metaKey, control } = useMagicKeys()
 
   const recentViews = computed<RecentView[]>(() =>
     allRecentViews.value.filter((f) => f.workspaceId === activeWorkspaceId.value).splice(0, 10),
@@ -219,7 +219,7 @@ export const useViewsStore = defineStore('viewsStore', () => {
     hardReload?: boolean
     doNotSwitchTab?: boolean
   }) => {
-    const cmdOrCtrl = isMac() ? metaKey.value : ctrlKey.value
+    const cmdOrCtrl = isMac() ? metaKey.value : control.value
 
     const routeName = 'index-typeOrId-baseId-index-index-viewId-viewTitle-slugs'
 


### PR DESCRIPTION
## Change Summary

- ref: #7920

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved keyboard shortcut handling across the dashboard by renaming and unifying key identification variables for better clarity and consistency, specifically impacting Mac users.
- **Bug Fixes**
	- Adjusted the order of attributes in the `<a-radio>` component to correctly bind the event listener (`@dblclick`) for toggling the `oneToOneEnabled` boolean variable when selecting the "hasMany" radio option, impacting the component's behavior.
- **Chores**
	- Added a todo comment to confirm the use case of `childrenExcludedOffsetCount.value`.
	- Introduced a new function `resetChildrenExcludedOffsetCount` to reset `childrenExcludedOffsetCount.value`.
	- Added `relatedTableDisplayValuePropId` to the returned object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->