### PR TITLE
fix: compose configuration generation

### DIFF
--- a/docker-compose/1_Auto_Upstall/noco.sh
+++ b/docker-compose/1_Auto_Upstall/noco.sh
@@ -497,7 +497,7 @@ generate_credentials() {
 create_docker_compose_file() {
 
     if [ "${CONFIG_EDITION}" = "EE" ] || [ "${CONFIG_EDITION}" = "ee" ]; then
-        image="nocodb/ee:latest"
+        image="nocodb/nocodb-ee:latest"
     else
         image="nocodb/nocodb:latest"
     fi

--- a/docker-compose/1_Auto_Upstall/noco.sh
+++ b/docker-compose/1_Auto_Upstall/noco.sh
@@ -496,11 +496,20 @@ generate_credentials() {
 
 create_docker_compose_file() {
 
-  image="nocodb/nocodb:latest"
+    if [ "${CONFIG_EDITION}" = "EE" ] || [ "${CONFIG_EDITION}" = "ee" ]; then
+        image="nocodb/ee:latest"
+    else
+        image="nocodb/nocodb:latest"
+    fi
 
-  if [ "${CONFIG_EDITION}" = "EE" ] || [ "${CONFIG_EDITION}" = "ee" ]; then
-    image="nocodb/ee:latest"
-  fi
+
+    # for easier string interpolation
+    if [ "${CONFIG_REDIS_ENABLED}" = "Y" ]; then
+        gen_redis=1
+    fi
+    if [ "${CONFIG_MINIO_ENABLED}" = "Y" ]; then
+        gen_minio=1
+    fi
 
     local compose_file="docker-compose.yml"
 
@@ -514,8 +523,8 @@ services:
       replicas: ${CONFIG_NUM_INSTANCES}
     depends_on:
       - db
-      ${CONFIG_REDIS_ENABLED:+- redis}
-      ${CONFIG_MINIO_ENABLED:+- minio}
+      ${gen_redis:+- redis}
+      ${gen_minio:+- minio}
     restart: unless-stopped
     volumes:
       - ./nocodb:/usr/app/data
@@ -674,10 +683,14 @@ fi
 EOF
     fi
 
-    cat >> "$compose_file" <<EOF
+    if [ "$CONFIG_REDIS_ENABLED" = "Y" ]; then
+cat >> "$compose_file" <<EOF
 volumes:
-  ${CONFIG_REDIS_ENABLED:+redis:}
+    redis:
+EOF
+    fi
 
+cat >> "$compose_file" <<EOF
 networks:
   nocodb-network:
     driver: bridge

--- a/docker-compose/1_Auto_Upstall/noco.sh
+++ b/docker-compose/1_Auto_Upstall/noco.sh
@@ -636,7 +636,6 @@ EOF
       - "traefik.http.routers.minio.rule=Host(\`${CONFIG_MINIO_DOMAIN_NAME}\`)"
 EOF
 # If minio SSL is enabled, set the entry point to websecure
-fi
     if [ "$CONFIG_MINIO_SSL_ENABLED" = "Y" ]; then
         cat >> "$compose_file" <<EOF
       - "traefik.http.routers.minio.entrypoints=websecure"
@@ -660,6 +659,7 @@ EOF
       - nocodb-network
 
 EOF
+fi
     if [ "${CONFIG_WATCHTOWER_ENABLED}" = "Y" ]; then
         cat >> "$compose_file" <<EOF
   watchtower:


### PR DESCRIPTION
## Change Summary
- closes #9533 
${parameter:+word} always expands word when parameter is set

## Change type
- [x] fix: compose configuration generation

## Test/ Verification
validated with docker bin
docker compose config > /dev/null; echo $?
> 0