### PR TITLE
fix: double click on col resize shouldn't open column edit modal

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -262,6 +262,17 @@ const {
   setCursor,
 })
 
+const activeCursor = ref<CursorType>('auto')
+
+function setCursor(cursor: CursorType, customCondition?: (prevValue: CursorType) => boolean) {
+  if (customCondition && !customCondition(activeCursor.value)) return
+
+  if (activeCursor.value !== cursor) {
+    activeCursor.value = cursor
+    if (canvasRef.value && canvasRef.value.style?.cursor !== cursor) canvasRef.value.style.cursor = cursor
+  }
+}
+
 // Computed
 const noPadding = computed(() => paddingLessUITypes.has(editEnabled.value?.column.uidt as UITypes))
 
@@ -882,6 +893,7 @@ async function handleMouseUp(e: MouseEvent) {
           // On Double-click, should open the column edit dialog
           // kept under else to avoid opening the column edit dialog on doubleclicking the column menu icon
           else if (clickType === MouseClickType.DOUBLE_CLICK) {
+            if (activeCursor.value === 'col-resize') return
             handleEditColumn(e, false, clickedColumn.columnObj)
             requestAnimationFrame(triggerRefreshCanvas)
             return
@@ -1139,17 +1151,6 @@ const getHeaderTooltipRegions = (
   })
 
   return regions
-}
-
-const activeCursor = ref<CursorType>('auto')
-
-function setCursor(cursor: CursorType, customCondition?: (prevValue: CursorType) => boolean) {
-  if (customCondition && !customCondition(activeCursor.value)) return
-
-  if (activeCursor.value !== cursor) {
-    activeCursor.value = cursor
-    if (canvasRef.value && canvasRef.value.style?.cursor !== cursor) canvasRef.value.style.cursor = cursor
-  }
 }
 
 const handleMouseMove = (e: MouseEvent) => {

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -893,7 +893,10 @@ async function handleMouseUp(e: MouseEvent) {
           // On Double-click, should open the column edit dialog
           // kept under else to avoid opening the column edit dialog on doubleclicking the column menu icon
           else if (clickType === MouseClickType.DOUBLE_CLICK) {
+            // If active cursor is col-resize, we don't want an accidental double click to
+            // open the edit column modal as the intention is to resize the column
             if (activeCursor.value === 'col-resize') return
+
             handleEditColumn(e, false, clickedColumn.columnObj)
             requestAnimationFrame(triggerRefreshCanvas)
             return


### PR DESCRIPTION
## Change Summary

Double click on col resize should not open the column edit modal.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
