### PR TITLE
fix(nc-gui): use keyup listener to add new row on pressing tab or arrowDown from last row of last page

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -582,12 +582,11 @@ const {
   makeEditable,
   scrollToCell,
   async (e: KeyboardEvent) => {
-    // ignore navigating if picker(Date, Time, DateTime, Year)
-    // or single/multi select options is open
-    const activePickerOrDropdownEl = document.querySelector(
+    // ignore navigating if single/multi select options is open
+    const activeDropdownEl = document.querySelector(
       '.nc-dropdown-single-select-cell.active,.nc-dropdown-multi-select-cell.active',
     )
-    if (activePickerOrDropdownEl) {
+    if (activeDropdownEl) {
       e.preventDefault()
       return true
     }
@@ -633,8 +632,6 @@ const {
         e.preventDefault()
 
         if (paginationDataRef.value?.isLastPage && isAddingEmptyRowAllowed.value) {
-          addEmptyRow()
-          await resetAndChangePage(dataRef.value.length - 1, 0)
           return true
         } else if (!paginationDataRef.value?.isLastPage) {
           await resetAndChangePage(0, 0, 1)
@@ -652,8 +649,6 @@ const {
         e.preventDefault()
 
         if (paginationDataRef.value?.isLastPage && isAddingEmptyRowAllowed.value) {
-          addEmptyRow()
-          await resetAndChangePage(dataRef.value.length - 1, activeCell.col!)
           return true
         } else if (!paginationDataRef.value?.isLastPage) {
           await resetAndChangePage(0, activeCell.col!, 1)
@@ -1193,6 +1188,23 @@ useEventListener(document, 'keyup', async (e: KeyboardEvent) => {
   if (e.key === 'Alt' && !isRichModalOpen) {
     altModifier.value = false
     disableUrlOverlay.value = false
+  }
+
+  const activeDropdownEl = document.querySelector('.nc-dropdown-single-select-cell.active,.nc-dropdown-multi-select-cell.active')
+
+  const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
+
+  if (!isRichModalOpen && !activeDropdownEl && !isDrawerOrModalExist() && !cmdOrCtrl && !e.shiftKey && !e.altKey) {
+    if (
+      (e.key === 'Tab' && activeCell.row === dataRef.value.length - 1 && activeCell.col === fields.value?.length - 1) ||
+      (e.key === 'ArrowDown' &&
+        activeCell.row === dataRef.value.length - 1 &&
+        paginationDataRef.value?.isLastPage &&
+        isAddingEmptyRowAllowed.value)
+    ) {
+      addEmptyRow()
+      await resetAndChangePage(dataRef.value.length - 1, 0)
+    }
   }
 })
 

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -264,6 +264,8 @@ const showContextMenu = (e: MouseEvent, target?: { row: number; col: number }) =
 const isJsonExpand = ref(false)
 provide(JsonExpandInj, isJsonExpand)
 
+const isKeyDown = ref(false)
+
 // #Cell - 1
 
 async function clearCell(ctx: { row: number; col: number } | null, skipUpdate = false) {
@@ -632,6 +634,8 @@ const {
         e.preventDefault()
 
         if (paginationDataRef.value?.isLastPage && isAddingEmptyRowAllowed.value) {
+          isKeyDown.value = true
+
           return true
         } else if (!paginationDataRef.value?.isLastPage) {
           await resetAndChangePage(0, 0, 1)
@@ -649,6 +653,8 @@ const {
         e.preventDefault()
 
         if (paginationDataRef.value?.isLastPage && isAddingEmptyRowAllowed.value) {
+          isKeyDown.value = true
+
           return true
         } else if (!paginationDataRef.value?.isLastPage) {
           await resetAndChangePage(0, activeCell.col!, 1)
@@ -1194,7 +1200,7 @@ useEventListener(document, 'keyup', async (e: KeyboardEvent) => {
 
   const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
 
-  if (!isRichModalOpen && !activeDropdownEl && !isDrawerOrModalExist() && !cmdOrCtrl && !e.shiftKey && !e.altKey) {
+  if (isKeyDown.value && !isRichModalOpen && !activeDropdownEl && !isDrawerOrModalExist() && !cmdOrCtrl && !e.shiftKey && !e.altKey) {
     if (
       (e.key === 'Tab' && activeCell.row === dataRef.value.length - 1 && activeCell.col === fields.value?.length - 1) ||
       (e.key === 'ArrowDown' &&
@@ -1204,6 +1210,7 @@ useEventListener(document, 'keyup', async (e: KeyboardEvent) => {
     ) {
       addEmptyRow()
       await resetAndChangePage(dataRef.value.length - 1, 0)
+      isKeyDown.value = false
     }
   }
 })


### PR DESCRIPTION
## Change Summary

- ref: #7519

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved navigation conditions when select options are open.
	- Removed unnecessary addition of an empty row and page resets under specific conditions.
	- Enhanced key event handling for better user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->