### PR TITLE
Nc fix: Groupby pagination layout shift and hide loading text from groupby header

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -2164,7 +2164,7 @@ onKeyStroke('ArrowDown', onDown)
       @apply border-r-1 border-r-gray-200;
     }
 
-    tbody td:nth-child(2) {
+    tbody tr:not(.nc-grid-add-new-cell) td:nth-child(2) {
       position: sticky !important;
       z-index: 4;
       left: 85px;

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -1367,7 +1367,7 @@ onKeyStroke('ArrowDown', onDown)
     </div>
     <div ref="gridWrapper" class="nc-grid-wrapper min-h-0 flex-1 relative" :class="gridWrapperClass">
       <div
-        v-show="isPaginationLoading"
+        v-show="isPaginationLoading && !headerOnly"
         class="flex items-center justify-center absolute l-0 t-0 w-full h-full z-10 pb-10 pointer-events-none"
       >
         <div class="flex flex-col justify-center gap-2">

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -1948,13 +1948,14 @@ onKeyStroke('ArrowDown', onDown)
       :extra-style="paginationStyleRef?.extraStyle"
     >
       <template #add-record>
-        <div v-if="isAddingEmptyRowAllowed && !showSkeleton && !isPaginationLoading" class="flex ml-1">
+        <div v-if="isAddingEmptyRowAllowed && !showSkeleton" class="flex ml-1">
           <NcButton
             v-if="isMobileMode"
             v-e="[isAddNewRecordGridMode ? 'c:row:add:grid' : 'c:row:add:form']"
             class="nc-grid-add-new-row"
             type="secondary"
             @click="onNewRecordToFormClick()"
+            :disabled="isPaginationLoading"
           >
             {{ $t('activity.newRecord') }}
           </NcButton>
@@ -1964,6 +1965,7 @@ onKeyStroke('ArrowDown', onDown)
             class="nc-grid-add-new-row"
             placement="top"
             @click="isAddNewRecordGridMode ? addEmptyRow() : onNewRecordToFormClick()"
+            :disabled="isPaginationLoading"
           >
             <div data-testid="nc-pagination-add-record" class="flex items-center px-2 text-gray-600 hover:text-black">
               <span>


### PR DESCRIPTION
## Change Summary

- ref: #8266 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved the visibility and responsiveness of table elements during loading states and when pagination is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->