### PR TITLE
ColumnFilter ToolBar Correctly Show I18n string and LanguageAlias for zh_Hans

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -667,7 +667,7 @@ const changeToDynamic = async (filter, i) => {
                       >
                         <a-select-option v-for="op in logicalOps" :key="op.value" :value="op.value">
                           <div class="flex items-center w-full justify-between w-full gap-2">
-                            <div class="truncate flex-1 capitalize">{{ op.value }}</div>
+                            <div class="truncate flex-1 capitalize">{{ op.text }}</div>
                             <component
                               :is="iconMap.check"
                               v-if="filter.logical_op === op.value"
@@ -719,7 +719,7 @@ const changeToDynamic = async (filter, i) => {
             >
               <a-select-option v-for="op of logicalOps" :key="op.value" :value="op.value">
                 <div class="flex items-center w-full justify-between w-full gap-2">
-                  <div class="truncate flex-1 capitalize">{{ op.value }}</div>
+                  <div class="truncate flex-1 capitalize">{{ op.text }}</div>
                   <component
                     :is="iconMap.check"
                     v-if="filter.logical_op === op.value"

--- a/packages/nc-gui/lib/enums.ts
+++ b/packages/nc-gui/lib/enums.ts
@@ -39,7 +39,7 @@ export enum Language {
 }
 
 export enum LanguageAlias {
-  zn_CN = 'zh-Hans',
+  zh_CN = 'zh-Hans',
   zh_TW = 'zh-Hant',
 }
 


### PR DESCRIPTION
## Change Summary

patch #9574 ColumnFilter ToolBar Correctly Show I18n string 
LanguageAlias for zh_Hans

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

this is a minor patch, tested on windows, ColumnFilter  Correctly Show I18n "and"/"or"   string.


