### PR TITLE
chore: create PR for master sync after release

### DIFF
--- a/.github/workflows/sync-to-develop.yml
+++ b/.github/workflows/sync-to-develop.yml
@@ -33,7 +33,8 @@ jobs:
           cd nocodb
           git fetch --quiet --unshallow origin
           git checkout master
-          BRANCH_NAME=oss/$(git rev-list -n 3 HEAD | tail -1 | cut -c1-8)
+          : # Use the first 8 characters of the latest commit hash as the branch name
+          BRANCH_NAME=nc/$(git rev-list -n 1 HEAD | cut -c1-8)
           git checkout -b $BRANCH_NAME
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/sync-to-develop.yml
+++ b/.github/workflows/sync-to-develop.yml
@@ -9,15 +9,36 @@ jobs:
   sync-to-develop:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Merge from master to develop
-        uses: wingkwong/gh-action-nightly-merge@master
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          stable_branch: 'master'
-          development_branch: 'develop'
-          allow_ff: true
-          allow_forks: true
+          node-version: 18.19.1
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: nocodb
+      - name: Prepare GH Cli
+        id: gh
+        run: |
+          wget https://github.com/cli/cli/releases/download/v2.33.0/gh_2.33.0_linux_amd64.tar.gz
+          tar -xvf gh_2.33.0_linux_amd64.tar.gz
+          GH=gh_2.33.0_linux_amd64/bin/gh
+          echo "GH=${GH}" >> $GITHUB_OUTPUT
+      - name: Sync Master to Develop
+        id: sync
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd nocodb
+          git fetch --quiet --unshallow origin
+          git checkout master
+          BRANCH_NAME=oss/$(git rev-list -n 3 HEAD | tail -1 | cut -c1-8)
+          git checkout -b $BRANCH_NAME
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          revertSDK=true node scripts/upgradeNocodbSdk.js
+          git add .
+          git diff-index --quiet HEAD || git commit -m "chore: update sdk path"
+          git push origin $BRANCH_NAME
+          ../${{ steps.gh.outputs.GH }} pr create --title "chore: post-release sync" --body "$(echo -e "This is an automated pull request to sync the master branch to develop.\nPlease review and merge this pull request if it looks good.")" --base develop --head $BRANCH_NAME

--- a/scripts/upgradeNocodbSdk.js
+++ b/scripts/upgradeNocodbSdk.js
@@ -5,6 +5,11 @@ const execSync = require('child_process').execSync;
 // extract latest version from package.json
 const nocodbSdkPackage = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'packages', 'nocodb-sdk', 'package.json'), 'utf8'))
 
+
+if (process.env.revertSDK === 'true') {
+  nocodbSdkPackage.version = 'workspace:^';
+}
+
 const replacePackageName = (filePath) => {
     return new Promise((resolve, reject) => {
         return fs.readFile(filePath, 'utf8', function (err, data) {


### PR DESCRIPTION
## Change Summary

Depends on #7940 - we can trigger a manual run after 7940 merged to test the action

- Action revised to sync master back to develop 
  - Create a PR instead of pushing (branch protection)
  - Target local SDK on automated PR

## Change type

- [x] chore: (updating grunt tasks etc; no production code change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the GitHub workflow for better synchronization between branches.
- **Refactor**
	- Enhanced the script for upgrading package versions with improved handling and environment-specific adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->