### PR TITLE
fix: support japanese, chinese and cryillic letters

### DIFF
--- a/packages/nocodb-sdk/src/lib/index.ts
+++ b/packages/nocodb-sdk/src/lib/index.ts
@@ -7,6 +7,7 @@ export * from '~/lib/globals';
 export * from '~/lib/helperFunctions';
 export * from '~/lib/enums';
 export * from '~/lib/formulaHelpers';
+export * from '~/lib/regex';
 export {
   default as UITypes,
   UITypesName,

--- a/packages/nocodb-sdk/src/lib/regex/index.ts
+++ b/packages/nocodb-sdk/src/lib/regex/index.ts
@@ -1,0 +1,1 @@
+export * from './token';

--- a/packages/nocodb-sdk/src/lib/regex/token.spec.ts
+++ b/packages/nocodb-sdk/src/lib/regex/token.spec.ts
@@ -1,0 +1,53 @@
+import {
+  REGEXSTR_ALPHABET,
+  REGEXSTR_CHINESE,
+  REGEXSTR_CYRILLIC,
+  REGEXSTR_INTL_LETTER,
+  REGEXSTR_JAPANESE,
+  REGEXSTR_NUMERIC_ARABIC,
+} from './token';
+
+describe('regex-token', () => {
+  it('will test alphabet', () => {
+    const testValue =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(testValue.match(new RegExp(`[${REGEXSTR_ALPHABET}]+`))[0]).toBe(
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    );
+  });
+  it('will test arabic numeral', () => {
+    const testValue =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(
+      testValue.match(new RegExp(`[${REGEXSTR_NUMERIC_ARABIC}]+`))[0]
+    ).toBe('0123456789');
+  });
+  it('will test chinese letters', () => {
+    const testValue =
+      '新年快乐おはようございますЁёАяabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(testValue.match(new RegExp(`[${REGEXSTR_CHINESE}]+`))[0]).toBe(
+      '新年快乐'
+    );
+  });
+  it('will test japanese letters', () => {
+    const testValue =
+      '新年快乐おはようございますЁёАяabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(testValue.match(new RegExp(`[${REGEXSTR_JAPANESE}]+`))[0]).toBe(
+      'おはようございます'
+    );
+  });
+  it('will test cryillic letters', () => {
+    const testValue =
+      '新年快乐おはようございますЁёАяabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(testValue.match(new RegExp(`[${REGEXSTR_CYRILLIC}]+`))[0]).toBe(
+      'ЁёАя'
+    );
+  });
+  it('will test international letters', () => {
+    const testValue =
+      '新年快乐おはようございますЁёАяabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.';
+    expect(testValue.match(new RegExp(`[${REGEXSTR_INTL_LETTER}]+`))[0]).toBe(
+      '新年快乐おはようございますЁёАяabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    );
+  });
+});

--- a/packages/nocodb-sdk/src/lib/regex/token.ts
+++ b/packages/nocodb-sdk/src/lib/regex/token.ts
@@ -1,0 +1,39 @@
+export const REGEXSTR_ALPHABET = <const>'A-Za-z';
+export const REGEXSTR_CHINESE = <const>'一-龠';
+export const REGEXSTR_MANDARIN = REGEXSTR_CHINESE;
+export const REGEXSTR_HIRA_KATA_KANA = <const>'ぁ-ゔァ-ヴー々〆〤ヶ';
+export const REGEXSTR_JAPANESE = REGEXSTR_HIRA_KATA_KANA;
+export const REGEXSTR_CYRILLIC = <const>'\u0400-\u04FF';
+export const REGEXSTR_INTL_LETTER = [
+  REGEXSTR_ALPHABET,
+  REGEXSTR_CHINESE,
+  REGEXSTR_CYRILLIC,
+  REGEXSTR_HIRA_KATA_KANA,
+].join();
+export const REGEXSTR_NUMERIC_ARABIC = <const>'0-9';
+export const REGEXSTR_IDENTIFIER_SPECIAL_CHAR = <const>(
+  '!@#$%^&*_+-=[]{};:\\|.<>/?'
+);
+export const REGEXSTR_IDENTIFIER = [
+  REGEXSTR_INTL_LETTER,
+  REGEXSTR_NUMERIC_ARABIC,
+  REGEXSTR_IDENTIFIER_SPECIAL_CHAR,
+].join();
+export const REGEXSTR_SGL_QUOTED_IDENTIFIER_SPECIAL_CHAR = [
+  REGEXSTR_IDENTIFIER_SPECIAL_CHAR,
+  '"(),',
+].join();
+export const REGEXSTR_DBL_QUOTED_IDENTIFIER_SPECIAL_CHAR = [
+  REGEXSTR_IDENTIFIER_SPECIAL_CHAR,
+  "'(),",
+].join();
+
+export const REGEXP_ALPHABET = new RegExp(`[${REGEXSTR_ALPHABET}]*`);
+export const REGEXP_CHINESE = new RegExp(`[${REGEXSTR_CHINESE}]*`);
+export const REGEXP_MANDARIN = REGEXP_CHINESE;
+export const REGEXP_HIRA_KATA_KANA = new RegExp(
+  `[${REGEXSTR_HIRA_KATA_KANA}]*`
+);
+export const REGEXP_JAPANESE = REGEXP_HIRA_KATA_KANA;
+export const REGEXP_INTL_LETTER = new RegExp(`[${REGEXSTR_INTL_LETTER}]*`);
+export const REGEXP_NUMBER_VALUE = /^[+-]?((\d+(\.\d*)?)|(\.\d+))$/;

--- a/packages/nocodb/src/helpers/columnHelpers.ts
+++ b/packages/nocodb/src/helpers/columnHelpers.ts
@@ -6,6 +6,10 @@ import {
   UITypes,
 } from 'nocodb-sdk';
 import { pluralize, singularize } from 'inflection';
+import {
+  REGEXSTR_INTL_LETTER,
+  REGEXSTR_NUMERIC_ARABIC,
+} from 'nocodb-sdk';
 import type {
   BoolType,
   ColumnReqType,
@@ -464,7 +468,10 @@ export async function populateRollupForLTAR({
 
 export const sanitizeColumnName = (name: string, sourceType?: DriverClient) => {
   if (process.env.NC_SANITIZE_COLUMN_NAME === 'false') return name;
-  let columnName = name.replace(/\W/g, '_');
+  let columnName = name.replace(
+    new RegExp(`[^${REGEXSTR_INTL_LETTER}${REGEXSTR_NUMERIC_ARABIC}_]`, 'g'),
+    '_',
+  );
 
   // if column name only contains _ then return as 'field'
   if (/^_+$/.test(columnName)) columnName = 'field';

--- a/tests/playwright/tests/db/features/undo-redo.spec.ts
+++ b/tests/playwright/tests/db/features/undo-redo.spec.ts
@@ -600,6 +600,12 @@ test.describe('Undo Redo - LTAR', () => {
       requestUrlPathToMatch: `/api/v1/db/data/noco`,
       responseJsonMatcher: json => json.pageInfo,
     });
+    // adding a delay to make tests more consistent
+    await new Promise<void>(resolve =>
+      setTimeout(() => {
+        resolve();
+      }, 50)
+    );
     await verifyRecords(values);
   }
 


### PR DESCRIPTION
## Change Summary

Do not replace chinese, japanese and cryillic letters for column name. Closes: https://github.com/nocodb/nocodb/issues/8606

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)