### PR TITLE
fix: break synchronous execution of recursive function

### DIFF
--- a/packages/nc-gui/store/notification.ts
+++ b/packages/nc-gui/store/notification.ts
@@ -28,7 +28,7 @@ export const useNotification = defineStore('notificationStore', () => {
         unreadCount.value = unreadCount.value + 1
       }
 
-      await pollNotifications()
+      setTimeout(pollNotifications, 0)
     } catch (e) {
       // If network error, retry after 2 seconds
       setTimeout(pollNotifications, 2000)


### PR DESCRIPTION
## Change Summary

Closes https://github.com/nocodb/nocodb/issues/8760

Previously we were awaiting the pollNotifications recursively causing pending promises growing in the stack causing high cpu usage.
When setTimeout is used, the pollNotifications is placed in the event queue and executed after current execution context.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)


