### PR TITLE
fix: don't apply filtering for the assumed default view

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -3251,7 +3251,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
 
     await this.getCustomConditionsAndApply({
       column: relColumn,
-      view: childView,
+      view: relColOptions.fk_target_view_id ? childView : null,
       filters: filterObj,
       args,
       qb,
@@ -3342,7 +3342,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     const filterObj = extractFilterFromXwhere(where, aliasColObjMap);
     await this.getCustomConditionsAndApply({
       column: relColumn,
-      view: childView,
+      view: relColOptions.fk_target_view_id ? childView : null,
       filters: filterObj,
       args,
       qb,
@@ -3521,7 +3521,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
 
     await this.getCustomConditionsAndApply({
       column: relColumn,
-      view: targetView,
+      view: relColOptions.fk_target_view_id ? targetView : null,
       filters: filterObj,
       args,
       qb,
@@ -3753,7 +3753,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     );
     await this.getCustomConditionsAndApply({
       column: relColumn,
-      view: targetView,
+      view: relColOptions.fk_target_view_id ? targetView : null,
       filters: filterObj,
       args,
       qb,


### PR DESCRIPTION
## Change Summary

Don't filter for the assumed view used for sorting linked records.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
