### PR TITLE
fix: Clear store values only after redirecting to SignIn page

### DIFF
--- a/packages/nc-gui/components/account/ResetPassword.vue
+++ b/packages/nc-gui/components/account/ResetPassword.vue
@@ -46,9 +46,9 @@ const passwordChange = async () => {
 
   message.success(t('msg.success.passwordChanged'))
 
-  await signOut()
-
-  await navigateTo('/signin')
+  await signOut({
+    redirectToSignin: true,
+  })
 }
 
 const resetError = () => {

--- a/packages/nc-gui/components/account/Setup.vue
+++ b/packages/nc-gui/components/account/Setup.vue
@@ -73,6 +73,7 @@ onMounted(async () => {
       <div class="flex flex-col gap-6 w-150">
         <div
           v-for="config of configs"
+          :key="config.key"
           class="flex flex-col border-1 rounded-2xl border-gray-200 p-6 gap-2 hover:(shadow bg-gray-10)"
           :class="{
             'cursor-pointer': config.itemClick,

--- a/packages/nc-gui/components/dashboard/Sidebar/UserInfo.vue
+++ b/packages/nc-gui/components/dashboard/Sidebar/UserInfo.vue
@@ -22,12 +22,10 @@ const logout = async () => {
   try {
     const isSsoUser = !!(user?.value as any)?.sso_client_id
 
-    await signOut(false)
-
-    // No need as all stores are cleared on signout
-    // await clearWorkspaces()
-
-    await navigateTo(isSsoUser ? '/sso' : '/signin')
+    await signOut({
+      redirectToSignin: true,
+      signinUrl: isSsoUser ? '/sso' : '/signin',
+    })
   } catch (e) {
     console.error(e)
   } finally {

--- a/packages/nc-gui/components/general/MiniSidebar.vue
+++ b/packages/nc-gui/components/general/MiniSidebar.vue
@@ -10,8 +10,9 @@ const route = useRoute()
 const email = computed(() => user.value?.email ?? '---')
 
 const logout = async () => {
-  await signOut(false)
-  await navigateTo('/signin')
+  await signOut({
+    redirectToSignin: true,
+  })
 }
 </script>
 

--- a/packages/nc-gui/composables/useApi/interceptors.ts
+++ b/packages/nc-gui/composables/useApi/interceptors.ts
@@ -124,9 +124,9 @@ export function addAxiosInterceptors(api: Api<any>) {
           })
         })
         .catch(async (refreshTokenError) => {
-          await state.signOut()
-
-          if (!route.value.meta.public) navigateTo('/signIn')
+          await state.signOut({
+            redirectToSignin: !route.value.meta.public,
+          })
 
           // reject the refresh token promise and reset
           refreshTokenPromiseRej(refreshTokenError)

--- a/packages/nc-gui/composables/useGlobal/actions.ts
+++ b/packages/nc-gui/composables/useGlobal/actions.ts
@@ -1,5 +1,5 @@
 import { getActivePinia } from 'pinia'
-import type { Actions, AppInfo, State } from './types'
+import type { Actions, AppInfo, SignOutParams, State } from './types'
 import type { NcProjectType } from '#imports'
 
 export function useGlobalActions(state: State): Actions {
@@ -8,14 +8,19 @@ export function useGlobalActions(state: State): Actions {
   }
 
   /** Sign out by deleting the token from localStorage */
-  const signOut: Actions['signOut'] = async (_skipRedirect = false) => {
+  const signOut: Actions['signOut'] = async ({ redirectToSignin, signinUrl = '/signin' }: SignOutParams = {}) => {
     try {
       const nuxtApp = useNuxtApp()
       await nuxtApp.$api.auth.signout()
     } catch {
+      // ignore error
     } finally {
       state.token.value = null
       state.user.value = null
+
+      if (redirectToSignin) {
+        await navigateTo(signinUrl)
+      }
 
       // clear all stores data on logout
       const pn = getActivePinia()

--- a/packages/nc-gui/composables/useGlobal/types.ts
+++ b/packages/nc-gui/composables/useGlobal/types.ts
@@ -80,9 +80,15 @@ export interface Getters {
   isLoading: WritableComputedRef<boolean>
 }
 
+export interface SignOutParams {
+  redirectToSignin?: boolean
+  signinUrl?: string
+  skipRedirect?: boolean
+}
+
 export interface Actions {
-  signOut: (skipRedirect?: boolean) => void
-  signIn: (token: string, keepProps?: boolean) => void
+  signOut: (signOutParams?: SignOutParams) => Promise<void>
+  signIn: (token: string, keepProps?: boolean) => Promise<void>
   refreshToken: () => void
   loadAppInfo: () => void
   setIsMobileMode: (isMobileMode: boolean) => void

--- a/packages/nc-gui/layouts/base.vue
+++ b/packages/nc-gui/layouts/base.vue
@@ -12,8 +12,9 @@ const hasSider = ref(false)
 const sidebar = ref<HTMLDivElement>()
 
 const logout = async () => {
-  await signOut(false)
-  await navigateTo('/signin')
+  await signOut({
+    redirectToSignin: true,
+  })
 }
 
 const { hooks } = useNuxtApp()

--- a/packages/nc-gui/layouts/new.vue
+++ b/packages/nc-gui/layouts/new.vue
@@ -33,8 +33,9 @@ watch(hasSidebar, (val) => {
 })
 
 const logout = async () => {
-  await signOut(false)
-  await navigateTo('/signin')
+  await signOut({
+    redirectToSignin: true,
+  })
   await clearWorkspaces()
 }
 </script>

--- a/packages/nc-gui/middleware/02.auth.global.ts
+++ b/packages/nc-gui/middleware/02.auth.global.ts
@@ -88,8 +88,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     }
   } else if (to.meta.requiresAuth === false && state.signedIn.value) {
     if (to.query?.logout) {
-      await state.signOut(true)
-      return navigateTo('/signin')
+      await state.signOut({ redirectToSignin: true })
     }
 
     /**

--- a/packages/nc-gui/pages/account/index.vue
+++ b/packages/nc-gui/pages/account/index.vue
@@ -20,8 +20,9 @@ const selectedKeys = computed(() => [
 const openKeys = ref([/^\/account\/users/.test($route.fullPath) && 'users'])
 
 const logout = async () => {
-  await signOut(false)
-  navigateTo('/signin')
+  await signOut({
+    redirectToSignin: true,
+  })
 }
 
 const isSetupPageAllowed = computed(() => isUIAllowed('superAdminSetup') && !isEeUI)


### PR DESCRIPTION
## Change Summary

- On signout clear store values only after redirecting to signin page, otherwise it will try to load project and throw 401 error.
- Re https://github.com/nocodb/nocodb/issues/8922#issuecomment-2322819659

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
