### PR TITLE
chore: update Node.js builder image

### DIFF
--- a/packages/nocodb/Dockerfile
+++ b/packages/nocodb/Dockerfile
@@ -17,7 +17,7 @@ RUN cp $GOPATH/bin/litestream /usr/src/lt
 ###########
 # Builder
 ###########
-FROM node:18.19.1-alpine as builder
+FROM node:18-alpine as builder
 WORKDIR /usr/src/app
 
 # install node-gyp dependencies

--- a/packages/nocodb/Dockerfile.local
+++ b/packages/nocodb/Dockerfile.local
@@ -3,7 +3,7 @@
 ###########
 # Builder
 ###########
-FROM node:18.19.1-alpine as builder
+FROM node:18-alpine as builder
 WORKDIR /usr/src/app
 
 # install node-gyp dependencies

--- a/packages/nocodb/Dockerfile.timely
+++ b/packages/nocodb/Dockerfile.timely
@@ -20,7 +20,7 @@ RUN git clone https://github.com/benbjohnson/litestream.git litestream \
 ###########
 # Builder
 ###########
-FROM --platform=$BUILDPLATFORM node:18.19.1-alpine as builder
+FROM --platform=$BUILDPLATFORM node:18-alpine as builder
 WORKDIR /usr/src/app
 
 # Install node-gyp dependencies


### PR DESCRIPTION
## Change Summary

[`node:18.20.4-alpine`](https://hub.docker.com/_/node) is currently the latest tag of the v18 major release line. To lower update maintenance burden and automatically pick up the latest minor release, just use the `node:18-alpine` tag.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

None.