### PR TITLE
fix: tweak invite and verify e-mail templates

### DIFF
--- a/packages/nocodb/src/controllers/auth/ui/emailTemplates/invite.ts
+++ b/packages/nocodb/src/controllers/auth/ui/emailTemplates/invite.ts
@@ -132,8 +132,8 @@ export default `<!doctype html>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
                                             Hi,</p>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            I invited you to be "<%- roles -%>" of the NocoDB base "<%- baseName %>".
-                                            Click the button below to to accept my invitation.</p>
+                                            You have been invited to become "<%- roles -%>" of the NocoDB base "<%- baseName %>".
+                                            Click the button below to accept the invitation.</p>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0"
                                                class="btn btn-primary"
                                                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;"
@@ -161,7 +161,7 @@ export default `<!doctype html>
                                             </tbody>
                                         </table>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Thanks regards <%- adminEmail %>.</p>
+                                            Have a nice day,<br><%- adminEmail %></p>
                                     </td>
                                 </tr>
                             </table>

--- a/packages/nocodb/src/controllers/auth/ui/emailTemplates/verify.ts
+++ b/packages/nocodb/src/controllers/auth/ui/emailTemplates/verify.ts
@@ -132,7 +132,7 @@ export default `<!doctype html>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
                                             Hi,</p>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Please verify your email address by clicking the following button.</p>
+                                            Please verify your e-mail address by clicking the following button.</p>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0"
                                                class="btn btn-primary"
                                                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;"
@@ -160,7 +160,7 @@ export default `<!doctype html>
                                             </tbody>
                                         </table>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Thanks regards NocoDB.</p>
+                                            Thank you and have a nice day,<br><%- adminEmail %></p>
                                     </td>
                                 </tr>
                             </table>

--- a/packages/nocodb/src/services/base-users/ui/emailTemplates/invite.ts
+++ b/packages/nocodb/src/services/base-users/ui/emailTemplates/invite.ts
@@ -132,8 +132,8 @@ export default `<!doctype html>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
                                             Hi,</p>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            I invited you to be "<%- roles -%>" of the NocoDB base "<%- baseName %>".
-                                            Click the button below to to accept my invitation.</p>
+                                            You have been invited to become "<%- roles -%>" of the NocoDB base "<%- baseName %>".
+                                            Click the button below to accept the invitation.</p>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0"
                                                class="btn btn-primary"
                                                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;"
@@ -161,7 +161,7 @@ export default `<!doctype html>
                                             </tbody>
                                         </table>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Thanks regards <%- adminEmail %>.</p>
+                                            Have a nice day,<br><%- adminEmail %></p>
                                     </td>
                                 </tr>
                             </table>

--- a/packages/nocodb/src/services/base-users/ui/emailTemplates/verify.ts
+++ b/packages/nocodb/src/services/base-users/ui/emailTemplates/verify.ts
@@ -132,7 +132,7 @@ export default `<!doctype html>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
                                             Hi,</p>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Please verify your email address by clicking the following button.</p>
+                                            Please verify your e-mail address by clicking the following button.</p>
                                         <table role="presentation" border="0" cellpadding="0" cellspacing="0"
                                                class="btn btn-primary"
                                                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;"
@@ -160,7 +160,7 @@ export default `<!doctype html>
                                             </tbody>
                                         </table>
                                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                                            Thanks regards NocoDB.</p>
+                                            Thank you and have a nice day,<br><%- adminEmail %>
                                     </td>
                                 </tr>
                             </table>


### PR DESCRIPTION
## Change Summary

Just some small rewordings / corrections of the invitation and e-mail verification templates.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Untested.

## Additional information / screenshots (optional)

Note that the `<%- baseName %>` placeholder doesn't work, i.e. results in an empty string in the sent e-mail. Unfortuantely, I dunno how to fix this.
