### PR TITLE
fix: avoid throwing if uidt is missing

### DIFF
--- a/packages/nocodb/src/models/Column.ts
+++ b/packages/nocodb/src/models/Column.ts
@@ -218,7 +218,11 @@ export default class Column<T = any> implements ColumnType {
       insertObj.source_id = model.source_id;
     }
 
-    if (!column.uidt) throw new Error('UI Datatype not found');
+    // Fallback to SingleLineText if no UI Datatype is provided
+    if (!column.uidt) {
+      insertObj.uidt = UITypes.SingleLineText;
+    }
+
     const row = await ncMeta.metaInsert2(
       context.workspace_id,
       context.base_id,


### PR DESCRIPTION
## Change Summary

Throwing here leads to row being created but not added to meta
Also in document we show uidt as non-mandatory

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

