### PR TITLE
fix: filter datetime (sqlite / mysql)

### DIFF
--- a/packages/nocodb/src/db/conditionV2.ts
+++ b/packages/nocodb/src/db/conditionV2.ts
@@ -597,12 +597,12 @@ const parseConditionV2 = async (
             UITypes.LastModifiedTime,
           ].includes(column.uidt)
         ) {
-          let now = dayjs(new Date());
+          let now = dayjs(new Date()).utc();
           const dateFormatFromMeta = column?.meta?.date_format;
           if (dateFormatFromMeta && isDateMonthFormat(dateFormatFromMeta)) {
             // reset to 1st
-            now = dayjs(now).date(1);
-            if (val) genVal = dayjs(val).date(1);
+            now = dayjs(now).utc().date(1);
+            if (val) genVal = dayjs(val).utc().date(1);
           }
           // handle sub operation
           switch (filter.comparison_sub_op) {
@@ -668,6 +668,20 @@ const parseConditionV2 = async (
           }
 
           if (dayjs.isDayjs(genVal)) {
+            /**
+             * When you want to compare time, you need to choose whether to measure from the beginning or end of a day.
+             * example
+             * expression: dateTime is after today. value is 'YYYY-MM-DD 23:59:59'.
+             * expression: dateTime is before today. value is 'YYYY-MM-DD 00:00:00'.
+             */
+            if (['gt', 'ge', 'gte'].includes(filter.comparison_op)) {
+              genVal = genVal.endOf('d');
+            }
+            if (
+              ['eq', 'neq', 'lt', 'lt', 'lte'].includes(filter.comparison_op)
+            ) {
+              genVal = genVal.startOf('d');
+            }
             // turn `val` in dayjs object format to string
             genVal = genVal.format(dateFormat).toString();
             // keep YYYY-MM-DD only for date
@@ -713,6 +727,11 @@ const parseConditionV2 = async (
                 (column.uidt === UITypes.Formula &&
                   getEquivalentUIType({ formulaColumn: column }) ==
                     UITypes.DateTime) ||
+                [
+                  UITypes.DateTime,
+                  UITypes.CreatedTime,
+                  UITypes.LastModifiedTime,
+                ].includes(column.uidt) ||
                 column.ct === 'timestamp' ||
                 column.ct === 'date' ||
                 column.ct === 'datetime'
@@ -740,7 +759,9 @@ const parseConditionV2 = async (
                   // else
                   qb = qb.where(knex.raw('??::date = ?', [field, val]));
                 } else {
-                  qb = qb.where(knex.raw('DATE(??) = DATE(?)', [field, val]));
+                  qb = qb.where(
+                    knex.raw("DATE(??, 'localtime') = DATE(?)", [field, val]),
+                  );
                 }
               } else {
                 qb = qb.where(field, val);


### PR DESCRIPTION
## Change Summary

- fix datatime can't filter data, where is today, datetime is now, use date without timezone no error, has timezone will can't filter. under other conditions, it's necessary to consider whether the time point is the beginning or the end of a day.
﻿
- fix mysql can't use datetime filter.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
