### PR TITLE
fix: disable adding columns to all view on creation

### DIFF
--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -593,7 +593,7 @@ export default class View implements ViewType {
       fk_column_id: param.fk_column_id,
       fk_model_id: param.fk_model_id,
       order: param.order,
-      show: param.column_show.show,
+      show: false,
     };
     const views = await this.list(context, param.fk_model_id, ncMeta);
 
@@ -631,8 +631,6 @@ export default class View implements ViewType {
           (c) => c.show && !isSystemColumn(colIdMap.get(c.fk_column_id)),
         ).length;
         modifiedInsertObj.show = visibleColumnsCount < 3;
-      } else if (view.type !== ViewTypes.FORM) {
-        modifiedInsertObj.show = true;
       }
 
       if (param.column_order?.view_id === view.id) {

--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -611,26 +611,10 @@ export default class View implements ViewType {
         fk_view_id: view.id,
       };
 
-      if (param.column_show?.view_id === view.id) {
-        modifiedInsertObj.show = true;
-      } else if (view.uuid) {
+      if (view.uuid) {
         // if view is shared, then keep the show state as it is
-      }
-      // if gallery/kanban view, show only 3 columns(excluding system columns)
-      else if (view.type === ViewTypes.GALLERY) {
-        const visibleColumnsCount = (
-          await GalleryViewColumn.list(context, view.id, ncMeta)
-        )?.filter(
-          (c) => c.show && !isSystemColumn(colIdMap.get(c.fk_column_id)),
-        ).length;
-        modifiedInsertObj.show = visibleColumnsCount < 3;
-      } else if (view.type === ViewTypes.KANBAN) {
-        const visibleColumnsCount = (
-          await KanbanViewColumn.list(context, view.id, ncMeta)
-        )?.filter(
-          (c) => c.show && !isSystemColumn(colIdMap.get(c.fk_column_id)),
-        ).length;
-        modifiedInsertObj.show = visibleColumnsCount < 3;
+      } else if (param.column_show?.view_id === view.id) {
+        modifiedInsertObj.show = true;
       }
 
       if (param.column_order?.view_id === view.id) {


### PR DESCRIPTION
## Change Summary

When a new column is added, it automatically gets added to all the views and enabled. 
This disables this. The column will be shown only for the view from where it is created, others has to be manually enabled from fieldList

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)