### PR TITLE
fix: properly export looked up attachments

### DIFF
--- a/packages/nocodb/src/helpers/dataHelpers.ts
+++ b/packages/nocodb/src/helpers/dataHelpers.ts
@@ -167,16 +167,17 @@ export async function serializeCellValue(
         }
 
         if (!Array.isArray(data)) {
-          data = undefined;
+          data = [data];
         }
       } catch {
         data = undefined;
       }
 
       return (data || [])
+        .filter((attachment) => attachment)
         .map(
           (attachment) =>
-            `${encodeURI(attachment.title)}(${encodeURI(
+            `${encodeURI(attachment.title || 'Attachment')}(${encodeURI(
               attachment.signedPath
                 ? `${siteUrl}/${attachment.signedPath}`
                 : attachment.signedUrl,

--- a/packages/nocodb/src/helpers/dataHelpers.ts
+++ b/packages/nocodb/src/helpers/dataHelpers.ts
@@ -177,7 +177,7 @@ export async function serializeCellValue(
         .filter((attachment) => attachment)
         .map(
           (attachment) =>
-            `${encodeURI(attachment.title || 'Attachment')}(${encodeURI(
+            `${attachment.title || 'Attachment'}(${encodeURI(
               attachment.signedPath
                 ? `${siteUrl}/${attachment.signedPath}`
                 : attachment.signedUrl,


### PR DESCRIPTION
## Change Summary

Lookup for mm or hm will be an array but we wrap bt with array as well to unify.
Issue here is we store attachment as json array as well and we are using `Array.isArray(value) ? value : [value]` which skips wrapping as it is already an array and send nested value as an object instead of array of objects.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
