### PR TITLE
Fix incorrect script path in build-local-docker-image.sh  

### DIFF
--- a/build-local-docker-image.sh
+++ b/build-local-docker-image.sh
@@ -45,7 +45,7 @@ function copy_gui_artifacts() {
 function package_nocodb() {
     # build nocodb ( pack nocodb-sdk and nc-gui )
     cd ${SCRIPT_DIR}/packages/nocodb
-    EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin --config ${SCRIPT_DIR}/packages/nocodb/rspack.config.js || ERROR="package_nocodb failed"
+    EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin/rspack.js --config ${SCRIPT_DIR}/packages/nocodb/rspack.config.js || ERROR="package_nocodb failed"
 }
 
 function build_image() {


### PR DESCRIPTION
## **Change Summary**  
This PR fixes an issue in `build-local-docker-image.sh` at line 48, where the script attempted to execute a directory instead of a file.  
The incorrect command was:  
```sh
EE=true ${SCRIPT_DIR}/node_modules/@rspack/cli/bin
```
This caused the following error during the build process:  
```
./build-local-docker-image.sh: line 48: ./node_modules/@rspack/cli/bin: Is a directory
```
The error was also reflected in `build-local-docker-image.log` as:  
```
Info: Build nocodb, package nocodb-sdk and nc-gui
ERROR: package_nocodb failed
```
The corrected command now explicitly points to the executable file within the directory. This change ensures successful execution of the build script.  

---

## **Change type**  

- [ ] feat: (new feature for the user, not a new feature for build script)  
- [x] fix: (bug fix for the user, not a fix to a build script)  
- [ ] docs: (changes to the documentation)  
- [ ] style: (formatting, missing semi colons, etc; no production code change)  
- [ ] refactor: (refactoring production code, e.g., renaming a variable)  
- [ ] test: (adding missing tests, refactoring tests; no production code change)  
- [ ] chore: (updating grunt tasks etc; no production code change)  

---

## **Test/ Verification**  

Added the correct script path:  
```sh
${SCRIPT_DIR}/node_modules/@rspack/cli/bin/rspack.js
```
This adjustment was tested by running the `build-local-docker-image.sh` script successfully without errors.  

---

## **Additional information / screenshots (optional)**  

None at this time. Let me know if any further details or adjustments are required.  
