### PR TITLE
Fix null Japanese translation

### DIFF
--- a/packages/nc-gui/lang/ja.json
+++ b/packages/nc-gui/lang/ja.json
@@ -136,7 +136,7 @@
     "abort": "中止",
     "saving": "保存中",
     "cancel": "キャンセル",
-    "null": "ヌル",
+    "null": "null",
     "escape": "エスケープ",
     "hex": "16進数",
     "clear": "クリア",


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Null is usually written as null in Japanese.
Make sure that the null notation is used except in the translation location. If turn on the null indication in the options, the UI will look strange from a Japanese point of view.
