### PR TITLE
fix (nocodb-sdk): isFloat on cell.ts

### DIFF
--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/cell.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/cell.ts
@@ -22,7 +22,7 @@ export const isInt = (_column: ColumnType, abstractType: any) =>
   abstractType === 'integer';
 
 export const isFloat = (_column: ColumnType, abstractType: any) =>
-  abstractType === 'float' || abstractType === UITypes.Number;
+  abstractType === 'float' || column.uidt === UITypes.Number;
 
 export const isDate = (column: ColumnType, abstractType: any) =>
   abstractType === 'date' || column.uidt === UITypes.Date;

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/cell.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/cell.ts
@@ -21,7 +21,7 @@ export const isRichText = (column: ColumnType) =>
 export const isInt = (_column: ColumnType, abstractType: any) =>
   abstractType === 'integer';
 
-export const isFloat = (_column: ColumnType, abstractType: any) =>
+export const isFloat = (column: ColumnType, abstractType: any) =>
   abstractType === 'float' || column.uidt === UITypes.Number;
 
 export const isDate = (column: ColumnType, abstractType: any) =>


### PR DESCRIPTION
## Change Summary

fix (nocodb-sdk): isFloat on cell.ts previously compare abstract type with UITypes, and not uidt with UITypes.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
