### PR TITLE
Auto Upstall Enhancements: Added help script generation

### DIFF
--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -62,6 +62,42 @@ check_for_docker_compose_sudo() {
     fi
 }
 
+# Function to read a number from the user
+read_number() {
+    local number
+    read -p "$1" number
+
+    # Ensure the input is a number or empty
+    while ! [[ $number =~ ^[0-9]+$ ]] && [ -n "$number" ] ; do
+        read -p "Please enter a valid number: " number
+    done
+
+    echo $number
+}
+
+# Function to read a number within a range from the user
+read_number_range() {
+    local number, min, max
+
+    # Check if there are 3 arguments
+    if [ "$#" -ne 3 ]; then
+        number=$(read_number)
+        min=$1
+        max=$2
+    else
+        number=$(read_number "$1")
+        min=$2
+        max=$3
+    fi
+
+    # Ensure the input is in the specified range
+    while [[ -n "$number" && ($number -lt $min || $number -gt $max) ]]; do
+        number=$(read_number "Please enter a number between $min and $max: ")
+    done
+
+    echo $number
+}
+
 # *****************    HELPER FUNCTIONS END  ***********************************
 # ******************************************************************************
 
@@ -213,7 +249,18 @@ else
     message_arr+=("Watchtower: Disabled")
 fi
 
+echo "Show Advanced Options [Y/N] (default: N): "
+read ADVANCED_OPTIONS
 
