### PR TITLE
fix: copyTable fallback to useCopy with plain text for insecure context

### DIFF
--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -300,7 +300,10 @@ export function useMultiSelect(
     const blobHTML = new Blob([copyHTML], { type: 'text/html' })
     const blobPlainText = new Blob([copyPlainText], { type: 'text/plain' })
 
-    return navigator.clipboard.write([new ClipboardItem({ [blobHTML.type]: blobHTML, [blobPlainText.type]: blobPlainText })])
+    return (
+      navigator.clipboard?.write([new ClipboardItem({ [blobHTML.type]: blobHTML, [blobPlainText.type]: blobPlainText })]) ??
+      copy(copyPlainText)
+    )
   }
 
   async function copyValue(ctx?: Cell) {


### PR DESCRIPTION
## Change Summary

Fixes #8338
- HTTP locations other than localhost treated as insecure by browsers and navigator.clipboard is disabled, add fallback to avoid this issue

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clipboard handling in multi-select functionality to ensure reliability when copying text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->