### PR TITLE
enhancement: increase file size limit to 25MB in QuickImport.vue (ref: #5858)

### DIFF
--- a/packages/nc-gui/components/dlg/QuickImport.vue
+++ b/packages/nc-gui/components/dlg/QuickImport.vue
@@ -318,9 +318,9 @@ const customReqCbk = (customReqArgs: { file: any; onSuccess: () => void }) => {
 
 /** check if the file size exceeds the limit */
 const beforeUpload = (file: UploadFile) => {
-  const exceedLimit = file.size! / 1024 / 1024 > 5
+  const exceedLimit = file.size! / 1024 / 1024 > 25
   if (exceedLimit) {
-    message.error(`File ${file.name} is too big. The accepted file size is less than 5MB.`)
+    message.error(`File ${file.name} is too big. The accepted file size is less than 25MB.`)
   }
   return !exceedLimit || Upload.LIST_IGNORE
 }


### PR DESCRIPTION
## Change Summary

This PR increases the file size limit for uploads from 5MB to 25MB in QuickImport.vue.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

1. Manually tested the file upload functionality by attempting to upload files larger than 5MB but less than 25MB.
2. Verified that files larger than 25MB are rejected with an appropriate error message.

## Additional information / screenshots (optional)

N/A
