### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/nc-gui/composables/useLoadingIndicator/index.ts
+++ b/packages/nc-gui/composables/useLoadingIndicator/index.ts
@@ -18,7 +18,7 @@ export function useLoadingIndicator({ duration = 2000, throttle = 200 }: UseLoad
     progress.value = 0
     isLoading.value = true
     if (throttle) {
-      if (process.client) {
+      if (import.meta.client) {
         _throttle = setTimeout(_startTimer, throttle)
       }
     } else {
@@ -44,7 +44,7 @@ export function useLoadingIndicator({ duration = 2000, throttle = 200 }: UseLoad
 
   function _hide() {
     clear()
-    if (process.client) {
+    if (import.meta.client) {
       setTimeout(() => {
         isLoading.value = false
         setTimeout(() => {
@@ -55,7 +55,7 @@ export function useLoadingIndicator({ duration = 2000, throttle = 200 }: UseLoad
   }
 
   function _startTimer() {
-    if (process.client) {
+    if (import.meta.client) {
       _timer = setInterval(() => {
         _increase(step.value)
       }, 100)


### PR DESCRIPTION
## Change Summary

This is a very early PR to make this app compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated client-side checks in the loading indicator for enhanced compatibility with the latest environment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->