### PR TITLE
fix: webhook trigger on link column update

### DIFF
--- a/packages/nc-gui/components/webhook/index.vue
+++ b/packages/nc-gui/components/webhook/index.vue
@@ -44,7 +44,7 @@ const testConnectionError = ref('')
 const useForm = Form.useForm
 
 let hookRef = reactive<
-  Omit<HookType, 'notification'> & { notification: Record<string, any>; eventOperation?: string; condition: boolean }
+  Omit<HookType, 'notification'> & { notification: Record<string, any>; eventOperation?: string; condition: boolean;   }
 >({
   id: '',
   title: defaultHookName,
@@ -64,6 +64,8 @@ let hookRef = reactive<
   condition: false,
   active: true,
   version: 'v2',
+  triggerOnLinkColumnUpdate: false,
+
 })
 
 const isBodyShown = ref(hookRef.version === 'v1' || isEeUI)
@@ -376,6 +378,10 @@ async function saveHooks() {
   }
 
   try {
+    ///dont enable triggerOnLinkedTable for events other than update
+    if(hookRef.eventOperation !== 'after update'){
+hookRef.triggerOnLinkColumnUpdate = false;
+    }
     let res
     if (hookRef.id) {
       res = await api.dbTableWebhook.update(hookRef.id, {
@@ -864,6 +870,9 @@ onMounted(async () => {
                 </NcSwitch>
               </div>
 
+
+              
+
               <LazySmartsheetToolbarColumnFilter
                 v-if="hookRef.condition"
                 ref="filterRef"
@@ -876,7 +885,12 @@ onMounted(async () => {
                 @update:filters-length="hookRef.condition = $event > 0"
               />
             </div>
-
+            <div >
+              <div class="w-full cursor-pointer flex items-center" @click.prevent="hookRef.triggerOnLinkColumnUpdate = !hookRef.triggerOnLinkColumnUpdate">
+                <NcSwitch  v-if="hookRef.eventOperation == 'after update'"   :checked="Boolean(hookRef.triggerOnLinkColumnUpdate)" class="nc-check-box-hook-trigger-on-link">
+                  <span class="!text-gray-700 font-semibold"> {{ $t('general.triggerOnLinkedTablesUpdates') }} </span>
+                </NcSwitch>
+              </div> </div>
             <a-form-item v-if="formInput[hookRef.notification.type] && hookRef.notification.payload">
               <div class="flex flex-col gap-4">
                 <div v-for="(input, i) in formInput[hookRef.notification.type]" :key="i">

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -293,6 +293,8 @@
     "languages": "Languages",
     "extension": "Extension",
     "extensions": "Extensions",
+    "triggerOnLinkedTablesUpdates": "Trigger on Link Column update"
+,
     "enable": "Enable",
     "poweredBy": "Powered by",
     "nocoAI": "Noco AI",

--- a/packages/nocodb-sdk/src/lib/Api.ts
+++ b/packages/nocodb-sdk/src/lib/Api.ts
@@ -11839,6 +11839,11 @@ export class Api<
          * @example download/noco/jango_fett/Table1/attachment/uVbjPVQxC_SSfs8Ctx.jpg
          */
         path: string;
+        /**
+         * The scope of the attachment
+         * @example workspacePics
+         */
+        scope?: 'workspacePics' | 'profilePics' | 'organizationPics';
       },
       data: {
         files: FileReqType[];
@@ -11869,6 +11874,11 @@ export class Api<
          * @example download/noco/jango_fett/Table1/attachment/c7z_UF8sZBgJUxMjpN.jpg
          */
         path: string;
+        /**
+         * The scope of the attachment
+         * @example workspacePics
+         */
+        scope?: 'workspacePics' | 'profilePics' | 'organizationPics';
       },
       data: AttachmentReqType[],
       params: RequestParams = {}

--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -6633,7 +6633,10 @@ class BaseModelSqlv2 {
     });
   }
 
-  public async beforeUpdate(data: any, _trx: any, req): Promise<void> {
+  public async beforeUpdate(data: any, _trx: any, req,
+    fromLinkColUpdate: boolean | null  = false,
+
+  ): Promise<void> {
     const ignoreWebhook = req.query?.ignoreWebhook;
     if (ignoreWebhook) {
       if (ignoreWebhook != 'true' && ignoreWebhook != 'false') {
@@ -6641,16 +6644,19 @@ class BaseModelSqlv2 {
       }
     }
     if (ignoreWebhook === undefined || ignoreWebhook === 'false') {
-      await this.handleHooks('before.update', null, data, req);
+      await this.handleHooks('before.update', null, data, req , fromLinkColUpdate);
     }
   }
 
   public async afterUpdate(
     prevData: any,
     newData: any,
+
     _trx: any,
     req,
     updateObj?: Record<string, any>,
+  fromLinkColUpdate: boolean | null  = false,
+
   ): Promise<void> {
     const id = this.extractPksValues(newData);
     let desc = `Record with ID ${id} has been updated in Table ${this.model.title}.`;
@@ -6695,7 +6701,7 @@ class BaseModelSqlv2 {
       }
     }
     if (ignoreWebhook === undefined || ignoreWebhook === 'false') {
-      await this.handleHooks('after.update', prevData, newData, req);
+      await this.handleHooks('after.update', prevData, newData, req , fromLinkColUpdate);
     }
   }
 
@@ -6723,7 +6729,9 @@ class BaseModelSqlv2 {
     await this.handleHooks('after.delete', null, data, req);
   }
 
-  protected async handleHooks(hookName, prevData, newData, req): Promise<void> {
+  protected async handleHooks(hookName, prevData, newData, req,
+    fromLinkColUpdate: boolean | null  = false,
+  ): Promise<void> {
     Noco.eventEmitter.emit(HANDLE_WEBHOOK, {
       context: this.context,
       hookName,
@@ -6733,6 +6741,7 @@ class BaseModelSqlv2 {
       viewId: this.viewId,
       modelId: this.model.id,
       tnPath: this.tnPath,
+      fromLinkColUpdate: fromLinkColUpdate
     });
   }
 

--- a/packages/nocodb/src/meta/migrations/v1/nc_001_init.ts
+++ b/packages/nocodb/src/meta/migrations/v1/nc_001_init.ts
@@ -95,6 +95,7 @@ const up = async (knex) => {
     table.integer('retry_interval').defaultTo(60000);
     table.integer('timeout').defaultTo(60000);
     table.boolean('active').defaultTo(true);
+    table.boolean('triggerOnLinkColumnUpdate').defaultTo(false);
 
     table.timestamps();
   });

--- a/packages/nocodb/src/meta/migrations/v2/nc_011.ts
+++ b/packages/nocodb/src/meta/migrations/v2/nc_011.ts
@@ -335,6 +335,8 @@ const up = async (knex) => {
     table.integer('retry_interval').defaultTo(60000);
     table.integer('timeout').defaultTo(60000);
     table.boolean('active').defaultTo(true);
+    table.boolean('triggerOnLinkColumnUpdate').defaultTo(false);
+
 
     table.timestamps(true, true);
   });

--- a/packages/nocodb/src/models/Hook.ts
+++ b/packages/nocodb/src/models/Hook.ts
@@ -33,11 +33,11 @@ export default class Hook implements HookType {
   retry_interval?: number;
   timeout?: number;
   active?: BoolType;
-
   fk_workspace_id?: string;
   base_id?: string;
   source_id?: string;
   version?: 'v1' | 'v2';
+  triggerOnLinkColumnUpdate?: BoolType;
 
   constructor(hook: Partial<Hook | HookReqType>) {
     Object.assign(this, hook);
@@ -86,6 +86,7 @@ export default class Hook implements HookType {
     const cachedList = await NocoCache.getList(CacheScope.HOOK, [
       param.fk_model_id,
     ]);
+    
     let { list: hooks } = cachedList;
     const { isNoneList } = cachedList;
     if (!isNoneList && !hooks.length) {
@@ -106,6 +107,7 @@ export default class Hook implements HookType {
           },
         },
       );
+
       await NocoCache.setList(CacheScope.HOOK, [param.fk_model_id], hooks);
     }
     // filter event & operation
@@ -146,6 +148,7 @@ export default class Hook implements HookType {
       'active',
       'base_id',
       'source_id',
+      'triggerOnLinkColumnUpdate'
     ]);
 
     if (insertObj.notification && typeof insertObj.notification === 'object') {
@@ -206,6 +209,7 @@ export default class Hook implements HookType {
       'timeout',
       'active',
       'version',
+      'triggerOnLinkColumnUpdate'
     ]);
 
     if (

--- a/packages/nocodb/src/services/data-alias-nested.service.ts
+++ b/packages/nocodb/src/services/data-alias-nested.service.ts
@@ -309,7 +309,18 @@ export class DataAliasNestedService {
       source,
     });
 
+
     const column = await getColumnByIdOrName(context, param.columnName, model);
+
+
+    const prevData = await  baseModel.readByPk(
+      param.rowId,
+      false,
+      {},
+      { ignoreView: true, getHiddenColumn: true },
+    );
+
+    await baseModel.beforeUpdate(prevData , null , param.cookie , true)
 
     await baseModel.removeChild({
       colId: column.id,
@@ -317,6 +328,13 @@ export class DataAliasNestedService {
       rowId: param.rowId,
       cookie: param.cookie,
     });
+    const newData = await  baseModel.readByPk(
+      param.rowId,
+      false,
+      {},
+      { ignoreView: true, getHiddenColumn: true },
+    );
+    await baseModel.afterUpdate(prevData , newData , null, param.cookie , null , true)
 
     return true;
   }
@@ -342,13 +360,29 @@ export class DataAliasNestedService {
       dbDriver: await NcConnectionMgrv2.get(source),
     });
 
+    const prevData = await  baseModel.readByPk(
+      param.rowId,
+      false,
+      {},
+      { ignoreView: true, getHiddenColumn: true },
+    );
+
+    await baseModel.beforeUpdate(prevData , null , param.cookie , true)
     const column = await getColumnByIdOrName(context, param.columnName, model);
+  
     await baseModel.addChild({
       colId: column.id,
       childId: param.refRowId,
       rowId: param.rowId,
       cookie: param.cookie,
     });
+    const newData = await  baseModel.readByPk(
+      param.rowId,
+      false,
+      {},
+      { ignoreView: true, getHiddenColumn: true },
+    );
+    await baseModel.afterUpdate(prevData , newData , null, param.cookie , null ,true)
 
     return true;
   }

--- a/packages/nocodb/src/services/hook-handler.service.ts
+++ b/packages/nocodb/src/services/hook-handler.service.ts
@@ -27,7 +27,7 @@ export class HookHandlerService implements OnModuleInit, OnModuleDestroy {
 
   public async handleHooks(
     context: NcContext,
-    { hookName, prevData, newData, user, viewId, modelId, tnPath },
+    { hookName, prevData, newData, user, viewId, modelId, tnPath , fromLinkColUpdate },
   ): Promise<void> {
     const view = await View.get(context, viewId);
     const model = await Model.get(context, modelId);
@@ -117,6 +117,11 @@ export class HookHandlerService implements OnModuleInit, OnModuleDestroy {
     });
     for (const hook of hooks) {
       if (hook.active) {
+        if( fromLinkColUpdate === true ){
+          if(  Boolean(hook.triggerOnLinkColumnUpdate) !== true ){
+            continue;
+          }
+        }
         try {
           await this.jobsService.add(JobTypes.HandleWebhook, {
             context,

--- a/tests/playwright/pages/Dashboard/WebhookForm/index.ts
+++ b/tests/playwright/pages/Dashboard/WebhookForm/index.ts
@@ -40,6 +40,7 @@ export class WebhookFormPage extends BasePage {
       value: 'application/json',
     });
     await this.configureWebhook({ title, event, url });
+
     await this.save();
     await this.close();
   }
@@ -221,5 +222,28 @@ export class WebhookFormPage extends BasePage {
 
   async goBackFromForm() {
     await this.get().locator('svg.nc-icon-hook-navigate-left').click();
+  }
+
+  async toggleTriggerOnLinkUpdate(index: number, enable: boolean) {
+    await this.open({ index });
+
+    const checkBox = this.get().locator(`.nc-check-box-hook-trigger-on-link`);
+    const isChecked = await checkBox.isChecked();
+
+    if (isChecked !== enable) {
+      await checkBox.click();
+    }
+
+    await this.save();
+    await this.close();
+  }
+
+  // Usage
+  async enableTriggerOnLinkUpdate(index: number) {
+    await this.toggleTriggerOnLinkUpdate(index, true);
+  }
+
+  async disableTriggerOnLinkUpdate(index: number) {
+    await this.toggleTriggerOnLinkUpdate(index, false);
   }
 }


### PR DESCRIPTION
## Change Summary

Fixes issue - #9763

Approach -
Maintaining a  bool during in hook model - triggerOnLinkColumUpdate
During creation of hook only in **On Record Update** user can enable or disable the triggerOnLinkColumnUpdate otherwise its always false
Handlehook functions is have a condition if hook is triggered from Linked column update

Playwright test - added a new test - trigger on link column update

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)
![23 11 2024_12 29 26_REC](https://github.com/user-attachments/assets/8fe8300d-b49d-4cd2-bae6-57ed8c281c96)

Anything for maintainers to be made aware of
