### PR TITLE
docs: move `NC_ATTACHMENT_EXPIRE_SECONDS` to storage block

### DIFF
--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
@@ -40,6 +40,7 @@ For production use cases, it is crucial to set all environment variables marked 
 | `NC_ATTACHMENT_FIELD_SIZE` | No | Maximum file size allowed for [attachments](/fields/field-types/custom-types/attachment/) in bytes.                                                                                          | Defaults to `20971520` (20 MiB).        |
 | `NC_MAX_ATTACHMENTS_ALLOWED` | No | Maximum number of attachments allowed per cell.                                                                                                                                              | Defaults to `10`.                       |
 | `NC_SECURE_ATTACHMENTS` | No | Enables access to attachments only through pre-signed URLs. Set to `true` to activate; all other values are treated as `false`. ⚠ Note: Enabling this will make existing links inaccessible. | Defaults to `false`.                    |
+| `NC_ATTACHMENT_EXPIRE_SECONDS` | No | Time in seconds after which pre-signed URLs for attachments start to expire. The actual expiration will occur after this time plus an additional 10 minutes. Only effective if `NC_SECURE_ATTACHMENTS` is enabled. | Defaults to `7200` (2 hours). |
 
 ## Email Notifications
 - The following SMTP variables are used to send email notifications to users, e.g., invites.
@@ -84,7 +85,6 @@ For production use cases, it is crucial to set all environment variables marked 
 | `NC_INVITE_ONLY_SIGNUP` | No | Disables public signup; signup is possible only via invitations. Integrated into the [super admin settings menu](/account-settings/oss-specific-details#enable--disable-signup) as of version 0.99.0. | |
 | `NC_REQUEST_BODY_SIZE` | No | Maximum size of the request body, based on [ExpressJS limits](https://expressjs.com/en/resources/middleware/body-parser.html#limit). | Defaults to `1048576` (approximately 1 MB). |
 | `NC_EXPORT_MAX_TIMEOUT` | No | Sets a timeout in milliseconds for downloading CSVs in batches if not completed within this period. | Defaults to `5000` (5 seconds). |
-| `NC_ATTACHMENT_EXPIRE_SECONDS` | No | Time in seconds after which pre-signed URLs for attachments start to expire. The actual expiration will occur after this time plus an additional 10 minutes. | Defaults to `7200` (2 hours). |
 | `NC_ALLOW_LOCAL_HOOKS` | No | Allows webhooks to call local network links, posing potential security risks. Set to `true` to enable; all other values are considered `false`. | Defaults to `false`. |
 | `NC_SANITIZE_COLUMN_NAME` | No | Enables sanitization of column names during their creation to prevent SQL injection and other security issues. | Defaults to `true`. |
 | `NC_TOOL_DIR` | No | Specifies the directory to store metadata and app-related files. In Docker setups, this maps to `/usr/app/data/` for mounting volumes. | Defaults to the current working directory. |

--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
@@ -40,7 +40,7 @@ For production use cases, it is crucial to set all environment variables marked 
 | `NC_ATTACHMENT_FIELD_SIZE` | No | Maximum file size allowed for [attachments](/fields/field-types/custom-types/attachment/) in bytes.                                                                                          | Defaults to `20971520` (20 MiB).        |
 | `NC_MAX_ATTACHMENTS_ALLOWED` | No | Maximum number of attachments allowed per cell.                                                                                                                                              | Defaults to `10`.                       |
 | `NC_SECURE_ATTACHMENTS` | No | Enables access to attachments only through pre-signed URLs. Set to `true` to activate; all other values are treated as `false`. ⚠ Note: Enabling this will make existing links inaccessible. | Defaults to `false`.                    |
-| `NC_ATTACHMENT_EXPIRE_SECONDS` | No | Time in seconds after which pre-signed URLs for attachments start to expire. The actual expiration will occur after this time plus an additional 10 minutes. Only effective if `NC_SECURE_ATTACHMENTS` is enabled. | Defaults to `7200` (2 hours). |
+| `NC_ATTACHMENT_EXPIRE_SECONDS` | No | Time in seconds after which pre-signed URLs for attachments start to expire. The actual expiration will occur after this time plus an additional 10 minutes. Only applicable if `NC_SECURE_ATTACHMENTS` is enabled. | Defaults to `7200` (2 hours). |
 
 ## Email Notifications
 - The following SMTP variables are used to send email notifications to users, e.g., invites.


### PR DESCRIPTION
## Change Summary

move `NC_ATTACHMENT_EXPIRE_SECONDS` to storage block and clarify that it only takes effect if `NC_SECURE_ATTACHMENTS` is enabled.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
