### PR TITLE
fix: handle missing col options for button

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/ButtonOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/ButtonOptions.vue
@@ -26,7 +26,8 @@ const vModel = useVModel(props, 'value', emit)
 
 const meta = inject(MetaInj, ref())
 
-const { isEdit, setAdditionalValidations, validateInfos, sqlUi, column, isWebhookCreateModalOpen } = useColumnCreateStoreOrThrow()
+const { isEdit, setAdditionalValidations, validateInfos, sqlUi, column, isWebhookCreateModalOpen, validate } =
+  useColumnCreateStoreOrThrow()
 
 const uiTypesNotSupportedInFormulas = [UITypes.QrCode, UITypes.Barcode, UITypes.Button]
 
@@ -77,7 +78,7 @@ const validators = {
       validator: (_: any, formula: any) => {
         return (async () => {
           if (vModel.value.type === 'url') {
-            if (!formula?.trim()) throw new Error('Required')
+            if (!formula?.trim()) throw new Error('Formula is required for URL Button')
 
             try {
               await validateFormulaAndExtractTreeWithType({
@@ -191,6 +192,8 @@ if ((column.value?.colOptions as any)?.formula_raw) {
       meta?.value?.columns as ColumnType[],
       (column.value?.colOptions as any)?.formula_raw,
     ) || ''
+} else {
+  vModel.value.formula_raw = ''
 }
 
 const colorClass = {

--- a/packages/nocodb/src/models/Column.ts
+++ b/packages/nocodb/src/models/Column.ts
@@ -503,6 +503,19 @@ export default class Column<T = any> implements ColumnType {
         break;
       case UITypes.Button:
         res = await ButtonColumn.read(context, this.id, ncMeta);
+
+        // add default values if options are missing
+        if (!res) {
+          res = {
+            type: 'url',
+            theme: 'solid',
+            color: 'brand',
+            label: 'Button',
+            error: 'Invalid configuration',
+            formula_raw: '',
+          };
+        }
+
         break;
       case UITypes.QrCode:
         res = await QrCodeColumn.read(context, this.id, ncMeta);


### PR DESCRIPTION
## Change Summary

- Refactor required message
- Return default col options if missing (AT Import includes those without colOptions instead of having a migration lets support this, moving forward we can consider if we want to avoid creating them altogether)

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

