### PR TITLE
fix (nc-gui): index prop lost after vmodel changed

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/SelectOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/SelectOptions.vue
@@ -405,12 +405,12 @@ onMounted(() => {
 
   isReverseLazyLoad.value = false
 
-  options.value = vModel.value.colOptions.options
+  options.value = [...vModel.value.colOptions.options]
 
   let indexCounter = 0
   options.value = options.value.map((el) => {
     el.index = indexCounter++
-    return el
+    return { ...el }
   })
 
   if (isKanbanStack.value) {


### PR DESCRIPTION
## Change Summary

fix (nc-gui): index prop lost after vmodel changed. Closes https://github.com/nocodb/nocodb/issues/11545

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)