### PR TITLE
Add fallback mechanism in decrypt upgrader

### DIFF
--- a/packages/noco-docs/docs/100.data-sources/050.updating-secret.md
+++ b/packages/noco-docs/docs/100.data-sources/050.updating-secret.md
@@ -37,7 +37,7 @@ To update a secret in NocoDB, you can use the `nc-secret-mgr` package. Follow th
 
 Alternatively, you can use the `nc-secret-mgr` executable to update secrets.
 
-1. Download the `nc-secret-mgr` executable from the [NocoDB website](https://github.com/nocodb/nc-secret-mgr/releases/latest).
+1. Download the `nc-secret-mgr` executable from the [NocoDB Github](https://github.com/nocodb/nc-secret-mgr/releases/latest).
 2. Run the executable using the following command:
 
    ```bash

--- a/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
+++ b/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
@@ -41,9 +41,7 @@ const decryptConfigWithFallbackKey = async ({
     return parsedVal === null ? null : decryptedVal;
   } catch (e) {
     if (fallbackSecret) {
-      logger.log(
-        'Falling back to fallback secret since decryption failed with primary secret',
-      );
+      logger.log('Retrying decryption with a fallback mechanism');
       return decryptConfigWithFallbackKey({
         encryptedConfig,
         secret: fallbackSecret,

--- a/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
+++ b/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
@@ -34,8 +34,8 @@ const decryptConfigWithFallbackKey = async ({
     // validate by parsing JSON
     try {
       parsedVal = JSON.parse(decryptedVal);
-    } catch {
-      throw new Error('JSON parse failed');
+    } catch (parseError) {
+      throw new Error(`JSON parse failed: ${parseError.message}`);
     }
     // if parsed value is null, return null
     return parsedVal === null ? null : decryptedVal;

--- a/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
+++ b/packages/nocodb/src/version-upgrader/upgraders/0225002_ncDatasourceDecrypt.ts
@@ -63,7 +63,7 @@ export default async function ({ ncMeta }: NcUpgraderCtx) {
   logger.log('Starting decryption of sources and integrations');
 
   let encryptionKey = process.env.NC_AUTH_JWT_SECRET;
-  let fallbackEncryptionKey: string = null;
+  let fallbackEncryptionKey: string | null = null;
 
   const encryptionKeyFromMeta = (
     await ncMeta.metaGet(RootScopes.ROOT, RootScopes.ROOT, MetaTable.STORE, {


### PR DESCRIPTION
## Change Summary

- Re #9653
- If decryption failed with environment variable then fallbacks to store table value if available
- If meta db source on failure fallback the config value to null since the value of config is encrypted json string `null`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
