### PR TITLE
fix: Prevent sum from failing if field is blank

### DIFF
--- a/packages/nocodb/src/db/formulav2/formulaQueryBuilderv2.ts
+++ b/packages/nocodb/src/db/formulav2/formulaQueryBuilderv2.ts
@@ -868,14 +868,26 @@ async function _formulaQueryBuilder(params: {
               {
                 type: 'BinaryExpression',
                 operator: '+',
-                left: pt.arguments[0],
+                left: {
+                  type: 'CallExpression',
+                  callee: { type: 'Identifier', name: 'COALESCE' },
+                  arguments: [ pt.arguments[0], { type: 'Literal', value: 0 } ],
+                },
                 right: { ...pt, arguments: pt.arguments.slice(1) },
               },
               a,
               prevBinaryOp,
             );
           } else {
-            return fn(pt.arguments[0], a, prevBinaryOp);
+            return fn(
+              {
+                type: 'CallExpression',
+                callee: { type: 'Identifier', name: 'COALESCE' },
+                arguments: [ pt.arguments[0], { type: 'Literal', value: 0 } ],
+              },
+              a,
+              prevBinaryOp
+            );
           }
           break;
         case 'CONCAT':


### PR DESCRIPTION
## Change Summary

Resolves #9876

The following changes are in `formulaQueryBuilderv2.ts`:
- SUM works by recursively calling an evaluation function over the relevant columns to accumulate a final result
- In the case where there is more than one argument left, the argument in question (left) is defaulted to 0 using`COALESCE`
- In the base case (there is exactly one argument left), the argument is defaulted to 0 using `COALESCE`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Manual UI testing of the SUM forumla

## Additional information / screenshots (optional)

I have attached screenshots of testing on the UI

<img width="818" alt="Screenshot 2024-12-05 at 7 48 22 PM" src="https://github.com/user-attachments/assets/33f4bb0f-d516-4a4a-9025-e83f1a068250">

<img width="988" alt="Screenshot 2024-12-05 at 7 49 11 PM" src="https://github.com/user-attachments/assets/9ea5b650-8d18-420a-932f-1019cdd5fd4a">

