### PR TITLE
fix: improve bulk update

### DIFF
--- a/packages/nocodb/src/utils/dataUtils.ts
+++ b/packages/nocodb/src/utils/dataUtils.ts
@@ -122,10 +122,16 @@ export const partialExtract = (obj: any, path: (string[] | string)[]) => {
 /**
  * Generates a batch update query using case statements
  * @param kn knex instance
- * @param tn table name
+ * @param tn table name or raw query for table
  * @param data array of objects to update (must include primary key)
  * @param pk primary key column name
  * @returns knex query object
+ *
+ * Generates queries in the format (supported by PostgreSQL, MySQL and SQLite):
+ * UPDATE table SET
+ *   col1 = CASE id WHEN 1 THEN 'val1' WHEN 2 THEN 'val2' ELSE col1 END,
+ *   col2 = CASE id WHEN 1 THEN 'val3' WHEN 2 THEN 'val4' ELSE col2 END
+ * WHERE id IN (1,2)
  */
 export function batchUpdate(
   kn: Knex,


### PR DESCRIPTION
## Change Summary

- Use when case to batch update multiple records with a single query which is a lot more sufficient

Simple Benchmark to compare using local PG show it is ~20x faster (Both used transaction, case when approach used batches of 1000 records per query)

```
Benchmark Results:
Batched CASE WHEN (tx):    94 ms — updated rows: 10000
Multiple UPDATEs (tx):     2046 ms — updated rows: 10000
```

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
