### PR TITLE
fix: send table alias for rollup when column is formula

### DIFF
--- a/packages/nocodb/src/db/genRollupSelectv2.ts
+++ b/packages/nocodb/src/db/genRollupSelectv2.ts
@@ -67,7 +67,7 @@ export default async function ({
           : childModel,
         rollupColumn,
         {},
-        undefined,
+        refTableAlias,
         false,
         formulOption.getParsedTree(),
         undefined,


### PR DESCRIPTION
## Change Summary

When a rollup refer to formula column, send table alias which previously not. Closes: https://github.com/nocodb/nocodb/issues/10429

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)