### PR TITLE
fix: 'Create View' button appearing through sharing link of Base #9055

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView/ViewsList.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ViewsList.vue
@@ -32,6 +32,8 @@ const { isUIAllowed } = useRoles()
 
 const { isMobileMode } = useGlobal()
 
+const { isSharedBase } = storeToRefs(useBase())
+
 const { $e } = useNuxtApp()
 
 const { t } = useI18n()
@@ -400,6 +402,7 @@ function onOpenModal({
     :selected-keys="selected"
     class="nc-views-menu flex flex-col w-full !border-r-0 !bg-inherit"
   >
+  <template v-if="!isSharedBase">
     <DashboardTreeViewCreateViewBtn
       v-if="isUIAllowed('viewCreateOrEdit')"
       :align-left-level="isDefaultSource ? 1 : 2"
@@ -429,7 +432,7 @@ function onOpenModal({
         </div>
       </div>
     </DashboardTreeViewCreateViewBtn>
-
+  </template>
     <template v-if="views.length">
       <DashboardTreeViewViewsNode
         v-for="view of views"


### PR DESCRIPTION
## Change Summary
Added a check for the 'isSharedBase' to determine whether the 'Create Views' button would appear when sharing user's Base. The button will now only appear if the ifSharedBase value is false meaning that it will not appear in the Base share version.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
Untested.

## Additional information / screenshots (optional)

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c07e76f9-5b4c-426e-8a8c-bd9dddb45bdc">

