### PR TITLE
fix: update discord link

### DIFF
--- a/packages/nc-gui/components/nc/ErrorBoundary.vue
+++ b/packages/nc-gui/components/nc/ErrorBoundary.vue
@@ -80,7 +80,7 @@ export default {
         <p class="mb-0">
           <span
             >Please report this error in our
-            <a href="https://discord.gg/8jX2GQn" target="_blank" rel="noopener noreferrer">Discord channel</a>. You can copy the
+            <a href="https://discord.gg/5RgZmkW" target="_blank" rel="noopener noreferrer">Discord channel</a>. You can copy the
             error message by clicking the "Copy" button below.</span
           >
         </p>

--- a/packages/nc-gui/composables/useCommandPalette/commands.ts
+++ b/packages/nc-gui/composables/useCommandPalette/commands.ts
@@ -32,7 +32,7 @@ export const homeCommands = [
     parent: 'user',
     section: 'Community',
     handler: () => {
-      navigateTo('https://discord.gg/8jX2GQn', { external: true })
+      navigateTo('https://discord.gg/5RgZmkW', { external: true })
     },
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the Discord channel links in both the error message and the command palette to ensure users have access to the correct support channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->