### PR TITLE
Add one click deploy on sealos

### DIFF
--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/010.installation.md
@@ -446,6 +446,9 @@ Go to [Templates](https://railway.app/templates), Search NocoDB and click Deploy
 
 See [here](https://gist.github.com/Zamana/e9281d736f9e9ce5882c6f4b140a590e) provided by [C. R. Zamana](https://github.com/Zamana).
 
+### Sealos
+
+[![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dnocodb)
 
 ## Sample Demos
 


### PR DESCRIPTION
## Change Summary

[![](https://raw.githubusercontent.com/labring-actions/templates/main/Deploy-on-Sealos.svg)](https://cloud.sealos.io/?openapp=system-template%3FtemplateName%3Dnocodb)

[Sealos](https://github.com/labring/sealos) is one of the biggest container platform in China, also an open source project.

## Change type

- [x] docs: (changes to the documentation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section in the installation guide for self-hosted solutions, detailing how to deploy NocoDB on Sealos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->