### PR TITLE
Nc fix(nc-gui): Copying and pasting from Excel overwrites one additional row cell

### DIFF
--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -816,7 +816,13 @@ export function useMultiSelect(
     e.preventDefault()
 
     // Replace \" with " in clipboard data
-    const clipboardData = e.clipboardData?.getData('text/plain') || ''
+    let clipboardData = e.clipboardData?.getData('text/plain') || ''
+
+    if (clipboardData?.endsWith('\n')) {
+      // Remove '\n' from the end of the clipboardData
+      clipboardData = clipboardData.replace(/\n$/, '')
+    }
+
     try {
       if (clipboardData?.includes('\n') || clipboardData?.includes('\t')) {
         // if the clipboard data contains new line or tab, then it is a matrix or LongText

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -820,6 +820,8 @@ export function useMultiSelect(
 
     if (clipboardData?.endsWith('\n')) {
       // Remove '\n' from the end of the clipboardData
+      // When copying from XLS/XLSX files, there is an extra '\n' appended to the end
+      //   this overwrites one additional cell information when we paste in NocoDB
       clipboardData = clipboardData.replace(/\n$/, '')
     }
 

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -818,7 +818,7 @@ export function useMultiSelect(
     // Replace \" with " in clipboard data
     let clipboardData = e.clipboardData?.getData('text/plain') || ''
 
-    if (clipboardData?.endsWith('\n') && !clipboardData?.endsWith('\n\n')) {
+    if (clipboardData?.endsWith('\n')) {
       // Remove '\n' from the end of the clipboardData
       clipboardData = clipboardData.replace(/\n$/, '')
     }

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -818,7 +818,7 @@ export function useMultiSelect(
     // Replace \" with " in clipboard data
     let clipboardData = e.clipboardData?.getData('text/plain') || ''
 
-    if (clipboardData?.endsWith('\n')) {
+    if (clipboardData?.endsWith('\n') && !clipboardData?.endsWith('\n\n')) {
       // Remove '\n' from the end of the clipboardData
       clipboardData = clipboardData.replace(/\n$/, '')
     }


### PR DESCRIPTION
## Change Summary

- ref: #2759

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Improved clipboard data handling in multi-select functionality by removing trailing newline characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->