### PR TITLE
fix(GCS): set the response headers accordingly

### DIFF
--- a/packages/nocodb/src/plugins/gcs/Gcs.ts
+++ b/packages/nocodb/src/plugins/gcs/Gcs.ts
@@ -179,7 +179,8 @@ export default class Gcs implements IStorageAdapterV2 {
       version: 'v4',
       action: 'read',
       expires: Date.now() + expiresInSeconds * 1000,
-      extensionHeaders: pathParameters,
+      responseDisposition: pathParameters?.ResponseContentDisposition,
+      responseType: pathParameters?.ResponseContentType
     };
 
     const [url] = await this.storageClient


### PR DESCRIPTION
## Change Summary

use the appropriate properties for setting the response headers in options object when requesting the signed url (based on the GetSignedUrlConfig interface).

Reference:
https://cloud.google.com/nodejs/docs/reference/storage/latest/storage/getsignedurlconfig

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Additional information / screenshots (optional)

I setup Google Cloud Storage as my Storage Provider.
While the files would get uploaded correctly in the Google Cloud Storage Bucket,
when retrieving the file I encountered issue ref: #9350. I was getting the following `400 Bad Request` response from Google Storage API: 
```xml
<Error>
<Code>MalformedSecurityHeader</Code>
<Message>Invalid argument.</Message>
<Details>Your request has a malformed header. Header was included in signedheaders, but not in the request.</Details>
<ParameterName>responsecontentdisposition</ParameterName>
</Error>
```

That's when I started to checkout the signedURL generation, and updated the `GetSignedUrlConfig` object being passed as options when calling getSignedUrl from Google Cloud Storage Client, as they are defined in the reference i have provided above.

With this addition it respects the Content-Type and Content-Disposition headers, as they get set correctly on the response from Google Cloud Storage, and getting the files from the bucket works without resolving a Bad Request.