### PR TITLE
fix: Reset offset count when closing modal or when filter query changes

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -59,6 +59,7 @@ const {
   link,
   meta,
   headerDisplayValue,
+  resetChildrenListOffsetCount,
 } = useLTARStoreOrThrow()
 
 const { isNew, state, removeLTARRef, addLTARRef } = useSmartsheetRowStoreOrThrow()
@@ -68,6 +69,11 @@ watch(
   (nextVal) => {
     if ((nextVal[0] || nextVal[1]) && !isNew.value) {
       loadChildrenList()
+    }
+
+    // reset offset count when closing modal
+    if (!nextVal[0]) {
+      resetChildrenListOffsetCount()
     }
   },
   { immediate: true },
@@ -207,9 +213,16 @@ watch(childrenListPagination, () => {
 })
 
 onUnmounted(() => {
+  resetChildrenListOffsetCount()
   childrenListPagination.query = ''
   window.removeEventListener('keydown', linkedShortcuts)
 })
+
+const onFilterChange = () => {
+  childrenListPagination.page = 1
+  // reset offset count when filter changes
+  resetChildrenListOffsetCount()
+}
 </script>
 
 <template>
@@ -242,7 +255,7 @@ onUnmounted(() => {
           :placeholder="`Search in ${relatedTableMeta?.title}`"
           class="w-full !sm:rounded-md xs:min-h-8 !xs:rounded-xl"
           size="small"
-          @change="childrenListPagination.page = 1"
+          @change="onFilterChange"
           @keydown.capture.stop="
             (e) => {
               if (e.key === 'Escape') {

--- a/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
@@ -256,6 +256,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  resetChildrenExcludedOffsetCount()
   childrenExcludedListPagination.query = ''
   window.removeEventListener('keydown', linkedShortcuts)
 })

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -554,6 +554,10 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
       childrenExcludedOffsetCount.value = 0;
     }
 
+    const resetChildrenListOffsetCount = () => {
+      childrenListOffsetCount.value = 0
+    }
+
     return {
       relatedTableMeta,
       loadRelatedTableMeta,
@@ -584,7 +588,8 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
       getRelatedTableRowId,
       headerDisplayValue,
       relatedTableDisplayValuePropId,
-      resetChildrenExcludedOffsetCount
+      resetChildrenExcludedOffsetCount,
+      resetChildrenListOffsetCount,
     }
   },
   'ltar-store',


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to reset pagination and offset counts for linked and unlinked items lists upon certain conditions, enhancing user experience in navigating through items.
- **Refactor**
	- Improved internal handling of pagination and list offsets to ensure smoother user interactions and data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->