### PR TITLE
ci(uffizzi-preview): use id of the workflow that triggered the workflow run

### DIFF
--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -25,6 +25,7 @@ jobs:
           path: preview-spec
           pattern: preview-spec-*
           merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: 'Accept event from first stage'
         run: cp preview-spec/event.json .


### PR DESCRIPTION
## Change Summary

The "Deploy Uffizzi Preview" job has been failing (https://github.com/nocodb/nocodb/actions/runs/12237653725/job/34133889626) since PR #9859 was merged. I forgot to specify the `run-id` in PR #9859, which caused the `cache-compose-file` job to attempt downloading artifacts from the current workflow, resulting in no matches. Instead, it should download artifacts uploaded by the workflow that triggered the run.

Fixes: 2684cedddf ("chore(release-pr): update `upload-artifact` action to v4 (#9859)")

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

/cc @dstala and @mertmit for review again :pray: 
