### PR TITLE
Fix row filter split error

### DIFF
--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -173,6 +173,22 @@ export function validateRowFilters(_filters: FilterType[], data: any, columns: C
     return true
   }
 
+function safeToString(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  
+  // Handle arrays (especially arrays of objects with IDs)
+  if (Array.isArray(value)) {
+    return value.map(item => 
+      typeof item === 'object' && item !== null ? (item.id || '') : String(item || '')
+    ).join(',');
+  }
+  
+  // Handle regular values
+  return String(value || '');
+}
+
   const filters = buildFilterTree(_filters)
 
   let isValid = null
@@ -371,10 +387,10 @@ export function validateRowFilters(_filters: FilterType[], data: any, columns: C
               res = val != filter.value
               break
             case 'like':
-              res = data[field]?.toString?.()?.toLowerCase()?.indexOf(filter.value?.toLowerCase()) > -1
+              res = safeFieldValue.toLowerCase().indexOf(filter.value?.toLowerCase()) > -1
               break
             case 'nlike':
-              res = data[field]?.toString?.()?.toLowerCase()?.indexOf(filter.value?.toLowerCase()) === -1
+              res = safeFieldValue.toLowerCase().indexOf(filter.value?.toLowerCase()) === -1
               break
             case 'empty':
             case 'blank':
@@ -398,22 +414,22 @@ export function validateRowFilters(_filters: FilterType[], data: any, columns: C
               break
             case 'allof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                safeFieldValue.split(',').includes(item)
               )
               break
             case 'anyof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                safeFieldValue.split(',').includes(item)
               )
               break
             case 'nallof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                safeFieldValue.split(',').includes(item)
               )
               break
             case 'nanyof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                safeFieldValue.split(',').includes(item)
               )
               break
             case 'lt':

--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -377,6 +377,7 @@ function safeToString(value) {
               res = false // Unsupported operation for User fields
           }
         } else {
+          const safeFieldValue = safeToString(data[field]);
           switch (filter.comparison_op) {
             case 'eq':
               // eslint-disable-next-line eqeqeq

--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -415,22 +415,22 @@ function safeToString(value) {
               break
             case 'allof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                safeFieldValue.split(',').includes(item)
+                (safeFieldValue ? safeFieldValue.split(',') : []).includes(item)
               )
               break
             case 'anyof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                safeFieldValue.split(',').includes(item)
+                (safeFieldValue ? safeFieldValue.split(',') : []).includes(item)
               )
               break
             case 'nallof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                safeFieldValue.split(',').includes(item)
+                (safeFieldValue ? safeFieldValue.split(',') : []).includes(item)
               )
               break
             case 'nanyof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                safeFieldValue.split(',').includes(item)
+                (safeFieldValue ? safeFieldValue.split(',') : []).includes(item)
               )
               break
             case 'lt':


### PR DESCRIPTION
## Change Summary

This PR fixes an issue where the "Row Filtered" message wasn't appearing for rows that should have been filtered out. The root cause was that the filter comparison logic was trying to call string methods (like .split()) on non-string values, particularly arrays of objects from relation fields.

Added a safeToString helper function that properly converts field values to strings before they're used in string operations, ensuring the row validation works correctly for all data types.

This prevents the "TypeError: data[field].split is not a function" error that was preventing the isValidationFailed flag from being set correctly

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
