### PR TITLE
Update copyright to 2024

### DIFF
--- a/packages/nc-gui/components/dashboard/Sidebar/UserInfo.vue
+++ b/packages/nc-gui/components/dashboard/Sidebar/UserInfo.vue
@@ -176,7 +176,7 @@ onMounted(() => {
     </NcDropdown>
 
     <template v-if="isMobileMode"></template>
-    <div v-else-if="appInfo.ee" class="text-gray-500 text-xs pl-3 mt-1">© 2023 NocoDB. Inc</div>
+    <div v-else-if="appInfo.ee" class="text-gray-500 text-xs pl-3 mt-1">© 2024 NocoDB. Inc</div>
     <div v-else class="flex flex-row w-full justify-between pt-0.5 truncate">
       <GeneralJoinCloud />
     </div>


### PR DESCRIPTION
This is a tiny PR. In the sidebar bottom left it still said copyright 2023. This updates it to 2024.

![screenshot 2024-04-09 at 08 59 19](https://github.com/nocodb/nocodb/assets/184567/add2e748-7dfa-4737-8fd4-e7bef72dfe9e)