### PR TITLE
feat: better json editing ux 

### DIFF
--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -147,7 +147,12 @@ useSelectedCellKeyupListener(active, (e) => {
       // non-printing keys, ignore them
       break
     default:
-      // Otherwise it's a printing character, open the JSON modal for editing
+      // Otherwise it's a printing character, append it and open the JSON modal for editing
+      if (typeof localValue.value === 'string') {
+        localValue.value += e.key
+      } else if (!localValue.value) {
+        localValue.value = e.key
+      }
       openJSONEditor()
   }
 })

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -54,6 +54,14 @@ const localValue = computed<ModelValueType>({
   },
 })
 
+function openJSONEditor() {
+  isExpanded.value = true
+}
+
+function closeJSONEditor() {
+  isExpanded.value = false
+}
+
 const formatJson = (json: string) => {
   try {
     return JSON.stringify(JSON.parse(json))
@@ -74,7 +82,7 @@ function setLocalValue(val: any) {
 const clear = () => {
   error.value = undefined
 
-  isExpanded.value = false
+  closeJSONEditor()
 
   editEnabled.value = false
 
@@ -82,7 +90,7 @@ const clear = () => {
 }
 
 const onSave = () => {
-  isExpanded.value = false
+  closeJSONEditor()
 
   editEnabled.value = false
 
@@ -113,7 +121,7 @@ watch([localValue, editEnabled], () => {
 })
 
 watch(editEnabled, () => {
-  isExpanded.value = false
+  closeJSONEditor()
 
   setLocalValue(vModel.value)
 })
@@ -126,7 +134,7 @@ useSelectedCellKeyupListener(active, (e) => {
       if (e.shiftKey) {
         return true
       }
-      isExpanded.value = true
+      openJSONEditor()
       break
     case e.metaKey:
     case e.altKey:
@@ -139,7 +147,7 @@ useSelectedCellKeyupListener(active, (e) => {
       break
     default:
       // Otherwise it's a printing character, open the JSON modal for editing
-      isExpanded.value = true
+      openJSONEditor()
   }
 })
 
@@ -174,6 +182,28 @@ watch(inputWrapperRef, () => {
     modal.parentElement.removeEventListener('mouseup', stopPropagation)
   }
 })
+
+const el = useCurrentElement()
+
+onMounted(() => {
+  const gridCell = el.value?.closest('td')
+  if (gridCell) {
+    gridCell.addEventListener('dblclick', openJSONEditor)
+    return
+  }
+  const formCell = el.value?.closest('.nc-data-cell')
+  if (formCell) formCell.addEventListener('click', openJSONEditor)
+})
+
+onUnmounted(() => {
+  const gridCell = el.value?.closest('td')
+  if (gridCell) {
+    gridCell.removeEventListener('dblclick', openJSONEditor)
+    return
+  }
+  const formCell = el.value?.closest('.nc-data-cell')
+  if (formCell) formCell.removeEventListener('click', openJSONEditor)
+})
 </script>
 
 <template>
@@ -189,7 +219,7 @@ watch(inputWrapperRef, () => {
   >
     <div v-if="isExpanded && !readOnly" class="flex flex-col w-full" @mousedown.stop @mouseup.stop @click.stop>
       <div class="flex flex-row justify-between items-center -mt-2 pb-2 nc-json-action" @mousedown.stop>
-        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="isExpanded = false">
+        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="closeJSONEditor">
           <component :is="iconMap.minimize" class="transform group-hover:(!text-grey-800) text-gray-700 w-3 h-3" />
         </NcButton>
 
@@ -229,7 +259,7 @@ watch(inputWrapperRef, () => {
     <div v-else class="h-5 relative">
       <NcTooltip placement="bottom" class="nc-json-expand-btn hidden absolute right-0">
         <template #title>{{ $t('title.expand') }}</template>
-        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="isExpanded = true">
+        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="openJSONEditor">
           <component :is="iconMap.maximize" class="hover:text-grey-800 text-gray-700 w-3 h-3" />
         </NcButton>
       </NcTooltip>

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -140,6 +140,7 @@ useSelectedCellKeyupListener(active, (e) => {
     case e.altKey:
     case e.ctrlKey:
     case e.key === 'Backspace':
+    case e.key === 'Spacebar' || e.key === ' ':
     case [...e.key].length > 1:
       // The string iterator that is used here iterates over characters, not mere code units
       // If a key is a modifier key or navigation key or function key or any of the
@@ -215,6 +216,7 @@ onUnmounted(() => {
     centered
     :footer="null"
     :wrap-class-name="isExpanded ? '!z-1051 nc-json-expanded-modal' : null"
+    class="relative"
     :class="{ 'json-modal min-w-80': isExpanded }"
   >
     <div v-if="isExpanded && !readOnly" class="flex flex-col w-full" @mousedown.stop @mouseup.stop @click.stop>
@@ -247,16 +249,14 @@ onUnmounted(() => {
         {{ error.toString() }}
       </span>
     </div>
-    <div v-else class="h-5 relative">
-      <NcTooltip placement="bottom" class="nc-json-expand-btn hidden absolute right-0">
-        <template #title>{{ $t('title.expand') }}</template>
-        <NcButton type="secondary" size="xsmall" class="!w-5 !h-5 !min-w-[fit-content]" @click.stop="openJSONEditor">
-          <component :is="iconMap.maximize" class="w-3 h-3" />
-        </NcButton>
-      </NcTooltip>
-      <span v-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
-      <LazyCellClampedText v-else :value="vModel ? stringifyProp(vModel) : ''" :lines="rowHeight" class="nc-cell-field" />
-    </div>
+    <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
+    <LazyCellClampedText v-else :value="vModel ? stringifyProp(vModel) : ''" :lines="rowHeight" class="nc-cell-field" />
+    <NcTooltip placement="bottom" class="nc-json-expand-btn hidden absolute top-0 right-0">
+      <template #title>{{ $t('title.expand') }}</template>
+      <NcButton type="secondary" size="xsmall" class="!w-5 !h-5 !min-w-[fit-content]" @click.stop="openJSONEditor">
+        <component :is="iconMap.maximize" class="w-3 h-3" />
+      </NcButton>
+    </NcTooltip>
   </component>
 </template>
 
@@ -267,8 +267,17 @@ onUnmounted(() => {
 </style>
 
 <style lang="scss">
-.cell:hover .nc-json-expand-btn,
-.nc-cell:hover .nc-json-expand-btn {
+.nc-cell-json:hover .nc-json-expand-btn,
+.nc-grid-cell:hover .nc-json-expand-btn {
   @apply block;
+}
+.nc-grid-cell .nc-cell-json {
+  min-height: 20px !important;
+}
+.nc-expanded-cell .nc-cell-json .nc-cell-field {
+  margin: 8px 0;
+}
+.nc-expand-col-JSON.nc-expanded-form-row .nc-cell-json {
+  min-height: 38px;
 }
 </style>

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -219,18 +219,13 @@ onUnmounted(() => {
   >
     <div v-if="isExpanded && !readOnly" class="flex flex-col w-full" @mousedown.stop @mouseup.stop @click.stop>
       <div class="flex flex-row justify-between items-center -mt-2 pb-2 nc-json-action" @mousedown.stop>
-        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="closeJSONEditor">
-          <component :is="iconMap.minimize" class="transform group-hover:(!text-grey-800) text-gray-700 w-3 h-3" />
+        <NcButton type="secondary" size="xsmall" class="!w-5 !h-5 !min-w-[fit-content]" @click.stop="closeJSONEditor">
+          <component :is="iconMap.minimize" class="w-3 h-3" />
         </NcButton>
 
-        <div v-if="!isForm || isExpanded" class="flex flex-row my-1 space-x-1">
+        <div class="flex flex-row my-1 space-x-1">
           <NcButton type="secondary" size="small" @click="clear">{{ $t('general.cancel') }}</NcButton>
-          <NcButton
-            :type="!isExpanded ? 'text' : 'primary'"
-            size="small"
-            :disabled="!!error || localValue === vModel"
-            @click="onSave"
-          >
+          <NcButton type="primary" size="small" :disabled="!!error || localValue === vModel" @click="onSave">
             {{ $t('general.save') }}
           </NcButton>
         </div>
@@ -239,8 +234,7 @@ onUnmounted(() => {
       <LazyMonacoEditor
         ref="inputWrapperRef"
         :model-value="localValue || ''"
-        class="min-w-full w-[40rem] min-w-80 resize overflow-auto"
-        :class="{ 'expanded-editor': isExpanded, 'editor': !isExpanded }"
+        class="min-w-full w-[40rem] min-w-80 resize-x overflow-auto expanded-editor"
         :hide-minimap="true"
         :disable-deep-compare="true"
         :auto-focus="true"
@@ -253,17 +247,15 @@ onUnmounted(() => {
         {{ error.toString() }}
       </span>
     </div>
-
-    <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
-
     <div v-else class="h-5 relative">
       <NcTooltip placement="bottom" class="nc-json-expand-btn hidden absolute right-0">
         <template #title>{{ $t('title.expand') }}</template>
-        <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="openJSONEditor">
-          <component :is="iconMap.maximize" class="hover:text-grey-800 text-gray-700 w-3 h-3" />
+        <NcButton type="secondary" size="xsmall" class="!w-5 !h-5 !min-w-[fit-content]" @click.stop="openJSONEditor">
+          <component :is="iconMap.maximize" class="w-3 h-3" />
         </NcButton>
       </NcTooltip>
-      <LazyCellClampedText :value="vModel ? stringifyProp(vModel) : ''" :lines="rowHeight" class="nc-cell-field" />
+      <span v-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
+      <LazyCellClampedText v-else :value="vModel ? stringifyProp(vModel) : ''" :lines="rowHeight" class="nc-cell-field" />
     </div>
   </component>
 </template>
@@ -271,10 +263,6 @@ onUnmounted(() => {
 <style scoped lang="scss">
 .expanded-editor {
   min-height: min(600px, 80vh);
-}
-
-.editor {
-  min-height: min(200px, 10vh);
 }
 </style>
 

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -226,11 +226,11 @@ watch(inputWrapperRef, () => {
 
     <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
 
-    <div v-else>
-      <NcTooltip placement="bottom" class="float-right nc-json-expand-btn hidden">
+    <div v-else class="h-5 relative">
+      <NcTooltip placement="bottom" class="nc-json-expand-btn hidden absolute right-0">
         <template #title>{{ $t('title.expand') }}</template>
         <NcButton type="secondary" size="xsmall" class="!p-0 !w-5 !h-5 !min-w-[fit-content]" @click.stop="isExpanded = true">
-          <component :is="iconMap.maximize" class="transform group-hover:(!text-grey-800) text-gray-700 w-3 h-3" />
+          <component :is="iconMap.maximize" class="hover:text-grey-800 text-gray-700 w-3 h-3" />
         </NcButton>
       </NcTooltip>
       <LazyCellClampedText :value="vModel ? stringifyProp(vModel) : ''" :lines="rowHeight" class="nc-cell-field" />
@@ -249,7 +249,8 @@ watch(inputWrapperRef, () => {
 </style>
 
 <style lang="scss">
-.cell:hover .nc-json-expand-btn {
-  @apply block cursor-pointer;
+.cell:hover .nc-json-expand-btn,
+.nc-cell:hover .nc-json-expand-btn {
+  @apply block;
 }
 </style>

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -171,6 +171,7 @@ watch(inputWrapperRef, () => {
   <component
     :is="isExpanded ? NcModal : 'div'"
     v-model:visible="isExpanded"
+    width="auto"
     :closable="false"
     centered
     :footer="null"
@@ -207,7 +208,7 @@ watch(inputWrapperRef, () => {
       <LazyMonacoEditor
         ref="inputWrapperRef"
         :model-value="localValue || ''"
-        class="min-w-full w-80"
+        class="min-w-full w-[40rem] min-w-80 resize overflow-auto"
         :class="{ 'expanded-editor': isExpanded, 'editor': !isExpanded }"
         :hide-minimap="true"
         :disable-deep-compare="true"

--- a/packages/nc-gui/components/monaco/Editor.vue
+++ b/packages/nc-gui/components/monaco/Editor.vue
@@ -151,8 +151,9 @@ onMounted(async () => {
       setTimeout(() => {
         const lineCount = editor.getModel()?.getLineCount() ?? 0
         const lastLineLength = editor.getModel()?.getLineContent(lineCount).length ?? 0
-        editor.setPosition({ lineNumber: lineCount, column: lastLineLength + 1 })
-        editor.revealPositionInCenter({ lineNumber: lineCount, column: lastLineLength + 1 })
+        const endPosition = { lineNumber: lineCount, column: lastLineLength + 1 }
+        editor.setPosition(endPosition)
+        editor.revealPositionInCenter(endPosition)
         editor.focus()
       }, 200)
     }

--- a/packages/nc-gui/components/monaco/Editor.vue
+++ b/packages/nc-gui/components/monaco/Editor.vue
@@ -142,9 +142,19 @@ onMounted(async () => {
 
     const activeDrawerOrModal = isDrawerOrModalExist()
 
-    if ((!activeDrawerOrModal || activeDrawerOrModal?.classList.contains('json-modal')) && autoFocus) {
+    if (!activeDrawerOrModal && autoFocus) {
       // auto focus on json cells only
       editor.focus()
+    }
+
+    if (activeDrawerOrModal?.classList.contains('json-modal') && autoFocus) {
+      setTimeout(() => {
+        const lineCount = editor.getModel()?.getLineCount() ?? 0
+        const lastLineLength = editor.getModel()?.getLineContent(lineCount).length ?? 0
+        editor.setPosition({ lineNumber: lineCount, column: lastLineLength + 1 })
+        editor.revealPositionInCenter({ lineNumber: lineCount, column: lastLineLength + 1 })
+        editor.focus()
+      }, 200)
     }
 
     if (lang === 'json') {

--- a/packages/nc-gui/components/monaco/Editor.vue
+++ b/packages/nc-gui/components/monaco/Editor.vue
@@ -140,7 +140,9 @@ onMounted(async () => {
       new PlaceholderContentWidget(placeholder, editor)
     }
 
-    if (!isDrawerOrModalExist() && autoFocus) {
+    const activeDrawerOrModal = isDrawerOrModalExist()
+
+    if ((!activeDrawerOrModal || activeDrawerOrModal?.classList.contains('json-modal')) && autoFocus) {
       // auto focus on json cells only
       editor.focus()
     }

--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -1992,7 +1992,7 @@ const { message: templatedMessage } = useTemplatedMessage(
   }
 
   &.nc-cell-json {
-    @apply h-auto;
+    @apply min-h-[38px] h-auto;
     & > div {
       @apply w-full;
     }

--- a/packages/nc-gui/pages/index/[typeOrId]/form/[viewId]/index.vue
+++ b/packages/nc-gui/pages/index/[typeOrId]/form/[viewId]/index.vue
@@ -186,7 +186,7 @@ p {
         }
 
         &.nc-cell-json {
-          @apply h-auto;
+          @apply min-h-[38px] h-auto;
           & > div {
             @apply w-full;
           }


### PR DESCRIPTION
## Change Summary

Make the JSON always editable in the modal. No inline editing of JSON.

1. In Grid View, you can trigger the modal by
    a. Typing on it.
    b. Pressing Enter
    c. Double clicking the cell.
    d. Pressing the expand button.
2. In other views
    a. Pressing the expand button
    b. Single click on the field.

The UI buttons (Cancel and Save and the expand/contract) buttons are unified like the rest of the app so they don't look out of place.

The JSON editor modal is resizable horizontally.

There was also a bug fix where the json editor wasn't focused upon expansion.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
