### PR TITLE
Nc fix(nc-gui): prefill currency readonly field ui alignment issue

### DIFF
--- a/packages/nc-gui/components/cell/Currency.vue
+++ b/packages/nc-gui/components/cell/Currency.vue
@@ -112,13 +112,14 @@ onMounted(() => {
     </span>
   </div>
   <input
-    v-if="!readOnly && editEnabled"
+    v-if="(!readOnly && editEnabled) || (isForm && !isEditColumn)"
     :ref="focus"
     v-model="vModel"
     type="number"
     class="nc-cell-field h-full text-sm border-none rounded-md py-1 outline-none focus:outline-none focus:ring-0"
     :class="isForm && !isEditColumn ? 'flex flex-1' : 'w-full'"
     :placeholder="isEditColumn ? $t('labels.optional') : ''"
+    :disabled="readOnly"
     @blur="onBlur"
     @keydown.enter="onKeydownEnter"
     @keydown.down.stop


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated visibility conditions and added a disabled state for the currency input field in forms and editable columns, enhancing user interaction and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->