### PR TITLE
chore: move sync action after npm release as it pushes some commits

### DIFF
--- a/.github/workflows/release-nocodb.yml
+++ b/.github/workflows/release-nocodb.yml
@@ -59,11 +59,6 @@ jobs:
     with:
       tag: ${{ needs.process-input.outputs.target_tag }}
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
-  
-  # Create a PR to sync changes back to develop branch from master
-  sync-to-develop:
-    needs: [pr-to-master, process-input]
-    uses: ./.github/workflows/sync-to-develop.yml
 
   # Build, install, publish frontend and backend to npm
   release-npm:
@@ -74,6 +69,11 @@ jobs:
       targetEnv: ${{ github.event.inputs.targetEnv || 'PROD' }}
     secrets:
       NPM_TOKEN: "${{ secrets.NPM_TOKEN }}"
+
+  # Create a PR to sync changes back to develop branch from master
+  sync-to-develop:
+    needs: [release-npm, process-input]
+    uses: ./.github/workflows/sync-to-develop.yml
 
   # Draft Release Note
   release-draft-note:


### PR DESCRIPTION
## Change Summary

- This step have to run after npm release as it also commits into master

## Change type

- [x] chore: (updating grunt tasks etc; no production code change)
