### PR TITLE
feat: single query command palette & dedicated cache

### DIFF
--- a/packages/nc-gui/app.vue
+++ b/packages/nc-gui/app.vue
@@ -14,7 +14,7 @@ const disableBaseLayout = computed(() => route.value.path.startsWith('/nc/view')
 
 useTheme()
 
-const { commandPalette, cmdData, cmdPlaceholder, activeScope, loadTemporaryScope, refreshCommandPalette } = useCommandPalette()
+const { commandPalette, cmdData, cmdPlaceholder, activeScope, loadTemporaryScope } = useCommandPalette()
 
 applyNonSelectable()
 useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
@@ -90,12 +90,6 @@ function setActiveCmdView(cmd: CommandPaletteType) {
     )
   }
 }
-
-onMounted(() => {
-  nextTick(() => {
-    refreshCommandPalette()
-  })
-})
 
 // ref: https://github.com/vuejs/vue-cli/issues/7431#issuecomment-1793385162
 // Stop error resizeObserver

--- a/packages/nc-gui/components/cmd-k/index.vue
+++ b/packages/nc-gui/components/cmd-k/index.vue
@@ -44,7 +44,7 @@ const { user } = useGlobal()
 
 const selected = ref<string>()
 
-const { cmdPlaceholder } = useCommandPalette()
+const { cmdPlaceholder, loadScope, cmdLoading } = useCommandPalette()
 
 const formattedData: ComputedRef<(CmdAction & { weight: number })[]> = computed(() => {
   const rt: (CmdAction & { weight: number })[] = []
@@ -206,6 +206,10 @@ const setScope = (scope: string) => {
 const show = () => {
   if (!user.value) return
   if (props.scope === 'disabled') return
+  if (!vOpen.value) {
+    loadScope()
+  }
+
   vOpen.value = true
   cmdInput.value = ''
   nextTick(() => {
@@ -329,46 +333,49 @@ defineExpose({
             <div
               class="text-gray-600 text-sm cursor-pointer flex gap-2 px-2 py-1 items-center justify-center font-medium capitalize"
             >
-              <GeneralWorkspaceIcon
-                v-if="el.icon && el.id.startsWith('ws')"
-                :workspace="{
-                  id: el.id.split('-')[1],
-                  meta: {
-                    color: el.iconColor,
-                  },
-                }"
-                hide-label
-                size="small"
-              />
+              <GeneralLoader v-if="cmdLoading && !el.label" />
+              <template v-else>
+                <GeneralWorkspaceIcon
+                  v-if="el.icon && el.id.startsWith('ws')"
+                  :workspace="{
+                    id: el.id.split('-')[1],
+                    meta: {
+                      color: el.iconColor,
+                    },
+                  }"
+                  hide-label
+                  size="small"
+                />
 
-              <component
-                :is="(iconMap as any)[el.icon]"
-                v-else-if="el.icon && typeof el.icon === 'string' && (iconMap as any)[el.icon]"
-                :class="{
-                  '!text-blue-500': el.icon === 'grid',
-                  '!text-purple-500': el.icon === 'form',
-                  '!text-[#FF9052]': el.icon === 'kanban',
-                  '!text-pink-500': el.icon === 'gallery',
-                  '!text-maroon-500': el.icon === 'calendar',
-                }"
-                class="cmdk-action-icon"
-              />
-              <div v-else-if="el.icon" class="cmdk-action-icon max-w-4 flex items-center justify-center">
-                <LazyGeneralEmojiPicker :emoji="el.icon" class="!text-sm !h-4 !w-4" readonly size="small" />
-              </div>
-              <span
-                class="text-ellipsis truncate capitalize max-w-16"
-                style="word-break: keep-all; white-space: nowrap; display: inline"
-              >
-                <NcTooltip show-on-truncate-only>
-                  <template #title>
-                    {{ el.label }}
-                  </template>
-                  <span class="text-ellipsis max-w-16">
-                    {{ el.label }}
-                  </span>
-                </NcTooltip>
-              </span>
+                <component
+                  :is="(iconMap as any)[el.icon]"
+                  v-else-if="el.icon && typeof el.icon === 'string' && (iconMap as any)[el.icon]"
+                  :class="{
+                    '!text-blue-500': el.icon === 'grid',
+                    '!text-purple-500': el.icon === 'form',
+                    '!text-[#FF9052]': el.icon === 'kanban',
+                    '!text-pink-500': el.icon === 'gallery',
+                    '!text-maroon-500': el.icon === 'calendar',
+                  }"
+                  class="cmdk-action-icon"
+                />
+                <div v-else-if="el.icon" class="cmdk-action-icon max-w-4 flex items-center justify-center">
+                  <LazyGeneralEmojiPicker :emoji="el.icon" class="!text-sm !h-4 !w-4" readonly size="small" />
+                </div>
+                <span
+                  class="text-ellipsis truncate capitalize max-w-16"
+                  style="word-break: keep-all; white-space: nowrap; display: inline"
+                >
+                  <NcTooltip show-on-truncate-only>
+                    <template #title>
+                      {{ el.label }}
+                    </template>
+                    <span class="text-ellipsis max-w-16">
+                      {{ el.label }}
+                    </span>
+                  </NcTooltip>
+                </span>
+              </template>
             </div>
 
             <span class="text-gray-700 text-sm pl-1 font-medium">/</span>
@@ -385,7 +392,10 @@ defineExpose({
       </div>
       <div class="cmdk-body">
         <div class="cmdk-actions nc-scrollbar-md">
-          <div v-if="searchedActionList.length === 0">
+          <div v-if="searchedActionList.length === 0 && cmdLoading" class="w-full h-[250px] flex justify-center items-center">
+            <GeneralLoader :size="30" />
+          </div>
+          <div v-else-if="searchedActionList.length === 0">
             <div class="cmdk-action">
               <div class="cmdk-action-content">No action found.</div>
             </div>

--- a/packages/nc-gui/components/general/Loader.vue
+++ b/packages/nc-gui/components/general/Loader.vue
@@ -2,7 +2,7 @@
 import { LoadingOutlined } from '@ant-design/icons-vue'
 
 const props = defineProps<{
-  size?: 'small' | 'medium' | 'large' | 'xlarge' | 'regular'
+  size?: 'small' | 'medium' | 'large' | 'xlarge' | 'regular' | number
   loaderClass?: string
 }>()
 
@@ -25,6 +25,7 @@ function getFontSize() {
 
 const indicator = h(LoadingOutlined, {
   class: `!${getFontSize()} flex flex-row items-center !bg-inherit !hover:bg-inherit !text-inherit ${props.loaderClass || ''}}`,
+  style: { ...(typeof props.size === 'number' && props.size ? { fontSize: `${props.size}px` } : {}) },
   spin: true,
 })
 </script>

--- a/packages/nocodb/src/helpers/commandPaletteHelpers.ts
+++ b/packages/nocodb/src/helpers/commandPaletteHelpers.ts
@@ -46,6 +46,7 @@ export async function getCommandPaletteForUserWorkspace(
         })
         .where('bu.fk_user_id', userId)
         .andWhereNot('bu.roles', 'no_access')
+        .andWhere('t.mm', false)
         .andWhere(function () {
           this.where('dm.disabled', false).orWhereNull('dm.disabled');
         })

--- a/packages/nocodb/src/helpers/commandPaletteHelpers.ts
+++ b/packages/nocodb/src/helpers/commandPaletteHelpers.ts
@@ -1,0 +1,105 @@
+import { CacheGetType, CacheScope, MetaTable } from '~/utils/globals';
+import Noco from '~/Noco';
+import NocoCache from '~/cache/NocoCache';
+
+export async function getCommandPaletteForUserWorkspace(
+  userId: string,
+  workspaceId: string = 'nc',
+  ncMeta = Noco.ncMeta,
+) {
+  const key = `${CacheScope.CMD_PALETTE}:${userId}:${workspaceId}`;
+
+  let cmdData = await NocoCache.get(key, CacheGetType.TYPE_OBJECT);
+
+  if (!cmdData) {
+    cmdData = {
+      data: await ncMeta
+        .knexConnection(`${MetaTable.PROJECT} as b`)
+        .select(
+          'b.id as base_id',
+          'b.title as base_title',
+          'b.meta as base_meta',
+          'b.order as base_order',
+          'bu.roles as base_role',
+          't.id as table_id',
+          't.title as table_title',
+          't.type as table_type',
+          't.meta as table_meta',
+          't.order as table_order',
+          'v.id as view_id',
+          'v.title as view_title',
+          'v.is_default as view_is_default',
+          'v.type as view_type',
+          'v.meta as view_meta',
+          'v.order as view_order',
+          'dm.disabled',
+        )
+        .innerJoin(
+          `${MetaTable.PROJECT_USERS} as bu`,
+          `bu.fk_workspace_id`,
+          `ws.id`,
+        )
+        .innerJoin(`${MetaTable.PROJECT} as b`, `bu.base_id`, `b.id`)
+        .innerJoin(`${MetaTable.MODELS} as t`, `t.base_id`, `b.id`)
+        .innerJoin(`${MetaTable.VIEWS} as v`, `v.fk_model_id`, `t.id`)
+        .leftJoin(`${MetaTable.MODEL_ROLE_VISIBILITY} as dm`, function () {
+          this.on(`dm.fk_view_id`, `=`, `v.id`).andOn(
+            `dm.role`,
+            `=`,
+            `bu.roles`,
+          );
+        })
+        .where('bu.fk_user_id', userId)
+        .andWhereNot('bu.roles', 'no_access')
+        .andWhere(function () {
+          this.where('dm.disabled', false).orWhereNull('dm.disabled');
+        })
+        .andWhere(function () {
+          this.where('b.deleted', false).orWhereNull('b.deleted');
+        })
+        .andWhere(function () {
+          this.where('t.deleted', false).orWhereNull('t.deleted');
+        }),
+    };
+
+    await NocoCache.set(key, cmdData);
+    // append to lists for later cleanup
+    await NocoCache.set(`${CacheScope.CMD_PALETTE}:ws`, [key]);
+    await NocoCache.set(`${CacheScope.CMD_PALETTE}:user:${userId}`, [key]);
+  }
+
+  return cmdData?.data?.sort((a, b) => {
+    if (a.base_order !== b.base_order) {
+      return (a.base_order ?? Infinity) - (b.base_order ?? Infinity);
+    }
+    if (a.table_order !== b.table_order) {
+      return (a.table_order ?? Infinity) - (b.table_order ?? Infinity);
+    }
+    if (a.view_order !== b.view_order) {
+      return (a.view_order ?? Infinity) - (b.view_order ?? Infinity);
+    }
+    return 0;
+  });
+}
+
+export async function cleanCommandPaletteCache(_ws?: string) {
+  const keys = await NocoCache.get(
+    `${CacheScope.CMD_PALETTE}:ws`,
+    CacheGetType.TYPE_ARRAY,
+  );
+
+  if (keys) {
+    await NocoCache.del([...keys, `${CacheScope.CMD_PALETTE}`]);
+  }
+}
+
+export async function cleanCommandPaletteCacheForUser(userId: string) {
+  const keys = await NocoCache.get(
+    `${CacheScope.CMD_PALETTE}:user:${userId}`,
+    CacheGetType.TYPE_ARRAY,
+  );
+
+  if (keys) {
+    await NocoCache.del([...keys, `${CacheScope.CMD_PALETTE}:${userId}`]);
+  }
+}

--- a/packages/nocodb/src/helpers/commandPaletteHelpers.ts
+++ b/packages/nocodb/src/helpers/commandPaletteHelpers.ts
@@ -34,12 +34,7 @@ export async function getCommandPaletteForUserWorkspace(
           'v.order as view_order',
           'dm.disabled',
         )
-        .innerJoin(
-          `${MetaTable.PROJECT_USERS} as bu`,
-          `bu.fk_workspace_id`,
-          `ws.id`,
-        )
-        .innerJoin(`${MetaTable.PROJECT} as b`, `bu.base_id`, `b.id`)
+        .innerJoin(`${MetaTable.PROJECT_USERS} as bu`, `b.id`, `bu.base_id`)
         .innerJoin(`${MetaTable.MODELS} as t`, `t.base_id`, `b.id`)
         .innerJoin(`${MetaTable.VIEWS} as v`, `v.fk_model_id`, `t.id`)
         .leftJoin(`${MetaTable.MODEL_ROLE_VISIBILITY} as dm`, function () {

--- a/packages/nocodb/src/models/Base.ts
+++ b/packages/nocodb/src/models/Base.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import type { BaseType, BoolType, MetaType } from 'nocodb-sdk';
 import type { DB_TYPES } from '~/utils/globals';
 import type { NcContext } from '~/interface/config';
@@ -14,6 +15,9 @@ import { extractProps } from '~/helpers/extractProps';
 import NocoCache from '~/cache/NocoCache';
 import { parseMetaProp, stringifyMetaProp } from '~/utils/modelUtils';
 import NcConnectionMgrv2 from '~/utils/common/NcConnectionMgrv2';
+import { cleanCommandPaletteCache } from '~/helpers/commandPaletteHelpers';
+
+const logger = new Logger('Base');
 
 export default class Base implements BaseType {
   public id: string;
@@ -94,6 +98,11 @@ export default class Base implements BaseType {
     }
 
     await NocoCache.del(CacheScope.INSTANCE_META);
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
+
     return this.getWithInfo(context, baseId, true, ncMeta).then(
       async (base) => {
         await NocoCache.appendToList(
@@ -297,6 +306,10 @@ export default class Base implements BaseType {
       CacheDelDirection.CHILD_TO_PARENT,
     );
 
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
+
     // set meta
     return await ncMeta.metaUpdate(
       context.workspace_id,
@@ -366,6 +379,10 @@ export default class Base implements BaseType {
       updateObj.meta = stringifyMetaProp(updateObj);
     }
 
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
+
     // set meta
     return await ncMeta.metaUpdate(
       context.workspace_id,
@@ -426,6 +443,10 @@ export default class Base implements BaseType {
         base_id: baseId,
       },
     );
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
 
     return await ncMeta.metaDelete(
       context.workspace_id,

--- a/packages/nocodb/src/models/BaseUser.ts
+++ b/packages/nocodb/src/models/BaseUser.ts
@@ -1,4 +1,5 @@
 import { ProjectRoles } from 'nocodb-sdk';
+import { Logger } from '@nestjs/common';
 import type { BaseType } from 'nocodb-sdk';
 import type User from '~/models/User';
 import type { NcContext } from '~/interface/config';
@@ -14,6 +15,9 @@ import NocoCache from '~/cache/NocoCache';
 import { extractProps } from '~/helpers/extractProps';
 import { parseMetaProp } from '~/utils/modelUtils';
 import { NcError } from '~/helpers/catchError';
+import { cleanCommandPaletteCacheForUser } from '~/helpers/commandPaletteHelpers';
+
+const logger = new Logger('BaseUser');
 
 export default class BaseUser {
   fk_workspace_id?: string;
@@ -73,6 +77,10 @@ export default class BaseUser {
         [d.base_id],
         `${CacheScope.BASE_USER}:${d.base_id}:${d.fk_user_id}`,
       );
+
+      cleanCommandPaletteCacheForUser(d.fk_user_id).catch(() => {
+        logger.error('Error cleaning command palette cache');
+      });
     }
   }
 
@@ -103,6 +111,10 @@ export default class BaseUser {
       [base_id],
       `${CacheScope.BASE_USER}:${base_id}:${fk_user_id}`,
     );
+
+    cleanCommandPaletteCacheForUser(fk_user_id).catch(() => {
+      logger.error('Error cleaning command palette cache');
+    });
 
     return res;
   }
@@ -293,6 +305,10 @@ export default class BaseUser {
       roles,
     });
 
+    cleanCommandPaletteCacheForUser(userId).catch(() => {
+      logger.error('Error cleaning command palette cache');
+    });
+
     return res;
   }
 
@@ -347,6 +363,10 @@ export default class BaseUser {
       `${CacheScope.BASE_USER}:${baseId}:list`,
       CacheDelDirection.PARENT_TO_CHILD,
     );
+
+    cleanCommandPaletteCacheForUser(userId).catch(() => {
+      logger.error('Error cleaning command palette cache');
+    });
 
     return response;
   }

--- a/packages/nocodb/src/models/Model.ts
+++ b/packages/nocodb/src/models/Model.ts
@@ -6,6 +6,7 @@ import {
   ViewTypes,
 } from 'nocodb-sdk';
 import dayjs from 'dayjs';
+import { Logger } from '@nestjs/common';
 import type { BoolType, TableReqType, TableType } from 'nocodb-sdk';
 import type { XKnex } from '~/db/CustomKnex';
 import type { LinksColumn, LinkToAnotherRecordColumn } from '~/models/index';
@@ -27,11 +28,14 @@ import NocoCache from '~/cache/NocoCache';
 import Noco from '~/Noco';
 import { BaseModelSqlv2 } from '~/db/BaseModelSqlv2';
 import { FileReference } from '~/models';
+import { cleanCommandPaletteCache } from '~/helpers/commandPaletteHelpers';
 import {
   parseMetaProp,
   prepareForDb,
   prepareForResponse,
 } from '~/utils/modelUtils';
+
+const logger = new Logger('Model');
 
 export default class Model implements TableType {
   copy_enabled: BoolType;
@@ -218,6 +222,10 @@ export default class Model implements TableType {
       [baseId],
       `${CacheScope.MODEL}:${id}`,
     );
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
 
     return modelRes;
   }
@@ -615,6 +623,11 @@ export default class Model implements TableType {
       `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.title}`,
       `${CacheScope.MODEL_ALIAS}:${this.base_id}:${this.source_id}:${this.title}`,
     ]);
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
+
     return true;
   }
 
@@ -777,6 +790,10 @@ export default class Model implements TableType {
       `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.title}`,
       `${CacheScope.MODEL_ALIAS}:${oldModel.base_id}:${oldModel.source_id}:${oldModel.title}`,
     ]);
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
 
     // clear all the cached query under this model
     await View.clearSingleQueryCache(context, tableId, null, ncMeta);

--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -4,6 +4,7 @@ import {
   UITypes,
   ViewTypes,
 } from 'nocodb-sdk';
+import { Logger } from '@nestjs/common';
 import type { BoolType, ColumnReqType, ViewType } from 'nocodb-sdk';
 import type { NcContext } from '~/interface/config';
 import Model from '~/models/Model';
@@ -39,8 +40,11 @@ import {
   stringifyMetaProp,
 } from '~/utils/modelUtils';
 import { LinkToAnotherRecordColumn } from '~/models';
+import { cleanCommandPaletteCache } from '~/helpers/commandPaletteHelpers';
 
 const { v4: uuidv4 } = require('uuid');
+
+const logger = new Logger('View');
 
 /*
 type ViewColumn =
@@ -552,6 +556,10 @@ export default class View implements ViewType {
       { modelId: view.fk_model_id },
       ncMeta,
     );
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
 
     return View.get(context, view_id, ncMeta).then(async (v) => {
       await NocoCache.appendToList(
@@ -1306,6 +1314,10 @@ export default class View implements ViewType {
     // on update, delete any optimised single query cache
     await View.clearSingleQueryCache(context, view.fk_model_id, [view], ncMeta);
 
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
+
     return view;
   }
 
@@ -1390,6 +1402,10 @@ export default class View implements ViewType {
     }
     // on update, delete any optimised single query cache
     await View.clearSingleQueryCache(context, view.fk_model_id, [view], ncMeta);
+
+    cleanCommandPaletteCache(context.workspace_id).catch(() => {
+      logger.error('Failed to clean command palette cache');
+    });
 
     await Model.getNonDefaultViewsCountAndReset(
       context,

--- a/packages/nocodb/src/services/command-palette.service.ts
+++ b/packages/nocodb/src/services/command-palette.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { type UserType, ViewTypes } from 'nocodb-sdk';
-import { BaseUser } from '~/models';
-import { TablesService } from '~/services/tables.service';
 import { deserializeJSON } from '~/utils/serialize';
+import { getCommandPaletteForUserWorkspace } from '~/helpers/commandPaletteHelpers';
 
 const viewTypeAlias: Record<number, string> = {
   [ViewTypes.GRID]: 'grid',
@@ -15,79 +14,128 @@ const viewTypeAlias: Record<number, string> = {
 
 @Injectable()
 export class CommandPaletteService {
-  constructor(private tablesService: TablesService) {}
+  constructor() {}
 
   async commandPalette(param: { body: any; user: UserType }) {
     const cmdData = [];
     try {
-      const allBases = [];
+      const list: {
+        base_id: string;
+        base_title: string;
+        base_meta: string;
+        base_role: string;
+        table_id: string;
+        table_title: string;
+        table_type: string;
+        table_meta: string;
+        view_id: string;
+        view_title: string;
+        view_is_default: boolean;
+        view_type: string;
+        view_meta: string;
+      }[] = await getCommandPaletteForUserWorkspace(param.user?.id);
 
-      const bases = await BaseUser.getProjectsList(param.user.id, param);
+      const bases = new Map<
+        string,
+        {
+          id: string;
+          title: string;
+          meta: any;
+        }
+      >();
+      const tables = new Map<
+        string,
+        {
+          id: string;
+          title: string;
+          base_id: string;
+          type: string;
+          meta: any;
+        }
+      >();
+      const views = new Map<
+        string,
+        {
+          id: string;
+          title: string;
+          base_id: string;
+          table_id: string;
+          is_default: boolean;
+          type: string;
+          meta: any;
+        }
+      >();
 
-      allBases.push(...bases);
+      for (const item of list) {
+        if (!bases.has(item.base_id)) {
+          bases.set(item.base_id, {
+            id: item.base_id,
+            title: item.base_title,
+            meta: deserializeJSON(item.base_meta),
+          });
+        }
 
-      const viewList = [];
+        if (!tables.has(item.table_id)) {
+          tables.set(item.table_id, {
+            id: item.table_id,
+            title: item.table_title,
+            meta: deserializeJSON(item.table_meta),
+            base_id: item.base_id,
+            type: item.table_type,
+          });
+        }
 
-      for (const base of bases) {
-        viewList.push(
-          ...(
-            (await this.tablesService.xcVisibilityMetaGet(
-              { workspace_id: base.fk_workspace_id, base_id: base.id },
-              base.id,
-              null,
-              false,
-            )) as any[]
-          ).filter((v) => {
-            return Object.keys(param.user.roles).some(
-              (role) => param.user.roles[role] && !v.disabled[role],
-            );
-          }),
-        );
+        if (!views.has(item.view_id)) {
+          views.set(item.view_id, {
+            id: item.view_id,
+            title: item.view_title,
+            meta: deserializeJSON(item.view_meta),
+            base_id: item.base_id,
+            table_id: item.table_id,
+            is_default: item.view_is_default,
+            type: item.view_type,
+          });
+        }
       }
 
-      const tableList = [];
-      const vwList = [];
-
-      for (const b of allBases) {
+      for (const [id, base] of bases) {
         cmdData.push({
-          id: `p-${b.id}`,
-          title: b.title,
+          id: `p-${id}`,
+          title: base.title,
           icon: 'project',
-          iconColor: deserializeJSON(b.meta)?.iconColor,
+          iconColor: deserializeJSON(base.meta)?.iconColor,
           section: 'Bases',
         });
       }
 
-      for (const v of viewList) {
-        if (!tableList.find((el) => el.id === `tbl-${v.fk_model_id}`)) {
-          tableList.push({
-            id: `tbl-${v.fk_model_id}`,
-            title: v._ptn,
-            parent: `p-${v.base_id}`,
-            icon: v?.table_meta?.icon || v.ptype,
-            projectName: bases.find((el) => el.id === v.base_id)?.title,
-            section: 'Tables',
-          });
-        }
-        vwList.push({
-          id: `vw-${v.id}`,
-          title: `${v.title}`,
-          parent: `tbl-${v.fk_model_id}`,
-          icon: v?.meta?.icon || viewTypeAlias[v.type] || 'table',
-          projectName: bases.find((el) => el.id === v.base_id)?.title,
+      for (const [id, table] of tables) {
+        cmdData.push({
+          id: `tbl-${id}`,
+          title: table.title,
+          parent: `p-${table.base_id}`,
+          icon: table?.meta?.icon || table.type,
+          projectName: bases.get(table.base_id)?.title,
+          section: 'Tables',
+        });
+      }
+
+      for (const [id, view] of views) {
+        cmdData.push({
+          id: `vw-${id}`,
+          title: `${view.title}`,
+          parent: `tbl-${view.table_id}`,
+          icon: view?.meta?.icon || viewTypeAlias[view.type] || 'table',
+          projectName: bases.get(view.base_id)?.title,
           section: 'Views',
-          is_default: v?.is_default,
+          is_default: view.is_default,
           handler: {
             type: 'navigate',
-            payload: `/nc/${v.base_id}/${v.fk_model_id}/${encodeURIComponent(
-              v.id,
+            payload: `/nc/${view.base_id}/${view.table_id}/${encodeURIComponent(
+              id,
             )}`,
           },
         });
       }
-
-      cmdData.push(...tableList);
-      cmdData.push(...vwList);
     } catch (e) {
       console.log(e);
       return [];

--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -186,6 +186,7 @@ export enum CacheScope {
   EXTENSION = 'uiExtension',
   INTEGRATION = 'integration',
   COL_BUTTON = 'colButton',
+  CMD_PALETTE = 'cmdPalette',
 }
 
 export enum CacheGetType {


### PR DESCRIPTION
## Change Summary

- Get all required information for command palette in single query
- Cache single query response separately (per user / ws)

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)