### PR TITLE
fix: map PostgreSQL 'double precision' correctly as 'float'

### DIFF
--- a/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
@@ -1435,13 +1435,12 @@ export class PgUi {
         return 'date';
       case 'daterange':
         return 'string';
-      case 'double precision':
-        return 'float';
 
       case 'event_trigger':
       case 'fdw_handler':
         return 'string';
 
+      case 'double precision':
       case 'float4':
       case 'float8':
         return 'float';

--- a/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/PgUi.ts
@@ -1436,7 +1436,7 @@ export class PgUi {
       case 'daterange':
         return 'string';
       case 'double precision':
-        return 'string';
+        return 'float';
 
       case 'event_trigger':
       case 'fdw_handler':

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
@@ -114,7 +114,7 @@ class ModelXcMetaPg extends BaseModelXcMeta {
         str = 'date';
         break;
       case 'double precision':
-        str = 'float';
+        str = 'double';
         break;
       case 'event_trigger':
         str = 'event_trigger';

--- a/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
+++ b/packages/nocodb/src/db/sql-mgr/code/models/xc/ModelXcMetaPg.ts
@@ -114,7 +114,7 @@ class ModelXcMetaPg extends BaseModelXcMeta {
         str = 'date';
         break;
       case 'double precision':
-        str = 'double';
+        str = 'float';
         break;
       case 'event_trigger':
         str = 'event_trigger';
@@ -430,13 +430,12 @@ class ModelXcMetaPg extends BaseModelXcMeta {
         return 'date';
       case 'daterange':
         return 'string';
-      case 'double precision':
-        return 'string';
 
       case 'event_trigger':
       case 'fdw_handler':
         return dt;
 
+      case 'double precision':
       case 'float4':
       case 'float8':
         return 'float';


### PR DESCRIPTION
## Change Summary
Fixes https://github.com/nocodb/nocodb/issues/8337

Corrected the data type mapping for PostgreSQL 'double precision' from 'string' to 'float'.

## Change type
- [X] fix: (bug fix for the user, not a fix to a build script)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Enhanced data type handling for 'double precision' to improve accuracy and performance in database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->