### PR TITLE
fix: args added to executable

### DIFF
--- a/scripts/pkg-executable/index.js
+++ b/scripts/pkg-executable/index.js
@@ -1,4 +1,33 @@
 process.env.NC_BINARY_BUILD = 'true';
+
+const args = process.argv.slice(2);
+
+const knownFlags = ['-h', '--help'];
+const unknownFlags = args.filter(arg => arg.startsWith('-') && !knownFlags.includes(arg));
+const helpText = `
+Usage:
+  nocodb [options]
+
+Options:
+  -h, --help     Show this help message and exit
+
+Description:
+  NocoDB turns your database into a smart spreadsheet.
+
+For more information, visit: https://github.com/nocodb/nocodb
+  `
+
+if (unknownFlags.length > 0) {
+  console.log(`Unknown option(s): ${unknownFlags.join(', ')}`);
+  console.log(helpText);
+  process.exit(1);
+}
+
+if (args.includes('-h') || args.includes('--help')) {
+  console.log(helpText);
+  process.exit(0);
+}
+
 (async () => {
   try {
     const app = require('express')();


### PR DESCRIPTION
Closes #11278
## Change Summary

- Fixes CLI help behavior for Homebrew and standalone executable builds.
- Adds handling for -h and --help flags to display a helpful usage message and exit without creating a noco.db file.
- Prints an error and help text for unknown CLI options.
- Ensures no unnecessary dependencies are loaded when only help is requested.

## Change type
- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
- Ran node scripts/pkg-executable/index.js -h and node scripts/pkg-executable/index.js --help to verify help message is shown and process exits cleanly.
- Ran with unknown options (e.g., --version) to verify error and help are shown.
- Ran with no options to verify normal server startup.

## Provide summary of changes
![image](https://github.com/user-attachments/assets/d0a3d1cd-bb00-4761-9f66-defb7d1f51f5)


Anything for maintainers to be made aware of
**NOTE:** If we plan to add more options, commands, or want advanced parsing features, we should use yargs, just how it is done for nc-cli.
