### PR TITLE
fix: skip trimming options while applying filter

### DIFF
--- a/packages/nocodb/src/db/conditionV2.ts
+++ b/packages/nocodb/src/db/conditionV2.ts
@@ -927,7 +927,14 @@ const parseConditionV2 = async (
             {
               // Condition for filter, without negation
               const condition = (builder: Knex.QueryBuilder) => {
-                const items = val?.split(',').map((item) => item.trim());
+                let items = val?.split(',');
+                // remove trailing space if database is MySQL and datatype is enum/set
+                if (
+                  ['mysql2', 'mysql'].includes(knex.clientType()) &&
+                  ['enum', 'set'].includes(column.dt?.toLowerCase())
+                ) {
+                  items = items.map((item) => item.trimEnd());
+                }
                 for (let i = 0; i < items?.length; i++) {
                   let sql;
                   const bindings = [field, `%,${items[i]},%`];


### PR DESCRIPTION
## Change Summary

- Skip trimming options while applying filter
- If MySQL and datatype is Enum/Set then trim trailing whitespace

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
