### PR TITLE
fix: thumbnail errors & path

### DIFF
--- a/packages/nocodb/src/plugins/s3/S3.ts
+++ b/packages/nocodb/src/plugins/s3/S3.ts
@@ -43,7 +43,8 @@ export default class S3 implements IStorageAdapterV2 {
       const response = await axios.get(url, {
         httpAgent: useAgent(url, { stopPortScanningByUrlRedirection: true }),
         httpsAgent: useAgent(url, { stopPortScanningByUrlRedirection: true }),
-        responseType: 'stream',
+        // TODO add an extra options argument to pass responseType & use stream for non-image files
+        responseType: 'arraybuffer',
       });
 
       uploadParams.Body = response.data;


### PR DESCRIPTION
## Change Summary

- call generate thumbnail job only for image attachments (instead of filtering inside the job, this way we will get better statistics & less number of jobs)
- thumbnail errors & path
- temporarily use arraybuffer for S3 as well to calculate image dimensions

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
