### PR TITLE
fix: handle body parser error and avoid logging

### DIFF
--- a/packages/nocodb-sdk/src/lib/globals.ts
+++ b/packages/nocodb-sdk/src/lib/globals.ts
@@ -144,6 +144,7 @@ export enum NcErrorType {
   INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR',
   DATABASE_ERROR = 'DATABASE_ERROR',
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+  BAD_JSON = 'BAD_JSON',
 }
 
 type Roles = OrgUserRoles | ProjectRoles | WorkspaceUserRoles;

--- a/packages/nocodb/src/filters/global-exception/global-exception.filter.ts
+++ b/packages/nocodb/src/filters/global-exception/global-exception.filter.ts
@@ -28,6 +28,15 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
+    // catch body-parser error and replace with NcBaseErrorv2
+    if (
+      exception.name === 'BadRequestException' &&
+      exception.status === 400 &&
+      /^Unexpected token .*? in JSON/.test(exception.message)
+    ) {
+      exception = new NcBaseErrorv2(NcErrorType.BAD_JSON);
+    }
+
     // skip unnecessary error logging
     if (
       process.env.NC_ENABLE_ALL_API_ERROR_LOGGING === 'true' ||

--- a/packages/nocodb/src/helpers/catchError.ts
+++ b/packages/nocodb/src/helpers/catchError.ts
@@ -514,6 +514,10 @@ const errorHelpers: {
     message: (feature: string) => `${feature} is not implemented`,
     code: 501,
   },
+  [NcErrorType.BAD_JSON]: {
+    message: 'Invalid JSON in request body',
+    code: 400,
+  },
 };
 
 function generateError(


### PR DESCRIPTION
## Change Summary

Catch body-parser error and return as NcBaseErrorv2 with proper response and avoid logging to console.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
