### PR TITLE
chore(ovhCloud): use async version of s3Client.upload APIs

### DIFF
--- a/packages/nocodb/src/plugins/ovhCloud/OvhCloud.ts
+++ b/packages/nocodb/src/plugins/ovhCloud/OvhCloud.ts
@@ -20,28 +20,25 @@ export default class OvhCloud implements IStorageAdapterV2 {
       ACL: 'public-read',
       ContentType: file.mimetype,
     };
-    return new Promise((resolve, reject) => {
-      // Configure the file stream and obtain the upload parameters
-      const fileStream = fs.createReadStream(file.path);
-      fileStream.on('error', (err) => {
-        console.log('File Error', err);
-        reject(err);
-      });
 
-      uploadParams.Body = fileStream;
-      uploadParams.Key = key;
-
-      // call S3 to retrieve upload file to specified bucket
-      this.s3Client.upload(uploadParams, (err, data) => {
-        if (err) {
-          console.log('Error', err);
-          reject(err);
-        }
-        if (data) {
-          resolve(data.Location);
-        }
-      });
+    // Configure the file stream and obtain the upload parameters
+    const fileStream = fs.createReadStream(file.path);
+    fileStream.on('error', (err) => {
+      console.log('File Error', err);
+      throw err;
     });
+
+    uploadParams.Body = fileStream;
+    uploadParams.Key = key;
+
+    try {
+      // call S3 to retrieve upload file to specified bucket
+      const data = await this.s3Client.upload(uploadParams).promise();
+      return data.Location;
+    } catch (err) {
+      console.log('Error', err);
+      throw err;
+    }
   }
 
   async fileCreateByUrl(key: string, url: string): Promise<any> {


### PR DESCRIPTION
## Change Summary

Refs: https://github.com/nocodb/nocodb/issues/5150

The async version of s3Client.upload API should be migrated to, before attempting migration to AWS SDK for JavaScript v3.
This draft PR provides an example to maintainers to refer to.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
