### PR TITLE
chore(github/workflow/bumper): init 

### DIFF
--- a/.github/workflows/nix-bumper.yml
+++ b/.github/workflows/nix-bumper.yml
@@ -1,0 +1,26 @@
+name: "bumper"
+
+on:
+  push:
+    branches:
+      - "devlop"
+  pull_request_target:
+    branches:
+      - "devlop"
+
+jobs:
+  bumper:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: "write"
+      id-token: "write"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+    - name: Run Bumper
+      run: nix run .#bumper

--- a/.github/workflows/nix-bumper.yml
+++ b/.github/workflows/nix-bumper.yml
@@ -3,10 +3,10 @@ name: "bumper"
 on:
   push:
     branches:
-      - "devlop"
+      - "develop"
   pull_request_target:
     branches:
-      - "devlop"
+      - "develop"
 
 jobs:
   bumper:

--- a/.github/workflows/nix-bumper.yml
+++ b/.github/workflows/nix-bumper.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   bumper:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     permissions:
       contents: "write"

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,9 @@
         {
           docker = pkgs.callPackage ./nix/docker.nix { };
           nocodb = pkgs.callPackage ./nix/package.nix { };
+          bumper = pkgs.callPackage ./nix/bumper { };
+
+          pnpmDeps = self.packages.${system}.nocodb.pnpmDeps;
           default = self.packages.${system}.nocodb;
         }
       );

