### PR TITLE
chore(docker): pin postgresql to 16.6

### DIFF
--- a/docker-compose/1_Auto_Upstall/noco.sh
+++ b/docker-compose/1_Auto_Upstall/noco.sh
@@ -609,7 +609,7 @@ EOF
 	if [ "$CONFIG_POSTGRES_SQLITE" = "P" ]; then
 		cat >>"$compose_file" <<EOF
   db:
-    image: postgres:16.1
+    image: postgres:16.6
     env_file: docker.env
     volumes:
       - ./postgres:/var/lib/postgresql/data

--- a/docker-compose/2_pg/docker-compose.yml
+++ b/docker-compose/2_pg/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       retries: 10
       test: "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""
       timeout: 2s
-    image: postgres
+    image: postgres:16.6
     restart: always
     volumes: 
       - "db_data:/var/lib/postgresql/data"


### PR DESCRIPTION
## Change Summary

pin postgresql to 16.6, currently it pulls latest and this can cause headaches for users when the latest tag bumps major version as the they will have to do manual migraton
 
## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)