### PR TITLE
fix: limit the number to safe integers

### DIFF
--- a/packages/nc-gui/components/cell/Integer/Editor.vue
+++ b/packages/nc-gui/components/cell/Integer/Editor.vue
@@ -35,7 +35,8 @@ const vModel = computed({
     } else if (isForm.value && !isEditColumn.value) {
       _vModel.value = isNaN(Number(value)) ? value : Number(value)
     } else {
-      _vModel.value = value
+      const currentValue = +(value ?? 0)
+      _vModel.value = toSafeInteger(currentValue)
     }
   },
 })

--- a/packages/nc-gui/composables/useMultiSelect/convertCellData.ts
+++ b/packages/nc-gui/composables/useMultiSelect/convertCellData.ts
@@ -44,7 +44,7 @@ export default function convertCellData(
           throw new SilentTypeConversionError()
         }
       }
-      return parsedNumber
+      return toSafeInteger(parsedNumber)
     }
     case UITypes.Currency:
     case UITypes.Percent:

--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -808,3 +808,7 @@ export const parsePlainCellValue = (
 
   return value as unknown as string
 }
+
+export function toSafeInteger(value: number) {
+  return Math.max(Number.MIN_SAFE_INTEGER, Math.min(value, Number.MAX_SAFE_INTEGER))
+}

--- a/packages/nocodb/src/helpers/catchError.ts
+++ b/packages/nocodb/src/helpers/catchError.ts
@@ -320,7 +320,11 @@ export function extractDBError(error): {
           const detailMatch = error.detail
             ? error.detail.match(/Column (\w+)/)
             : null;
-          const columnName = detailMatch ? detailMatch[1] : 'unknown';
+
+          const columnName =
+            detailMatch?.[1] ??
+            error.message.match(/ set\s+"([^"]+)"/)?.[1] ??
+            'unknown';
           message = `Invalid data type or value for column '${columnName}'.`;
           _type = DBError.DATA_TYPE_MISMATCH;
           _extra = { column: columnName };


### PR DESCRIPTION
## Change Summary

In PG, long numbers cause number overflow issues.

In Javascript, numbers after `Number.MAX_SAFE_VALUE` and before `Number.MIN_SAFE_VALUE` lose their precision so there is data loss. We fix the issue of number overflow by limiting the numeric values between the safe range.

Also the BE errors was throwing 'unknown' column error. Now it should correctly specify which column is causing the issue.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
