### PR TITLE
docs: fix `NC_DISABLE_PG_DATA_REFLECTION` description

### DIFF
--- a/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
+++ b/packages/noco-docs/docs/020.getting-started/050.self-hosted/020.environment-variables.md
@@ -105,7 +105,7 @@ To update **either** `NC_ADMIN_EMAIL` or `NC_ADMIN_PASSWORD`, you must set **bot
 | `NC_ALLOW_LOCAL_HOOKS`               | No        | Allows webhooks to call local network links, posing potential security risks. Set to `true` to enable; all other values are considered `false`.                                                       | Defaults to `false`.                       |
 | `NC_SANITIZE_COLUMN_NAME`            | No        | Enables sanitization of column names during their creation to prevent SQL injection and other security issues.                                                                                        | Defaults to `true`.                        |
 | `NC_TOOL_DIR`                        | No        | Specifies the directory to store metadata and app-related files. In Docker setups, this maps to `/usr/app/data/` for mounting volumes.                                                                | Defaults to the current working directory. |
-| `NC_DISABLE_PG_DATA_REFLECTION`      | No        | Disables the creation of a schema for each base in PostgreSQL.  [Click here for more detail](#postgres-data-reflection)                                                                               |                                            |
+| `NC_DISABLE_PG_DATA_REFLECTION`      | No        | Disables the creation of a schema for each base in PostgreSQL.  [Click here for more detail](#postgres-data-reflection)                                                                               | Defaults to `false`.                                            |
 | `NC_MIGRATIONS_DISABLED`             | No        | Disables NocoDB migrations.                                                                                                                                                                           |                                            |
 | `NC_DISABLE_AUDIT`                   | No        | Disables the audit log feature.                                                                                                                                                                       | Defaults to `false`.                       |
 | `NC_AUTOMATION_LOG_LEVEL`            | No        | Configures logging levels for automation features. Possible values: `OFF`, `ERROR`, `ALL`. More details can be found under [Webhooks](/automation/webhook/create-webhook).                            | Defaults to `OFF`.                         |
@@ -114,7 +114,7 @@ To update **either** `NC_ADMIN_EMAIL` or `NC_ADMIN_PASSWORD`, you must set **bot
 
 NocoDB UI is exactly what's in your Postgres database schema. Same tables, same columns—everything is perfectly
 mirrored. This is done by creating a schema for each base in PostgreSQL. This feature is enabled by default if the user
-has the required permissions. To disable it, set the `NC_DISABLE_PG_DATA_REFLECTION` environment variable to `false`.
+has the required permissions. To disable it, set the `NC_DISABLE_PG_DATA_REFLECTION` environment variable to `true`.
 
 ## Logging & Monitoring
 


### PR DESCRIPTION
## Change Summary

Added [default value](https://github.com/nocodb/nocodb/blob/4c54106fea66ecba719f07d19105a7e262c9ecf3/packages/nocodb/src/helpers/initBaseBehaviour.ts#L77-L78) and fixed instructions to disable it.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)