### PR TITLE
Updated Modal to open as a Side Drawer in Web browser on clicking expand in Table Row

### DIFF
--- a/packages/nc-gui/components/smartsheet/expanded-form/index.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/index.vue
@@ -569,7 +569,7 @@ export default {
 
 <template>
   <component
-    :is="isMobileMode ? Drawer : NcModal"
+    :is="Drawer"
     :body-style="{ padding: 0 }"
     :class="{ active: isExpanded }"
     :closable="false"
@@ -1002,6 +1002,7 @@ export default {
 
   .ant-drawer-content-wrapper {
     @apply !h-[90vh];
+    width: min(30vw, 1280px);
     .ant-drawer-content {
       @apply rounded-t-2xl;
     }
@@ -1110,5 +1111,8 @@ export default {
 }
 :deep(.nc-data-cell .nc-cell-field.nc-lookup-cell .nc-cell-field) {
   @apply px-0;
+}
+.ant-drawer {
+  z-index: 0 !important;
 }
 </style>


### PR DESCRIPTION
NOTE: Not yet fully complete. DO NOT MERGE!!

Updated Modal to open as a Side Drawer in Web browser on clicking expand in Table Row.
Behavior for mobile unchanged. 

## Change Summary

Initial change for the following task:
Updated Modal to open as a Drawer in Web browser on clicking expand in Table Row 
Behavior for mobile unchanged.
[Drawer UI component](https://ant.design/components/drawer)

This is the assignment given for SDE
https://leapx.notion.site/SDE-Assignment-25415c65e73347b6b2d51da3f9133692?pvs=74

for the requirement that the Drawer has to be in the same layer as the Cell, the Z-index for the layers need to be  modified The Z-index values, and the layer stack can be looked by debugging using browser `Inspect Console` 
`Inspect Console` -> `More Tools` -> `Layers` -> `Rotate`
Image given as follows
![Screenshot 2024-07-04 at 1 35 17 AM](https://github.com/nocodb/nocodb/assets/10289181/c1418349-0555-4a50-8cbe-c739b0066d06)
Instruction on how to debug the layers for Z-index values
https://www.youtube.com/watch?v=6je49J67TQk

## Test/ Verification

Table view when expanded, should open 

![Screenshot 2024-07-04 at 1 32 37 AM](https://github.com/nocodb/nocodb/assets/10289181/2e1a9218-8b47-415c-bdcb-106be844a81e)

![Screenshot 2024-07-04 at 1 55 31 AM](https://github.com/nocodb/nocodb/assets/10289181/bbbc77a9-937e-4ea4-9380-561ac9406411)

https://www.notion.so/leapx/SDE-Assignment-25415c65e73347b6b2d51da3f9133692?pvs=4#d1870dbf46c24d81ae8349e18b3eb52b

## Additional information / screenshots (optional)

The behavior of Mobile is maintained.
Behavior Not tested in mobile yet.
