### PR TITLE
fix: view loading indicator does not stops

### DIFF
--- a/packages/nc-gui/store/views.ts
+++ b/packages/nc-gui/store/views.ts
@@ -140,7 +140,7 @@ export const useViewsStore = defineStore('viewsStore', () => {
           tableId,
           (viewsByTable.value.get(tableId) ?? []).sort((a, b) => a.order! - b.order!),
         )
-
+        isViewsLoading.value = false
         return
       }
       if (!ignoreLoading) isViewsLoading.value = true


### PR DESCRIPTION
## Change Summary

- Go to All Tables Page
- Expand a Table in List
- Now open a view in the table. Now you will end up with loading indicator in toolbar and topbar

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