--- a/nix/bumper/bumper.sh
+++ b/nix/bumper/bumper.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 commit_message="chore(nix/pacakge/pnpmDeps): bump hash"
-commit_author="sinanmohd"
-commit_email="sinan@sinanmohd.com"
+commit_author="auto walle"
+commit_email="auto@sinanmohd.com"
 
 hash_get() {
 	grep -Eo 'sha256-[^=]*=' nix/package.nix

--- a/nix/bumper/bumper.sh
+++ b/nix/bumper/bumper.sh
@@ -3,13 +3,14 @@
 commit_message="chore(nix/pacakge/pnpmDeps): bump hash"
 commit_author="auto walle"
 commit_email="auto@sinanmohd.com"
+package_path="nix/package.nix"
 
 hash_get() {
-	grep -Eo 'sha256-[^=]*=' nix/package.nix
+	grep -Eo 'sha256-[^=]*=' "$package_path"
 }
 
 hash_set() {
-	sed -i "s|sha256-[A-Za-z0-9+/=]\+|$1|" nix/package.nix
+	sed -i "s|sha256-[A-Za-z0-9+/=]\+|$1|" "$package_path"
 }
 
 early_escape_possible() {
@@ -39,8 +40,8 @@ nix_hash() {
 ## MAIN ##
 ##########
 
-if [ ! -w nix/package.nix ] || [ ! -r nix/package.nix ]; then
-	echo "nix/package: not writiable or readable"
+if [ ! -w "$package_path" ] || [ ! -r "$package_path" ]; then
+	echo "$package_path: not writiable or readable"
 	exit 1
 fi
 
@@ -56,20 +57,16 @@ cur_hash="$(hash_get)"
 hash_set "$fake_hash"
 new_hash="$(nix_hash)"
 
-if [ -z "$new_hash" ]; then
-	echo "empty hash: must be same"
-	exit 0
-fi
-
 if [ "$cur_hash" != "$new_hash" ]; then
 	echo "hash changed: ${cur_hash} -> ${new_hash}"
 	hash_set "$new_hash"
 
-	git add nix/pacakge.nix
+	git add "$package_path"
 	git config --global user.name "$commit_author"
 	git config --global user.email "$commit_email"
 	git commit -m "$commit_message"
 	git push
 else
 	echo "hash staysss: waiting for your next commit"
+	hash_set "$cur_hash"
 fi

--- a/nix/bumper/bumper.sh
+++ b/nix/bumper/bumper.sh
@@ -65,6 +65,7 @@ if [ "$cur_hash" != "$new_hash" ]; then
 
 	git add nix/pacakge.nix
 	git commit --author="$commit_author" -m "$commit_message"
+	git push
 else
 	echo "hash staysss: waiting for your next commit"
 fi

--- a/nix/bumper/bumper.sh
+++ b/nix/bumper/bumper.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+commit_message="chore(nix/pacakge/pnpmDeps): bump hash"
+commit_author="sinanmohd <sinanmohd>"
+
+hash_get() {
+	grep -Eo 'sha256-[^=]*=' nix/package.nix
+}
+
+hash_set() {
+	sed -i "s|sha256-[A-Za-z0-9+/=]\+|$1|" nix/package.nix
+}
+
+early_escape_possible() {
+	last_bump_commit=$(git log --oneline | grep "$commit_message"  | cut -d' ' -f1)
+	if [ -z "$last_bump_commit" ]; then
+		return 1
+	fi
+
+	last_pnpm_time="$(git log -1 --format="%at" pnpm-lock.yaml)"
+	last_bump_time="$(git log -1 --format="%at" "$last_bump_commit")"
+
+	if [ "$last_bump_time" -lt "$last_pnpm_time" ]; then
+		return 1
+	fi
+
+	return 0
+}
+
+nix_hash() {
+	out="$(mktemp)"
+	nix build .#pnpmDeps -L > "$out" 2>&1
+	tac "$out" | grep -Eom1 'sha256-[^=]*='
+}
+
+##########
+## MAIN ##
+##########
+
+if [ ! -w nix/package.nix ] || [ ! -r nix/package.nix ]; then
+	echo "nix/package: not writiable or readable"
+	exit 1
+fi
+
+if early_escape_possible; then
+	echo "early escape suckcess : nix bump commit is newer"
+	exit 0
+else
+	echo "early esacpe failuree : npm bump commit is newer, here we go again"
+fi
+
+fake_hash="sha256-0000000000000000000000000000000000000000000="
+cur_hash="$(hash_get)"
+hash_set "$fake_hash"
+new_hash="$(nix_hash)"
+
+if [ -z "$new_hash" ]; then
+	echo "empty hash: must be same"
+	exit 0
+fi
+
+if [ "$cur_hash" != "$new_hash" ]; then
+	echo "hash changed: ${cur_hash} -> ${new_hash}"
+	hash_set "$new_hash"
+
+	git add nix/pacakge.nix
+	git commit --author="$commit_author" -m "$commit_message"
+else
+	echo "hash staysss: waiting for your next commit"
+fi

--- a/nix/bumper/bumper.sh
+++ b/nix/bumper/bumper.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-commit_message="chore(nix/pacakge/pnpmDeps): bump hash"
+commit_message="chore(nix/package/pnpmDeps): bump hash"
 commit_author="auto walle"
 commit_email="auto@sinanmohd.com"
 package_path="nix/package.nix"
@@ -46,10 +46,10 @@ if [ ! -w "$package_path" ] || [ ! -r "$package_path" ]; then
 fi
 
 if early_escape_possible; then
-	echo "early escape suckcess : nix bump commit is newer"
+	echo "early escape success : nix bump commit is newer"
 	exit 0
 else
-	echo "early esacpe failuree : npm bump commit is newer, here we go again"
+	echo "early esacpe failure : npm bump commit is newer, here we go again"
 fi
 
 fake_hash="sha256-0000000000000000000000000000000000000000000="
@@ -67,6 +67,6 @@ if [ "$cur_hash" != "$new_hash" ]; then
 	git commit -m "$commit_message"
 	git push
 else
-	echo "hash staysss: waiting for your next commit"
+	echo "hash did not change: waiting for your next commit"
 	hash_set "$cur_hash"
 fi

--- a/nix/bumper/default.nix
+++ b/nix/bumper/default.nix
@@ -1,0 +1,19 @@
+{
+  writeShellApplication,
+  gnugrep,
+  gnused,
+  git,
+  nix,
+}:
+writeShellApplication {
+  name = "bumper";
+
+  runtimeInputs = [
+    gnugrep
+    gnused
+    git
+    nix
+  ];
+
+  text = builtins.readFile ./bumper.sh;
+}


### PR DESCRIPTION
## Change Summary

avoid nix hash missmatch issues when pnpm-lock is updated

this pr allows us to confidently run `nix run github:nocodb/nocodb/<branch-name>`
to locally test any pr/branch at any time with a single command 

## Change type

- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

tested with nix run