### PR TITLE
Fix: Cmd+K visibility

### DIFF
--- a/packages/nc-gui/components/cmd-k/index.vue
+++ b/packages/nc-gui/components/cmd-k/index.vue
@@ -595,7 +595,7 @@ defineExpose({
   width: 100%;
   height: 100%;
   background-color: rgba(255, 255, 255, 0.5);
-  z-index: 1000;
+  z-index: 10000;
 
   color: rgb(60, 65, 73);
   font-size: 16px;

--- a/packages/nc-gui/components/cmd-k/index.vue
+++ b/packages/nc-gui/components/cmd-k/index.vue
@@ -595,7 +595,7 @@ defineExpose({
   width: 100%;
   height: 100%;
   background-color: rgba(255, 255, 255, 0.5);
-  z-index: 10000;
+  z-index: 1100;
 
   color: rgb(60, 65, 73);
   font-size: 16px;

--- a/packages/nc-gui/components/cmd-l/index.vue
+++ b/packages/nc-gui/components/cmd-l/index.vue
@@ -271,7 +271,7 @@ onMounted(() => {
   width: 100%;
   height: 100%;
   background-color: rgba(255, 255, 255, 0.5);
-  z-index: 10000;
+  z-index: 1100;
 
   color: rgb(60, 65, 73);
   font-size: 16px;

--- a/packages/nc-gui/components/cmd-l/index.vue
+++ b/packages/nc-gui/components/cmd-l/index.vue
@@ -271,7 +271,7 @@ onMounted(() => {
   width: 100%;
   height: 100%;
   background-color: rgba(255, 255, 255, 0.5);
-  z-index: 1000;
+  z-index: 10000;
 
   color: rgb(60, 65, 73);
   font-size: 16px;


### PR DESCRIPTION
## Change Summary

Fixes issue where the Cmd+K command modal doesn't appear on top when another modal is open (Attached current behaviour). Ensures Cmd+K modal is prioritized in z-index stacking.

https://github.com/user-attachments/assets/387beb94-c9c0-4e82-a9e1-9496594b1890


## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

