### PR TITLE
refactor: Additional informations added on Airtable Import feature th…

### DIFF
--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -352,7 +352,8 @@ export class ColumnsService {
         exclude_id: param.columnId,
       }))
     ) {
-      NcError.badRequest('Duplicate column alias');
+      // This error will be thrown if there are more than one column linking to the same table. You have to delete one of them
+      NcError.badRequest(`Duplicate column alias for table ${table.title} and column is ${param.column.title}. Please change the name of this column and retry.`);
     }
 
     let colBody = { ...param.column } as Column & {


### PR DESCRIPTION

<img width="726" alt="Screenshot 2024-10-30 at 11 05 48 AM" src="https://github.com/user-attachments/assets/88858720-9bfc-49fb-b8ad-b2c25d126cbe">
…at tells which column in which table was Duplicate column alias. Issue Refs: #8798

## Change Summary

Provide summary of changes with issue number if any.
When you import from airtable if there are more than 2 columns with type "link to other record" that point to same table you will have the error Duplicate column alias, but you will not be able to tell in which table or which column is duplicated. So I have added the logs that will show you exactly which table and which column is duplicate so you can go in Airtable and delete the one that is duplicated since there is no sense to have 2 columns that are linked to same record.

In screenshot you can see how it was and how it is.

Issue Refs: #8798

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [x] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

No functionality was changed.

## Additional information / screenshots (optional)

Added screenshots
