### PR TITLE
chore(release-pr): update `upload-artifact` action to v4

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -107,7 +107,7 @@ jobs:
           envsubst < .github/uffizzi/docker-compose.uffizzi.yml > docker-compose.rendered.yml
           cat docker-compose.rendered.yml
       - name: Upload Rendered Compose File as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: docker-compose.rendered.yml
@@ -118,7 +118,7 @@ jobs:
           ${{ toJSON(github.event) }}
           EOF
       - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: event.json
@@ -174,7 +174,7 @@ jobs:
 
           EOF
       - name: Upload PR Event as Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: preview-spec
           path: event.json

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Upload Rendered Compose File as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: preview-spec
+          name: preview-spec-docker-compose
           path: docker-compose.rendered.yml
           retention-days: 2
       - name: Serialize PR Event to File
@@ -120,7 +120,7 @@ jobs:
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: preview-spec
+          name: preview-spec-event
           path: event.json
           retention-days: 2
 
@@ -176,6 +176,7 @@ jobs:
       - name: Upload PR Event as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: preview-spec
+          name: preview-spec-event
           path: event.json
           retention-days: 2
+          overwrite: true

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -20,31 +20,14 @@ jobs:
     steps:
       - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
-        uses: actions/github-script@v6
+        uses: actions/download-artifact@v4
         with:
-          script: |
-            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               run_id: context.payload.workflow_run.id,
-            });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "preview-spec"
-            })[0];
-            if (matchArtifact === undefined) {
-              throw TypeError('Build Artifact not found!');
-            }
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
-            });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+          path: preview-spec
+          pattern: preview-spec-*
+          merge-multiple: true
 
       - name: 'Accept event from first stage'
-        run: unzip preview-spec.zip event.json
+        run: cp preview-spec/event.json .
 
       - name: Read Event into ENV
         id: event
@@ -58,7 +41,7 @@ jobs:
         # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
         run: |
-          unzip preview-spec.zip docker-compose.rendered.yml
+          cp preview-spec/docker-compose.rendered.yml .
           echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
 
       - name: Cache Rendered Compose File


### PR DESCRIPTION
## Change Summary

v3 of `actions/upload-artifact` and `actions/download-artifact` will be fully deprecated by **30 January 2025**. Jobs that are scheduled to run during the brownout periods will also fail. See:

1. https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
2. https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/
3. https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#artifacts-v3-brownouts

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
