### PR TITLE
feat(nc-gui): allow Monday to be the first column in date picker

### DIFF
--- a/packages/nc-gui/components/nc/DatePicker.vue
+++ b/packages/nc-gui/components/nc/DatePicker.vue
@@ -9,6 +9,7 @@ interface Props {
   type: 'date' | 'time' | 'year' | 'month'
   isOpen: boolean
   showCurrentDateOption?: boolean | 'disabled'
+  isMondayFirst?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<Props>(), {
   isCellInputField: false,
   type: 'date',
   isOpen: false,
+  isMondayFirst: true,
 })
 const emit = defineEmits(['update:selectedDate', 'update:pageDate', 'update:selectedWeek', 'currentDate'])
 // Page date is the date we use to manage which month/date that is currently being displayed
@@ -131,7 +133,7 @@ onMounted(() => {
     v-model:page-date="localStatePageDate"
     v-model:selected-date="localStateSelectedDate"
     :picker-type="pickerType"
-    :is-monday-first="false"
+    :is-monday-first="props.isMondayFirst"
     is-cell-input-field
     size="medium"
     :show-current-date-option="showCurrentDateOption"


### PR DESCRIPTION
## Change Summary

Resolves #9633. Updates `DatePicker` to make Monday first day of the week.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


## Additional information / screenshots (optional)

**Previous Behavior**
![image](https://github.com/user-attachments/assets/f146428c-d203-4768-8c15-c42544a8eef4)

**Current Behavior**
![image](https://github.com/user-attachments/assets/fecbadb6-23ff-408a-a10b-3e527f23852d)

