### PR TITLE
fix: #8910 trim extra space during sign in & sign up

### DIFF
--- a/packages/nc-gui/pages/signin.vue
+++ b/packages/nc-gui/pages/signin.vue
@@ -31,7 +31,7 @@ const formRules: Record<string, RuleObject[]> = {
     {
       validator: (_: unknown, v: string) => {
         return new Promise((resolve, reject) => {
-          if (!v?.length || validateEmail(v)) return resolve()
+          if (!v?.length || validateEmail(v.trim())) return resolve()
 
           reject(new Error(t('msg.error.signUpRules.emailInvalid')))
         })

--- a/packages/nc-gui/pages/signup/[[token]].vue
+++ b/packages/nc-gui/pages/signup/[[token]].vue
@@ -37,7 +37,7 @@ const formRules = {
     {
       validator: (_: unknown, v: string) => {
         return new Promise((resolve, reject) => {
-          if (!v?.length || validateEmail(v)) return resolve()
+          if (!v?.length || validateEmail(v.trim())) return resolve()
 
           reject(new Error(t('msg.error.signUpRules.emailInvalid')))
         })


### PR DESCRIPTION
## Change Summary

Fixes trim issues in signin and signup pages.

## Change type

fix: Bug: SignIn/SignUp -- trim extra spaces if any #8910 

## Test/ Verification
Now, there is no such trim error in signin/signup pages.

![image](https://github.com/user-attachments/assets/367c3f85-6416-43e9-85eb-4c54d1d42e9d)

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
