### PR TITLE
chore(nix/module): zeroconf

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -9,6 +9,10 @@ inputs:
 let
   cfg = config.services.nocodb;
   inherit (pkgs.stdenv.hostPlatform) system;
+
+  defaultEnvs = {
+    DATABASE_URL="sqlite:///%S/nocodb/sqlite.db";
+  };
 in
 {
   meta.maintainers = with lib.maintainers; [ sinanmohd ];
@@ -40,20 +44,14 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
-      inherit (cfg) environment;
+      environment = defaultEnvs // cfg.environment;
 
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;
-
-        RuntimeDirectory = "nocodb";
         StateDirectory = "nocodb";
-        RuntimeDirectoryMode = "0700";
-
         Restart = "on-failure";
-
         EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
-
         ExecStart = lib.getExe cfg.package;
       };
     };


### PR DESCRIPTION
## Change Summary
now nixos users just have to `services.nocodb.enable = true`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

tested on nixos

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
