### PR TITLE
fix: fixed input ordering

### DIFF
--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -254,9 +254,7 @@ else
     message_arr+=("Watchtower: Disabled")
 fi
 
-
-
-if [ "$ADVANCED_OPTIONS" = "Y" ] ; then
+if [ "$ADVANCED_OPTIONS" = "y" ] ; then
     NUM_CORES=$(nproc || sysctl -n hw.ncpu || echo 1)
     echo  "How many instances of NocoDB do you want to run (Maximum: ${NUM_CORES}) ? (default: 1): "
     NUM_INSTANCES=$(read_number_range 1 "$NUM_CORES")

--- a/docker-compose/setup-script/noco.sh
+++ b/docker-compose/setup-script/noco.sh
@@ -195,7 +195,7 @@ cd "$FOLDER_NAME" || exit
 # ******************************************************************************
 
 echo "Enter the IP address or domain name for the NocoDB instance (default: $PUBLIC_IP): "
-read DOMAIN_NAME
+read -r DOMAIN_NAME
 
 echo "Show Advanced Options [Y/N] (default: N): "
 read -r ADVANCED_OPTIONS
@@ -207,7 +207,7 @@ fi
 if [ -n "$DOMAIN_NAME" ]; then
   if [ "$ADVANCED_OPTIONS" == "y" ]; then
     echo "Do you want to configure SSL [Y/N] (default: N): "
-    read SSL_ENABLED
+    read -r SSL_ENABLED
     message_arr+=("SSL: ${SSL_ENABLED}")
   fi
 else
@@ -218,7 +218,7 @@ message_arr+=("Domain: $PUBLIC_IP")
 
 if [ "$ADVANCED_OPTIONS" == "y" ]; then
     echo "Choose Community or Enterprise Edition [CE/EE] (default: CE): "
-    read EDITION
+    read -r EDITION
 fi
 
 if [ -n "$EDITION" ] && { [ "$EDITION" = "EE" ] || [ "$EDITION" = "ee" ]; }; then
@@ -233,7 +233,7 @@ fi
 
 if [ "$ADVANCED_OPTIONS" == "y" ]; then
   echo "Do you want to enabled Redis for caching [Y/N] (default: Y): "
-  read REDIS_ENABLED
+  read -r REDIS_ENABLED
 fi
 
 if [ -z "$REDIS_ENABLED" ] || { [ "$REDIS_ENABLED" != "N" ] && [ "$REDIS_ENABLED" != "n" ]; }; then
@@ -245,7 +245,7 @@ fi
 
 if [ "$ADVANCED_OPTIONS" == "y" ]; then
   echo "Do you want to enabled Watchtower for automatic updates [Y/N] (default: Y): "
-  read WATCHTOWER_ENABLED
+  read -r WATCHTOWER_ENABLED
 fi
 
 if [ -z "$WATCHTOWER_ENABLED" ] || { [ "$WATCHTOWER_ENABLED" != "N" ] && [ "$WATCHTOWER_ENABLED" != "n" ]; }; then


### PR DESCRIPTION
## Change Summary

Fixed the ordering of user input in autoinstall script

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Tested and verified to be working in test VM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the NocoDB setup script to provide users with more customization options:
		- Input a domain name.
		- Choose between Community or Enterprise Edition.
		- Enable/disable SSL, Redis caching, and Watchtower for automatic updates.
		- Specify the number of NocoDB instances to run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->