### PR TITLE
fix: use alias when constructing hm filter query to avoid self-reference issue

### DIFF
--- a/packages/nocodb/src/db/conditionV2.ts
+++ b/packages/nocodb/src/db/conditionV2.ts
@@ -213,30 +213,18 @@ const parseConditionV2 = async (
             filter.comparison_op,
           )
         ) {
-          // handle self reference
-          if (parentModel.id === childModel.id) {
-            if (filter.comparison_op === 'blank') {
-              return (qb) => {
-                qb.whereNull(childColumn.column_name);
-              };
-            } else {
-              return (qb) => {
-                qb.whereNotNull(childColumn.column_name);
-              };
-            }
-          }
+          const childTableAlias = getAlias(aliasCount);
 
           const selectHmCount = knex(
-            baseModelSqlv2.getTnPath(childModel.table_name),
+            baseModelSqlv2.getTnPath(childModel.table_name, childTableAlias),
           )
             .count(childColumn.column_name)
-            .where(
+            .whereRaw('??.?? = ??.??', [
+              childTableAlias,
               childColumn.column_name,
-              knex.raw('??.??', [
-                alias || baseModelSqlv2.getTnPath(parentModel.table_name),
-                parentColumn.column_name,
-              ]),
-            );
+              alias || baseModelSqlv2.getTnPath(parentModel.table_name),
+              parentColumn.column_name,
+            ]);
 
           return (qb) => {
             if (filter.comparison_op === 'blank') {


### PR DESCRIPTION
## Change Summary

- HM part of One-to-one self link blank filter not working as expected 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
