### PR TITLE
docs: fixed some errors in documentation

### DIFF
--- a/packages/noco-docs/docs/020.getting-started/040.keyboard-shortcuts.md
+++ b/packages/noco-docs/docs/020.getting-started/040.keyboard-shortcuts.md
@@ -34,7 +34,7 @@ Access recently visited views quickly using `⌘` + `L` (or `Ctrl` + `L` on Wind
 
 ![Recent Views](/img/v2/cmd-l.png)
 
-To navigate within ⌘+K menu,
+To navigate within ⌘+L menu,
 - Use `↑` `↓` to navigate between listed items
 - Use `Enter` to select an item
 - Use `Backspace` to move to parent menu
@@ -49,7 +49,7 @@ This feature is available only in NocoDB Cloud hosted version.
 
 Quickly search through docs from within NocoDB UI using `⌘` + `J` (or `Ctrl` + `J` on Windows). Search results will be displayed in a modal window; click on the result to open the page in a new tab.
 
-To navigate within ⌘+K menu,
+To navigate within ⌘+J menu,
 - Use `↑` `↓` to navigate between listed items
 - Use `Enter` to select an item
 - Use `Backspace` to move to parent menu

--- a/packages/noco-docs/docs/040.bases/070.actions-on-base.md
+++ b/packages/noco-docs/docs/040.bases/070.actions-on-base.md
@@ -33,7 +33,7 @@ You can star a base by following simple steps below:
 ![base starred](/img/v2/base/base-starred.png)
 
 :::info
-Starred base will appear in both `Starred` section and `All Bases` section on the left sidebar.
+Starred base will appear in the `Starred` section on the left sidebar.
 :::
 
 ### Remove a base from starred list

--- a/packages/noco-docs/docs/110.roles-and-permissions/010.roles-permissions-overview.md
+++ b/packages/noco-docs/docs/110.roles-and-permissions/010.roles-permissions-overview.md
@@ -15,7 +15,7 @@ You can give a member one of these roles:
 * Viewer 
 
 :::info
-Role for a member, if assigned at base level carry precedence over workspace level role.
+If a role is assigned to a member at the base level, it takes precedence over a role assigned at the workspace level.
 :::
 
 When inviting a user, their role designation is initially assigned but can be modified later. Our role system 
@@ -31,7 +31,7 @@ permissions at the project level to align with specific needs. This dual-level r
 ensures adaptable user permissions and access management in NocoDB.
 
 **Owner**: When a member creates a new Workspace or Base, they automatically become the Workspace or Base "Owner." 
-\This role grants exclusive privileges, including the authority to delete the Workspace or Base. 
+This role grants exclusive privileges, including the authority to delete the Workspace or Base. 
 The "Owner" role's privileges are non-transferable, ensuring ownership and control integrity.
 
 **Creator**: The "Creator" role shares all privileges with an "Owner," except for deleting the workspace or base. 

--- a/packages/noco-docs/docs/120.collaboration/020.base-collaboration.md
+++ b/packages/noco-docs/docs/120.collaboration/020.base-collaboration.md
@@ -6,7 +6,7 @@ keywords: ['NocoDB base', 'base collaboration', 'base context menu', 'base owner
 ---
 
 ## Inviting members to your base
-A member added to a workspace will carry his assigned role specific permissions to all the base with in workspace. To override member permissions to your base, please follow steps outlined below:
+When a member is added to a workspace, they will carry their assigned role-specific permissions to all the bases within the workspace. To override member permissions to your base, please follow steps outlined below:
 
 1. Go to the left sidebar and select `Base name` to access the `Base Dashboard.`
 2. Click on the `Members` tab.


### PR DESCRIPTION
## Change Summary

Corrected typos and improved phrasing of certain sentences for better clarity and readability.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated keyboard shortcuts in the documentation, changing navigation references from `⌘+K` to `⌘+L` and `⌘+J`.
	- Refined the description of where a starred base appears, now specifically noted in the `Starred` section on the left sidebar.
	- Clarified that roles assigned at the base level take precedence over workspace-level assignments and corrected the description of the "Owner" role's privileges.
	- Improved the clarity of instructions for overriding member permissions in a workspace by refining language around member roles and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->