### PR TITLE
chore: update runner image

### DIFF
--- a/packages/nocodb/Dockerfile
+++ b/packages/nocodb/Dockerfile
@@ -47,7 +47,7 @@ RUN pnpm install --prod --shamefully-hoist \
 ##########
 # Runner
 ##########
-FROM alpine:3.19
+FROM alpine:3.20
 WORKDIR /usr/src/app
 
 ENV LITESTREAM_S3_SKIP_VERIFY=false \

--- a/packages/nocodb/Dockerfile.local
+++ b/packages/nocodb/Dockerfile.local
@@ -35,7 +35,7 @@ RUN pnpm install --prod --shamefully-hoist --reporter=silent \
 ##########
 # Runner
 ##########
-FROM alpine:3.19
+FROM alpine:3.20
 WORKDIR /usr/src/app
 
 ENV NC_DOCKER=0.6 \

--- a/packages/nocodb/Dockerfile.timely
+++ b/packages/nocodb/Dockerfile.timely
@@ -66,7 +66,7 @@ RUN SQLITE3_VERSION=$(jq -r '.dependencies["sqlite3"]' /usr/src/app/package-copy
 ###########
 # Runner
 ###########
-FROM --platform=$TARGETPLATFORM alpine:3.19
+FROM --platform=$TARGETPLATFORM alpine:3.20
 WORKDIR /usr/src/app
 
 ENV LITESTREAM_S3_SKIP_VERIFY=false \


### PR DESCRIPTION
## Change Summary

Update Alpine Linux runner image to v3.20. It ships the same version (v20.15.1) of Node.js than v3.19.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

None.