### PR TITLE
fix (nc-gui): rename table whitespace issue

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView/TableNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/TableNode.vue
@@ -401,10 +401,6 @@ const validateTitle = async () => {
 async function onRename() {
   if (!isEditing.value) return
 
-  if (formState.title) {
-    formState.title = formState.title.trim()
-  }
-
   if (!formState.title?.trim() || table.value.title === formState.title) {
     onCancel()
     return
@@ -419,7 +415,7 @@ async function onRename() {
 
   const originalTitle = table.value.title
 
-  table.value.title = formState.title || ''
+  table.value.title = formState.title.trim() || ''
 
   const updateTitle = (title: string) => {
     table.value.title = title


### PR DESCRIPTION
## Change Summary

Fix the issue when rename table with whitespace at the start or end.
https://github.com/nocodb/nocodb/issues/10313

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)