### PR TITLE
fix: Alt + Left Arrow Shortcut Causes Data Loss

### DIFF
--- a/packages/nc-gui/composables/useSelectedCellKeyupListener/index.ts
+++ b/packages/nc-gui/composables/useSelectedCellKeyupListener/index.ts
@@ -7,6 +7,13 @@ function useSelectedCellKeydownListener(
   { immediate = false, isGridCell = true }: { immediate?: boolean; isGridCell?: boolean } = {},
 ) {
   const finalHandler = (e: KeyboardEvent) => {
+    /**
+     * Add check for input/textarea elements
+     */
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      return;
+    }
+
     if (cmdKActive()) return
 
     /**

--- a/packages/nc-gui/composables/useSelectedCellKeyupListener/index.ts
+++ b/packages/nc-gui/composables/useSelectedCellKeyupListener/index.ts
@@ -10,7 +10,11 @@ function useSelectedCellKeydownListener(
     /**
      * Add check for input/textarea elements
      */
-    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+    if (
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement ||
+      (e.target instanceof HTMLElement && e.target.isContentEditable)
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fix of https://github.com/nocodb/nocodb/issues/10513

## Change Summary

Target Check: The added condition skips grid keyboard handling if the event occurs in an input/textarea.

Preserves Default Behavior: This allows native text navigation shortcuts (like Alt + Arrow) to work as expected in form fields.

Non-Intrusive: Maintains existing grid navigation behavior when not editing text cells.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
