### PR TITLE
fix (nc-gui): false readonly checkbox still show empty square

### DIFF
--- a/packages/nc-gui/components/cell/Checkbox/index.vue
+++ b/packages/nc-gui/components/cell/Checkbox/index.vue
@@ -98,9 +98,8 @@ const wrapperClassName = computed(() => {
   return [
     isForm?.value || isGallery.value || isExpandedFormOpen.value ? 'w-full flex-start pl-2' : 'w-full justify-center',
     {
-      'nc-cell-hover-show': !vModel.value && !readOnly?.value,
-      'opacity-0': readOnly?.value && !vModel.value,
-      'pointer-events-none': readOnly?.value,
+      'nc-cell-hover-show': !vModel.value,
+      // 'pointer-events-none': readOnly?.value,
     },
   ]
 })


### PR DESCRIPTION
## Change Summary

false readonly checkbox still show empty square. Closes https://github.com/nocodb/nocodb/issues/9815

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)