### PR TITLE
feat: configure db max. pool size through environment variable

### DIFF
--- a/packages/nocodb/src/utils/nc-config/constants.ts
+++ b/packages/nocodb/src/utils/nc-config/constants.ts
@@ -25,7 +25,9 @@ export const defaultConnectionConfig: any = {
 export const defaultConnectionOptions = {
   pool: {
     min: 0,
-    max: 10,
+    max: Number.isNaN(parseInt(process.env.DB_MAX_POOL_SIZE))
+      ? 10
+      : parseInt(process.env.DB_MAX_POOL_SIZE),
   },
 };
 


### PR DESCRIPTION
introduce environment variable `DB_MAX_POOL_SIZE` for configuring the maximum connection pool size.

ref: #9973

## Change Summary

Added the means to configure the maximum connection pool size for the database dynamically through an environment variable.

Closes #9973 

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Additional information / screenshots (optional)

Should this get into the codebase, I'm assuming that it'll be important to keep in mind to update [docs.nocodb.com](https://docs.nocodb.com/getting-started/self-hosted/environment-variables) environment variable section to reflect this addition.
