### PR TITLE
fix: formula error on field title update

### DIFF
--- a/packages/nocodb/src/utils/modelUtils.ts
+++ b/packages/nocodb/src/utils/modelUtils.ts
@@ -11,12 +11,15 @@ export function parseMetaProp(model: any, propName = 'meta'): any {
   }
 }
 
-export function stringifyMetaProp(model: any, propName = 'meta'): string {
+export function stringifyMetaProp(
+  model: any,
+  propName = 'meta',
+): string | null {
   if (!model) return null;
 
   // stringify meta property
   try {
-    return typeof model[propName] === 'string'
+    return typeof model[propName] === 'string' || model[propName] === null
       ? model[propName]
       : JSON.stringify(model[propName]);
   } catch (e) {


### PR DESCRIPTION
## Change Summary

Fixes #7923

- Avoid stringifying null with stringifyMetaProp (this ends up pushing 'null' to db instead of null)
- There was repetitive logic within columns service to update formulas, wrapped it with a function
  - Also avoided recalculating parsed tree as marking it as null will make it recalculate

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced formula management in columns, including automatic updates and improved handling for name changes.
- **Refactor**
	- Optimized formula update processes for efficiency and reliability.
- **Bug Fixes**
	- Fixed issues with formula parsing to ensure accurate recalculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->