### PR TITLE
Nc fix(nc-gui): group by header is not sticky if we scroll down more than screen height(100vh)

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/GroupBy.vue
+++ b/packages/nc-gui/components/smartsheet/grid/GroupBy.vue
@@ -209,7 +209,7 @@ const shouldRenderCell = (column) =>
     >
       <div
         ref="scrollable"
-        class="flex flex-col h-full"
+        class="flex flex-col"
         :class="{ 'my-2': vGroup.root !== true }"
         :style="`${vGroup.root === true ? 'width: fit-content' : 'width: 100%'}`"
       >


### PR DESCRIPTION
## Change Summary

- ref: #8234 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the CSS styling of the grid component to enhance layout flexibility based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->