### PR TITLE
Fix: hide description field if no applicabale columns present

### DIFF
--- a/packages/nc-gui/components/dlg/View/Create.vue
+++ b/packages/nc-gui/components/dlg/View/Create.vue
@@ -1461,7 +1461,12 @@ const getPluralName = (name: string) => {
           '-mt-2': aiMode,
         }"
       >
-        <NcButton v-if="!enableDescription && !aiMode" size="small" type="text" @click.stop="toggleDescription">
+        <NcButton
+          v-if="!enableDescription && !aiMode && isNecessaryColumnsPresent"
+          size="small"
+          type="text"
+          @click.stop="toggleDescription"
+        >
           <div class="flex !text-gray-700 items-center gap-2">
             <GeneralIcon icon="plus" class="h-4 w-4" />
 


### PR DESCRIPTION
## Change Summary

The **Add Description** button previously appeared even when no applicable column types were present, which was redundant. This update hides the button when it's not needed.

### Before
<img src="https://github.com/user-attachments/assets/265b9427-1b20-4ec7-9cfe-7fdf50f0564c" width="600px" />


### After
<img width="407" alt="image" src="https://github.com/user-attachments/assets/5e575c80-e3f2-48a4-9cb4-20111354cae2" />


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
