### PR TITLE
fix: show self referencing belongs to

### DIFF
--- a/packages/nocodb/src/helpers/columnHelpers.ts
+++ b/packages/nocodb/src/helpers/columnHelpers.ts
@@ -65,8 +65,7 @@ export async function createHmAndBtColumn(
       fk_parent_column_id: parentColumn?.id || parent.primaryKey.id,
       fk_related_model_id: parent.id,
       virtual,
-      // if self referencing treat it as system field to hide from ui
-      system: isSystemCol || parent.id === child.id,
+      system: isSystemCol,
       fk_col_name: fkColName,
       fk_index_name: fkColName,
       ...(type === 'bt' ? colExtra : {}),


### PR DESCRIPTION
closes: #8958

## Change Summary

Change visibility of self referencing belongs to in ui, see #8958.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

1. Create a self referencing "Links" column (with "Has Many" relation type).
2. Two columns should be created and displayed on ui, one for the `has-many` side, another for the `belongs-to` side of the relation.

## Additional information

According to previously implemented code comment, self referencing belongs to were purposely hidden from ui, but i don't figure out why, any idea?
