### PR TITLE
bug: add table display for linked items with URL handling 

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -418,8 +418,8 @@ const handleKeyDown = (e: KeyboardEvent) => {
               />
             </template>
             <template>
-              <div>
-                <table v-if="tableData && tableData.length">
+              <div class="linked-table-container">
+                <table v-if="tableData && tableData.length" class="linked-items-table">
                   <thead>
                     <tr>
                       <th v-for="(key, index) in Object.keys(tableData[0] || {})" :key="index">
@@ -428,17 +428,31 @@ const handleKeyDown = (e: KeyboardEvent) => {
                     </tr>
                   </thead>
                   <tbody>
-                    <tr v-for="(row, rowIndex) in tableData" :key="row.id || rowIndex">
-                      <td v-for="(value, key) in row" :key="key">
-                        <a v-if="isURL(value)" :href="value" target="_blank" rel="noopener noreferrer">
-                          {{ value }}
-                        </a>
-                        <span v-else>{{ value }}</span>
+                    <tr v-for="(row, rowIndex) in tableData" :key="row.id || rowIndex" class="linked-items-row">
+                     <td v-for="(value, key) in row" :key="key" class="linked-items-cell">
+                        <template v-if="isURL(value)">
+                          <a 
+                            :href="value" 
+                            target="_blank" 
+                            rel="noopener noreferrer"
+                            :title="value"
+                            class="linked-items-url"
+                            aria-label="Open link in new tab"
+                          >
+                            {{ value }}
+                          </a>
+                        </template>
+                        <span v-else>{{ value !== null && value !== undefined ? value : '' }}</span>
                       </td>
                     </tr>
                   </tbody>
                 </table>
-                <p v-else>No data available</p>
+                <div v-else-if="tableData && tableData.length === 0" class="no-data-message">
+                  <p>No data a vailable</p>
+                </div>
+                <div v-else class="loading-data">
+                  <p>Loading data...</p>
+                </div>
               </div>
             </template>
           </div>
@@ -576,6 +590,34 @@ const handleKeyDown = (e: KeyboardEvent) => {
   color: rgb(54, 54, 224);
   text-decoration: underline;
   cursor: pointer;
-}
+  }
+  .linked-items-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+  }
+
+  .linked-items-table th, 
+  .linked-items-table td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .linked-items-table th {
+    font-weight: 600;
+    background-color: #f9fafb;
+  }
+
+  .linked-items-row:hover {
+    background-color: #f9fafb;
+  }
+
+  .no-data-message,
+  .loading-data {
+    text-align: center;
+    padding: 1rem;
+    color: #6b7280;
+  }
 }
 </style>

--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -417,7 +417,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
                 @keydown.enter.prevent.stop="() => linkOrUnLink(refRow, id)"
               />
             </template>
-            <template>
+            <template v-if="tableData && tableData.length > 0 && showAsTable">
               <div class="linked-table-container">
                 <table v-if="tableData && tableData.length" class="linked-items-table">
                   <thead>

--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -6,6 +6,7 @@ interface Prop {
   modelValue?: boolean
   cellValue: any
   column: any
+  tableData: Array<any>
   items: number
 }
 
@@ -80,6 +81,17 @@ watch(
   },
   { immediate: true },
 )
+const isURL = (value: any): boolean => {
+  if (typeof value !== "string") return false;
+  if (!value.startsWith("http://") && !value.startsWith("https://")) return false;
+  
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 const unlinkRow = async (row: Record<string, any>, id: number) => {
   if (isNew.value) {
@@ -405,6 +417,30 @@ const handleKeyDown = (e: KeyboardEvent) => {
                 @keydown.enter.prevent.stop="() => linkOrUnLink(refRow, id)"
               />
             </template>
+            <template>
+              <div>
+                <table v-if="tableData && tableData.length">
+                  <thead>
+                    <tr>
+                      <th v-for="(key, index) in Object.keys(tableData[0] || {})" :key="index">
+                        {{ key }}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="(row, rowIndex) in tableData" :key="row.id || rowIndex">
+                      <td v-for="(value, key) in row" :key="key">
+                        <a v-if="isURL(value)" :href="value" target="_blank" rel="noopener noreferrer">
+                          {{ value }}
+                        </a>
+                        <span v-else>{{ value }}</span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-else>No data available</p>
+              </div>
+            </template>
           </div>
         </div>
         <div v-else class="h-full flex flex-col gap-2 my-auto items-center justify-center text-gray-500 text-center">
@@ -536,5 +572,10 @@ const handleKeyDown = (e: KeyboardEvent) => {
       @apply text-gray-500;
     }
   }
+  a {
+  color: rgb(54, 54, 224);
+  text-decoration: underline;
+  cursor: pointer;
+}
 }
 </style>


### PR DESCRIPTION
## Change Summary  
This PR **fixes** issue **#10812**, ensuring URLs in linked table views are rendered as clickable links instead of plain text.


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
✅ Verified that URLs are correctly detected and rendered as links in the default table grid view.
✅ Verified that URLs now function properly in linked table views.
✅ Tested the fix with an external PostgreSQL database.

Provide summary of changes.
URLs appeared as plain text instead of clickable links in the linked table view.
This bug was observed in NocoDB v0.262.1 with PostgreSQL as the external database.

Before (Bugged View)
🔴 URLs in linked tables were displayed as plain text (no clickable link).

After (Fixed View)
✅ URLs in linked tables are now properly formatted as clickable links.
