### PR TITLE
ci(uffizzi-preview): provide GitHub token to download artifacts

### DIFF
--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -19,12 +19,14 @@ jobs:
       action: ${{ steps.event.outputs.ACTION }}
     steps:
       - name: 'Download artifacts'
-        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        # Download artifacts from the workflow run that triggered this workflow.
+        # Token is required to download from a different workflow run.
         uses: actions/download-artifact@v4
         with:
           path: preview-spec
           pattern: preview-spec-*
           merge-multiple: true
+          github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: 'Accept event from first stage'


### PR DESCRIPTION
## Change Summary

The "Deploy Uffizzi Preview" is still failing, https://github.com/nocodb/nocodb/actions/runs/12238779097.

Turns out GitHub token is required to download artifacts from another workflow run, see https://github.com/actions/download-artifact/issues/320.

Fixes: 62e1485143 ("ci(uffizzi-preview): use id of the workflow that triggered the workflow run (#10003)")
Fixes: 2684cedddf ("chore(release-pr): update `upload-artifact` action to v4 (#9859)")

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

/cc @mertmit :pray: Sorry for the multiple PRs, this time it should really work
