### PR TITLE
fix: e-mail verification endpoint path

### DIFF
--- a/packages/nocodb/src/services/users/users.service.ts
+++ b/packages/nocodb/src/services/users/users.service.ts
@@ -485,7 +485,7 @@ export class UsersService {
         html: ejs.render(template, {
           verifyLink:
             (param.req as any).ncSiteUrl +
-            `/email/verify/${user.email_verification_token}`,
+            `/email/validate/${user.email_verification_token}`,
         }),
       });
     } catch (e) {


### PR DESCRIPTION
## Change Summary

The correct API endpoint is [`POST /api/v1/auth/email/validate/{token}`](https://data-apis-v1.nocodb.com/#tag/Auth/operation/auth-email-validate).

fixes #7241
fixes #7473

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Untested.
