### PR TITLE
fix: upload modal data only headers

### DIFF
--- a/packages/nc-gui/components/dlg/QuickImport.vue
+++ b/packages/nc-gui/components/dlg/QuickImport.vue
@@ -97,7 +97,7 @@ const { validate, validateInfos } = useForm(importState, validators)
 const importMeta = computed(() => {
   if (IsImportTypeExcel.value) {
     return {
-      header: `${t('title.quickImportExcel')}`,
+      header: importDataOnly ? t('activity.uploadExcel') : t('title.quickImportExcel'),
       icon: 'importExcel',
       uploadHint: '',
       urlInputLabel: t('msg.info.excelURL'),
@@ -106,7 +106,7 @@ const importMeta = computed(() => {
     }
   } else if (isImportTypeCsv.value) {
     return {
-      header: `${t('title.quickImportCSV')}`,
+      header: importDataOnly ? t('activity.uploadCSV') : t('title.quickImportCSV'),
       icon: 'importCsv',
       uploadHint: '',
       urlInputLabel: t('msg.info.csvURL'),
@@ -796,7 +796,7 @@ watch(
           :disabled="disablePreImportButton"
           @click="handlePreImport"
         >
-          {{ $t('activity.import') }}
+          {{ importDataOnly ? $t('activity.upload') : $t('activity.import') }}
         </nc-button>
 
         <nc-button
@@ -807,7 +807,7 @@ watch(
           :disabled="disableImportButton"
           @click="handleImport"
         >
-          {{ $t('activity.import') }}
+          {{ importDataOnly ? $t('activity.upload') : $t('activity.import') }}
         </nc-button>
       </div>
     </template>

--- a/packages/nc-gui/components/dlg/QuickImport.vue
+++ b/packages/nc-gui/components/dlg/QuickImport.vue
@@ -78,7 +78,7 @@ const defaultImportState = {
     importDataOnly: true,
   },
 }
-const importState = reactive(defaultImportState)
+const importState = reactive(structuredClone(defaultImportState))
 
 const { token } = useGlobal()
 
@@ -125,6 +125,12 @@ const importMeta = computed(() => {
 })
 
 const dialogShow = useVModel(rest, 'modelValue', emit)
+
+watch(dialogShow, (newValue) => {
+  if (newValue) {
+    Object.assign(importState, structuredClone(defaultImportState))
+  }
+})
 
 // watch dialogShow to init or terminate worker
 if (isWorkerSupport && process.env.NODE_ENV === 'production') {
@@ -587,7 +593,7 @@ watch(
     v-model:visible="dialogShow"
     :class="{ active: dialogShow }"
     :closable="false"
-    width="448px"
+    :width="(templateEditorModal && importDataOnly) ? '640px' : '448px'"
     class="!top-[12.5vh]"
     wrap-class-name="nc-modal-quick-import"
     :transition-name="transition"

--- a/packages/nc-gui/components/template/Editor.vue
+++ b/packages/nc-gui/components/template/Editor.vue
@@ -41,7 +41,8 @@ const reloadHook = inject(ReloadViewDataHookInj, createEventHook())
 
 const useForm = Form.useForm
 
-const { $api } = useNuxtApp()
+const { $api, $state } = useNuxtApp()
+const baseURL = $api.instance.defaults.baseURL
 
 const { addTab } = useTabs()
 
@@ -447,18 +448,18 @@ async function importTemplate() {
                   return res
                 }, {}),
               )
-              const res = await $api.dbTableRow.bulkCreate('noco', baseId, tableId!, batchData, {
-                query: {
-                  operation_id: operationId,
-                },
-                wrapped: true,
+              const res = await $fetch.raw(`/api/v1/db/data/bulk/noco/${baseId}/${tableId}?wrapped=true&headers[nc-import-type]=${quickImportType}${operationId ? `&operation_id=${operationId}` : ''}`, {
+                baseURL,
+                method: 'POST',
                 headers: {
+                  'xc-auth': $state.token.value as string,
                   'nc-operation-id': operationId,
                   'nc-import-type': quickImportType,
                 },
-              })
+                body: batchData,
+              });
 
-              operationId = res.headers['nc-operation-id']
+              operationId = res.headers?.['nc-operation-id']
               updateImportTips(baseId, tableId!, progress, total)
               progress += batchData.length
             }

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -1259,6 +1259,8 @@
     "downloadCSV": "Download CSV",
     "downloadExcel": "Download Excel",
     "uploadCSV": "Upload CSV",
+    "uploadExcel": "Upload Excel",
+    "upload": "Upload",
     "import": "Import",
     "importMetadata": "Import Metadata",
     "exportMetadata": "Export Metadata",


### PR DESCRIPTION
From @yooneskh 

## Change Summary

Since `headers` field is not present when making requests using `$api`, the upload request in data only import modal has to  be done through the `$fetch.raw` to be able to extract the headers.

Also makes some QoL fixes to the quick import dialog.

fixes nocodb/nocohub#4381

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
