### PR TITLE
fix: avoid trimming of select options in column conversion

### DIFF
--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -684,11 +684,11 @@ export class ColumnsService {
                   }
                 }
                 for (const v of values) {
-                  if (!existingOptions.includes(v.trim())) {
+                  if (!existingOptions.includes(v)) {
                     acc.push({
-                      title: v.trim(),
+                      title: v,
                     });
-                    existingOptions.push(v.trim());
+                    existingOptions.push(v);
                   }
                 }
               }


### PR DESCRIPTION
## Change Summary

Avoid trimming of select options


## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