+if [ -n "$ADVANCED_OPTIONS" ] && { [ "$ADVANCED_OPTIONS" = "Y" ] || [ "$ADVANCED_OPTIONS" = "y" ]; }; then
+    NUM_CORES=$(nproc)
+    echo  "How many instances of NocoDB do you want to run? (Maximum: ${NUM_CORES} (default: 1): "
+    NUM_INSTANCES=$(read_number_range 1 $NUM_CORE
+fi
+
+if [ -z "$NUM_INSTANCES" ]; then
+    NUM_INSTANCES=1
+fi
 
 # ******************************************************************************
 # *********************** INPUTS FROM USER END  ********************************

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -686,6 +686,7 @@ monitoring_service() {
 
 # Main program loop
 while true; do
+    trap - INT
     show_menu
     echo "Enter your choice: "
 

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -252,7 +252,7 @@ echo "Show Advanced Options [Y/N] (default: N): "
 read -r ADVANCED_OPTIONS
 
 if [ -n "$ADVANCED_OPTIONS" ] && { [ "$ADVANCED_OPTIONS" = "Y" ] || [ "$ADVANCED_OPTIONS" = "y" ]; }; then
-    NUM_CORES=$(nproc)
+    NUM_CORES=$(nproc || sysctl -n hw.ncpu || echo 1)
     echo  "How many instances of NocoDB do you want to run (Maximum: ${NUM_CORES}) ? (default: 1): "
     NUM_INSTANCES=$(read_number_range 1 "$NUM_CORES")
 
@@ -640,9 +640,7 @@ show_logs() {
     elif [ "\$log_choice" == "A" ] || [ "\$log_choice" == "a" ]; then
         trap 'show_logs' INT
         $DOCKER_COMMAND compose logs -f
-    elif [ "\$log_choice" == "0" ]; then
-        return
-    else
+    elif [ "\$log_choice" != "0" ]; then
         show_logs
     fi
 
@@ -665,7 +663,7 @@ upgrade_service() {
 
 # Function to scale the service
 scale_service() {
-    num_cores=\$(nproc)
+    num_cores=\$(nproc || sysctl -n hw.ncpu || echo 1)
     current_scale=\$($DOCKER_COMMAND compose ps -q nocodb | wc -l)
     echo -e "\nCurrent number of instances: \$current_scale"
     echo "How many instances of NocoDB do you want to run (Maximum: \${num_cores}) ? (default: 1): "

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -705,7 +705,7 @@ message_arr+=("Help script: help.sh")
 
 cat > ./update.sh <<EOF
 $DOCKER_COMMAND compose pull
-$DOCKER_COMMAND up -d --force-recreate
+$DOCKER_COMMAND compose up -d --force-recreate
 $DOCKER_COMMAND image prune -a -f
 EOF
 

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -543,9 +543,25 @@ $(declare -f read_number)
 
 $(declare -f read_number_range)
 
+check_if_docker_is_running() {
+    yellow="\033[1;33m"
+    nocolor="\033[0m"
+    blue="\033[1;34m"
+
+    if ! $DOCKER_COMMAND ps >/dev/null 2>&1; then
+        echo    "+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-+"
+        echo -e "| \${yellow}Warning !          \${nocolor}                                                       |"
+        echo    "| Docker is not running. Most of the commands will not work without Docker. |"
+        echo    "| Use the following command to start Docker:                                |"
+        echo -e "| \${blue}     sudo systemctl start docker        \${nocolor}                                  |"
+        echo    "+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-+"
+    fi
+}
+
 # Function to display the menu
 show_menu() {
-#    clear
+    clear
+    check_if_docker_is_running
     echo ""
     echo \$MSG
     echo "Service Management Menu:"

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -721,7 +721,7 @@ sleep 5
 if [ "$SSL_ENABLED" = 'y' ] || [ "$SSL_ENABLED" = 'Y' ]; then
   echo 'Starting Letsencrypt certificate request...';
 
-  $DOCKER_COMMAND compose exec certbot certbot certonly --webroot --webroot-path=/var/www/certbot -d "$DOMAIN_NAME" --email contact@"$DOMAIN_NAME" --agree-tos --no-eff-email && echo "Certificate request successful" || echo "Certificate request failed"
+  $DOCKER_COMMAND compose exec certbot certbot certonly --webroot --webroot-path=/var/www/certbot -d "$DOMAIN_NAME" --email "contact@$DOMAIN_NAME" --agree-tos --no-eff-email && echo "Certificate request successful" || echo "Certificate request failed"
   # Initial Let's Encrypt certificate request
 
   # Update the nginx config to use the new certificates

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -580,7 +580,7 @@ show_logs_sub_menu() {
     echo "A. All"
     echo "0. Back to Logs Menu"
     echo "Enter replica number: "
-    read -n 1 replica_choice
+    read replica_choice
 
     if [[ "\$replica_choice" =~ ^[0-9]+\$ ]] && [ "\$replica_choice" -gt 0 ] && [ "\$replica_choice" -le "\$2" ]; then
         container_id=\$($DOCKER_COMMAND compose ps | grep "\$1-\$replica_choice" | cut -d " " -f 1)
@@ -627,7 +627,7 @@ show_logs() {
     echo "A. All"
     echo "0. Back to main menu"
     echo "Enter your choice: "
-    read -n 1 log_choice
+    read log_choice
     echo
 
     if [[ "\$log_choice" =~ ^[0-9]+\$ ]] && [ "\$log_choice" -gt 0 ] && [ "\$log_choice" -lt "\$count" ]; then

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -543,17 +543,23 @@ $(declare -f read_number)
 
 $(declare -f read_number_range)
 
-check_if_docker_is_running() {
-    yellow="\033[1;33m"
-    nocolor="\033[0m"
-    blue="\033[1;34m"
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+MAGENTA='\033[0;35m'
+CYAN='\033[0;36m'
+ORANGE='\033[0;33m'
+BOLD='\033[1m'
+NC='\033[0m'
 
+check_if_docker_is_running() {
     if ! $DOCKER_COMMAND ps >/dev/null 2>&1; then
         echo    "+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-+"
-        echo -e "| \${yellow}Warning !          \${nocolor}                                                       |"
+        echo -e "| \${BOLD}\${YELLOW}Warning !          \${NC}                                                       |"
         echo    "| Docker is not running. Most of the commands will not work without Docker. |"
         echo    "| Use the following command to start Docker:                                |"
-        echo -e "| \${blue}     sudo systemctl start docker        \${nocolor}                                  |"
+        echo -e "| \${BLUE}     sudo systemctl start docker        \${NC}                                  |"
         echo    "+-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-+"
     fi
 }
@@ -564,15 +570,15 @@ show_menu() {
     check_if_docker_is_running
     echo ""
     echo \$MSG
-    echo "Service Management Menu:"
-    echo "1. Start Service"
-    echo "2. Stop Service"
-    echo "3. Logs"
-    echo "4. Restart"
-    echo "5. Upgrade"
-    echo "6. Scale"
-    echo "7. Monitoring"
-    echo "0. Exit"
+    echo -e "\t\t\${BOLD}Service Management Menu\${NC}"
+    echo -e " \${GREEN}1. Start Service"
+    echo -e " \${ORANGE}2. Stop Service"
+    echo -e " \${CYAN}3. Logs"
+    echo -e " \${MAGENTA}4. Restart"
+    echo -e " \${BLUE}5. Upgrade"
+    echo -e " 6. Scale"
+    echo -e " 7. Monitoring"
+    echo -e " \${RED}0. Exit\${NC}"
 }
 
 # Function to start the service
@@ -714,7 +720,7 @@ while true; do
     show_menu
     echo "Enter your choice: "
 
-    read -n 1 choice
+    read choice
     case \$choice in
         1) start_service && MSG="NocoDB Started" ;;
         2) stop_service && MSG="NocoDB Stopped" ;;

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -536,7 +536,7 @@ IS_DOCKER_REQUIRE_SUDO=$(check_for_docker_sudo)
 DOCKER_COMMAND=$([ "$IS_DOCKER_REQUIRE_SUDO" = "y" ] && echo "sudo docker" || echo "docker")
 
 # Generate help script
-cat > nocodb_20240417_131051/help.sh <<EOF
+cat > help.sh <<EOF
 #!/bin/bash
 
 trap show_menu INT
@@ -548,7 +548,7 @@ $(declare -f read_number_range)
 
 # Function to display the menu
 show_menu() {
-#    clear
+    clear
     echo ""
     echo \$MSG
     echo "Service Management Menu:"


### PR DESCRIPTION
## Change Summary

- Created an advanced options menu where the users can set the number of `nocodb` container instances to run
- `noco.sh` now generates a script `help.sh` that helps the user in managing their NocoDB. It provides functionality to
   - Start / Stop / Restart all containers
   - Upgrade NocoaDB to the latest version
   - See logs for each container ( `nocodb`,  `postgres`,  `nginx`, `redis`, `watchtower` )
   - Scale the number of `nocodb` containers
   - Monitor the resource usage

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

The script has been tested in the provided VM and is verified to be working. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the setup script to support running multiple instances of NocoDB.
	- Introduced a service management menu for better user interaction.
	- Improved SSL certificate handling for increased security.
- **Refactor**
	- Updated service configurations for optimized performance.
	- Switched to using Docker commands directly for specific operations, enhancing script efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->