### PR TITLE
🖱 Add `title` attribute to `AdvancedOptions.vue` on mouse hover

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/AdvancedOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/AdvancedOptions.vue
@@ -40,6 +40,7 @@ vModel.value.au = !!vModel.value.au */
             v-model:checked="vModel.rqd"
             :disabled="vModel.pk || !sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-NN"
+            title="Not Null"
             @change="onAlter"
           />
         </a-form-item>
@@ -49,6 +50,7 @@ vModel.value.au = !!vModel.value.au */
             v-model:checked="vModel.pk"
             :disabled="!sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-PK"
+            title="Primary Key"
             @change="onAlter"
           />
         </a-form-item>
@@ -58,16 +60,17 @@ vModel.value.au = !!vModel.value.au */
             v-model:checked="vModel.ai"
             :disabled="sqlUi.colPropUNDisabled(vModel) || !sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-AI"
+            title="Auto Increment"
             @change="onAlter"
           />
         </a-form-item>
 
         <a-form-item label="UN" :disabled="sqlUi.colPropUNDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
-          <a-checkbox v-model:checked="vModel.un" class="nc-column-checkbox-UN" />
+          <a-checkbox v-model:checked="vModel.un" class="nc-column-checkbox-UN" title="Unsigned" />
         </a-form-item>
 
         <a-form-item label="AU" :disabled="sqlUi.colPropAuDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
-          <a-checkbox v-model:checked="vModel.au" class="nc-column-checkbox-AU" />
+          <a-checkbox v-model:checked="vModel.au" class="nc-column-checkbox-AU" title="Auto Update" />
         </a-form-item>
       </div>
 

--- a/packages/nc-gui/components/smartsheet/column/AdvancedOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/AdvancedOptions.vue
@@ -35,42 +35,54 @@ vModel.value.au = !!vModel.value.au */
   <div class="p-4 border-[0.1px] radius-1 rounded-lg border-grey w-full flex flex-col gap-2">
     <template v-if="props.advancedDbOptions">
       <div class="flex justify-between w-full gap-1">
-        <a-form-item label="NN">
+        <a-form-item>
+          <template #label>
+            <span title="Not Null">NN</span>
+          </template>
           <a-checkbox
             v-model:checked="vModel.rqd"
             :disabled="vModel.pk || !sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-NN"
-            title="Not Null"
             @change="onAlter"
           />
         </a-form-item>
 
-        <a-form-item label="PK">
+        <a-form-item>
+          <template #label>
+            <span title="Primary Key">PK</span>
+          </template>
           <a-checkbox
             v-model:checked="vModel.pk"
             :disabled="!sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-PK"
-            title="Primary Key"
             @change="onAlter"
           />
         </a-form-item>
 
-        <a-form-item label="AI">
+        <a-form-item>
+          <template #label>
+            <span title="Auto Increment">AI</span>
+          </template>
           <a-checkbox
             v-model:checked="vModel.ai"
             :disabled="sqlUi.colPropUNDisabled(vModel) || !sqlUi.columnEditable(vModel)"
             class="nc-column-checkbox-AI"
-            title="Auto Increment"
             @change="onAlter"
           />
         </a-form-item>
 
-        <a-form-item label="UN" :disabled="sqlUi.colPropUNDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
-          <a-checkbox v-model:checked="vModel.un" class="nc-column-checkbox-UN" title="Unsigned" />
+        <a-form-item :disabled="sqlUi.colPropUNDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
+          <template #label>
+            <span title="Unsigned">UN</span>
+          </template>
+          <a-checkbox v-model:checked="vModel.un" class="nc-column-checkbox-UN" />
         </a-form-item>
 
-        <a-form-item label="AU" :disabled="sqlUi.colPropAuDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
-          <a-checkbox v-model:checked="vModel.au" class="nc-column-checkbox-AU" title="Auto Update" />
+        <a-form-item :disabled="sqlUi.colPropAuDisabled(vModel) || !sqlUi.columnEditable(vModel)" @change="onAlter">
+          <template #label>
+            <span title="Auto Update">AU</span>
+          </template>
+          <a-checkbox v-model:checked="vModel.au" class="nc-column-checkbox-AU" />
         </a-form-item>
       </div>
 


### PR DESCRIPTION
## Change Summary

Add `title` attribute to `AdvancedOptions.vue` to display the full name of the helper columns on mouse hover.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)