### PR TITLE
fix(nc-gui): Hide Members tab for base when user doesn't have newUser permission

### DIFF
--- a/packages/nc-gui/components/project/View.vue
+++ b/packages/nc-gui/components/project/View.vue
@@ -20,7 +20,7 @@ const { $e } = useNuxtApp()
   return openedProject.value?.sources?.[0]
 }) */
 
-const { isUIAllowed } = useRoles()
+const { isUIAllowed, baseRoles } = useRoles()
 
 const { base } = storeToRefs(useBase())
 
@@ -121,7 +121,7 @@ watch(
         <!-- <a-tab-pane v-if="defaultBase" key="erd" tab="Base ERD" force-render class="pt-4 pb-12">
           <ErdView :source-id="defaultBase!.id" class="!h-full" />
         </a-tab-pane> -->
-        <a-tab-pane v-if="isUIAllowed('newUser')" key="collaborator">
+        <a-tab-pane v-if="isUIAllowed('newUser', { roles: baseRoles })" key="collaborator">
           <template #tab>
             <div class="tab-title" data-testid="proj-view-tab__access-settings">
               <GeneralIcon icon="users" class="!h-3.5 !w-3.5" />


### PR DESCRIPTION
## Change Summary

Added baseRoles scope to function `isUIAllowed` because API for changing roles or inviting new users is forbidden for Editor/Commenter/Viewer. Also, Editor/Commenter/Viewer can not see the role of other users.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

I tested on different roles.

## Additional information / screenshots (optional)

https://github.com/nocodb/nocodb/assets/162738418/0ceb4849-dbb3-4d4d-a2a4-e4748def46ad

User has a Commenter role in the video.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced role-based access control in project views by incorporating base roles into UI permissions checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->