### PR TITLE
fix: create view keyboard events should not affect the canvas when ex…

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
@@ -56,7 +56,7 @@ export function useKeyboardNavigation({
   const meta = inject(MetaInj, ref())
 
   const handleKeyDown = async (e: KeyboardEvent) => {
-    if (isViewSearchActive()) return
+    if (isViewSearchActive() || isCreateViewActive()) return
     const activeDropdownEl = document.querySelector(
       '.nc-dropdown-single-select-cell.active,.nc-dropdown-multi-select-cell.active',
     )

--- a/packages/nc-gui/utils/browserUtils.ts
+++ b/packages/nc-gui/utils/browserUtils.ts
@@ -10,6 +10,7 @@ export const isExtensionPaneActive = () => document.querySelector('.nc-extension
 export const isGeneralOverlayActive = () => document.querySelector('.nc-general-overlay')
 export const isSelectActive = () => document.querySelector('.ant-select-dropdown')
 export const isViewSearchActive = () => document.querySelector('.nc-view-search-data') === document.activeElement
+export const isCreateViewActive = () => document.querySelector('.nc-view-create-modal')
 
 export function hasAncestorWithClass(element: HTMLElement, className: string): boolean {
   return !!element.closest(`.${className}`)


### PR DESCRIPTION
…tension pane is open

## Change Summary

There's a bug when extension pane is open and canvas is open and you try to create a new view. The arrows won't work and backspace won't work.


https://github.com/user-attachments/assets/3861ab69-d621-4ff7-a323-fa570ff9150d


This PR fixes it.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
