### PR TITLE
fix: empty lookup when tranforming object

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -5337,7 +5337,11 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         if (alias) {
           if (ltarMap[key]) {
             // Handle LTAR/Lookup columns
-            if (ncIsArray(value) && value.length > 0 && ncIsObject(value[0])) {
+            if (
+              ncIsArray(value) &&
+              value.length > 0 &&
+              ncIsObject(value.filter((k) => k)[0])
+            ) {
               // Transform array of objects
               item[alias] = value.map((arrVal) =>
                 transformObject(arrVal, idToAliasMap),

--- a/packages/nocodb/src/helpers/dbHelpers.ts
+++ b/packages/nocodb/src/helpers/dbHelpers.ts
@@ -7,6 +7,7 @@ import {
   isVirtualCol,
   NcApiVersion,
   type NcContext,
+  ncIsNullOrUndefined,
   ncIsNumber,
   parseProp,
   RelationTypes,
@@ -330,6 +331,9 @@ export const isPrimitiveType = (val) =>
   typeof val === 'string' || typeof val === 'number';
 
 export function transformObject(value, idToAliasMap) {
+  if (ncIsNullOrUndefined(value)) {
+    return value;
+  }
   const result = {};
   Object.entries(value).forEach(([k, v]) => {
     const btAlias = idToAliasMap[k];


### PR DESCRIPTION
## Change Summary

fix: empty lookup when tranforming object. Closes https://github.com/nocodb/nocodb/issues/11696#issuecomment-2982867469

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)