### PR TITLE
Decode field name as utf-8

### DIFF
--- a/packages/nocodb/src/services/public-datas.service.ts
+++ b/packages/nocodb/src/services/public-datas.service.ts
@@ -307,7 +307,9 @@ export class PublicDatasService {
 
     for (const file of param.files || []) {
       // remove `_` prefix and `[]` suffix
-      const fieldName = file?.fieldname?.replace(/^_|\[\d*]$/g, '');
+      const fieldName = Buffer.from(file?.fieldname || '', 'binary')
+        .toString('utf-8')
+        .replace(/^_|\[\d*]$/g, '');
 
       const filePath = sanitizeUrlPath([
         'noco',


### PR DESCRIPTION
## Change Summary

The field names in file attachments were being decoded incorrectly. Added proper `UTF-8` decoding to ensure non-english field names are handled properly.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Additional information / screenshots

[recording-29_05_2024.webm](https://github.com/nocodb/nocodb/assets/45072928/d38b2cb6-e951-4095-add6-a0d47cce16b1)

