### PR TITLE
fix (nocodb): check if select option is missing in kanban view

### DIFF
--- a/packages/nocodb/src/modules/jobs/jobs/export-import/import.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/import.service.ts
@@ -1749,9 +1749,16 @@ export class ImportService {
                   const tempVal = [];
                   for (const vl of mv as any) {
                     if (vl.fk_column_id) {
-                      const id = grpCol.colOptions.options.find(
+                      // check if the option is still exists on field option
+                      // currently any modification on field option
+                      // is not reflected yet to kanban view
+                      const metaValueOption = grpCol.colOptions.options.find(
                         (el) => el.title === vl.title,
-                      ).id;
+                      );
+                      if (!metaValueOption) {
+                        continue;
+                      }
+                      const id = metaValueOption.id;
                       tempVal.push({
                         ...vl,
                         fk_column_id: idMap.get(vl.fk_column_id),
@@ -1765,6 +1772,9 @@ export class ImportService {
                       });
                     }
                   }
+                  // TODO (optional): check grpCol.colOptions.options not exists in tempVal
+                  // and generate that
+
                   meta[idMap.get(mk)] = tempVal;
                 }
                 kanbanData[k] = meta;


### PR DESCRIPTION
## Change Summary

fix (nocodb): check if select option is missing in kanban view when duplicating table.

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)