### PR TITLE
fix(nc-gui): Handle array fields in filter comparisons

### DIFF
--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -162,6 +162,16 @@ export const rowDefaultData = (columns: ColumnType[] = []) => {
   return defaultData
 }
 
+// Helper function just for getting ID(s) from possible LTAR field
+function getFieldValue(value) {
+  if (Array.isArray(value)) {
+    // If it's an array of objects with IDs, map to just the IDs
+    return value.map(item => item.id || item).join(',');
+  }
+  // Otherwise return the value as is
+  return value;
+}
+
 export const isRowEmpty = (record: Pick<Row, 'row'>, col: ColumnType): boolean => {
   if (!record || !col || !col.title) return true
 
@@ -361,6 +371,7 @@ export function validateRowFilters(_filters: FilterType[], data: any, columns: C
               res = false // Unsupported operation for User fields
           }
         } else {
+          const dataFieldValue = getFieldValue(data[field]);
           switch (filter.comparison_op) {
             case 'eq':
               // eslint-disable-next-line eqeqeq
@@ -398,22 +409,22 @@ export function validateRowFilters(_filters: FilterType[], data: any, columns: C
               break
             case 'allof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                (dataFieldValue?.split(',') ?? []).includes(item),
               )
               break
             case 'anyof':
               res = (filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                (dataFieldValue?.split(',') ?? []).includes(item),
               )
               break
             case 'nallof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).every((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                (dataFieldValue?.split(',') ?? []).includes(item),
               )
               break
             case 'nanyof':
               res = !(filter.value?.split(',').map((item) => item.trim()) ?? []).some((item) =>
-                (data[field]?.split(',') ?? []).includes(item),
+                (dataFieldValue?.split(',') ?? []).includes(item),
               )
               break
             case 'lt':


### PR DESCRIPTION
## Change Summary

Previously, filter comparisons (lallof, anyof, etc.) expected string values but would break when encountering fields that return arrays of objects. This PR adds inline handling to extract IDs from arrays when performing these comparisons.

Changes:
- Added array check and ID extraction for 'allof', 'anyof', 'nallof', and 'nanyof' cases
- Maintains existing behavior for non-array fields

Example:
Before: [{id: 1}, {id: 2}] would cause comparison errors After: [{id: 1}, {id: 2}] is properly handled as "1,2" for comparisons

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
