### PR TITLE
Add service Label to NocoDB image for compatibility with Kamal

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -135,6 +135,8 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           push: true
+          labels: |
+            "service=nocodb"
           tags: |
             nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:${{ steps.get-docker-repository.outputs.DOCKER_BUILD_TAG }}
             nocodb/${{ steps.get-docker-repository.outputs.DOCKER_REPOSITORY }}:${{ steps.get-docker-repository.outputs.DOCKER_BUILD_LATEST_TAG }}


### PR DESCRIPTION
## Change Summary

### Problem
The currently published NocoDB image is incompatible with [Kamal](https://kamal-deploy.org/) out of the box. This is due to Kamal requiring a service label to be attached to the image.

```
  ERROR (SSHKit::Command::Failed): Exception while executing on host 5.78.123.98: docker exit status: 1
docker stdout: Image nocodb/nocodb:0.257.0 is missing the 'service' label
docker stderr: Nothing written
```

### Solution
This PR adds a `service=nocodb` label to future image builds. This is a harmless addition that ensures NocoDB can be deployed using Kamal without needing to rebuild the image and host it independently. It also simplifies future upgrades, as users will no longer have to manually pull the latest image, label it, and push it to their own repositories.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
