### PR TITLE
fix: Sanitise string literals in formula

### DIFF
--- a/packages/nocodb/src/db/formulav2/formulaQueryBuilderv2.ts
+++ b/packages/nocodb/src/db/formulav2/formulaQueryBuilderv2.ts
@@ -39,6 +39,7 @@ import FormulaColumn from '~/models/FormulaColumn';
 import { BaseUser, ButtonColumn } from '~/models';
 import { getRefColumnIfAlias } from '~/helpers';
 import { ExternalTimeout, NcError } from '~/helpers/catchError';
+import { sanitize } from '~/helpers/sqlSanitize';
 
 const logger = new Logger('FormulaQueryBuilderv2');
 
@@ -1121,7 +1122,11 @@ async function _formulaQueryBuilder(params: FormulaQueryBuilderBaseParams) {
         ),
       };
     } else if (pt.type === 'Literal') {
-      return { builder: knex.raw(`?${colAlias}`, [pt.value]) };
+      return {
+        builder: knex.raw(`?${colAlias}`, [
+          typeof pt.value === 'string' ? sanitize(pt.value) : pt.value,
+        ]),
+      };
     } else if (pt.type === 'Identifier') {
       const { builder } = (await aliasToColumn?.[pt.name]?.()) || {};
       if (typeof builder === 'function') {


### PR DESCRIPTION
## Change Summary

- Closes https://github.com/nocodb/nocodb/issues/10708
- Sanitise string literals in formula to escape `?` since it have special meaning in knex and treated as dynamic param.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
