### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ NocoDB is the fastest and easiest way to build databases online.
 
 <img src="https://static.scarf.sh/a.png?x-pxid=c12a77cc-855e-4602-8a0f-614b2d0da56a" />
 
+<p align="center">
+    Translated by readme-i18n:<!-- Keep these links. Translations will automatically update with the README. -->
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=de">Deutsch</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=es">Español</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=fr">français</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=ja">日本語</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=ko">한국어</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=pt">Português</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=ru">Русский</a> | 
+    <a href="https://www.readme-i18n.com/nocodb/nocodb?lang=zh">中文</a>
+</p>
+
 # Join Our Community
 
 <a href="https://discord.gg/5RgZmkW" target="_blank">


### PR DESCRIPTION
I noticed that the project already includes README translations in multiple languages, but they don't seem to be in sync with the latest version of the main README. This might be because updates to the main README aren't manually reflected in the translated versions.

I also noticed that some of the localized language labels look a bit unusual — for example, the Chinese translation is labeled "读我", which may not be the most natural or expected choice.

I’d like to suggest integrating [readme-i18n](https://www.readme-i18n.com/), a tool designed to automate README translations. By simply including links in the main README, users can easily access other language versions. Once integrated, all translations will stay automatically in sync with the latest README — no manual updates needed.

This PR includes links to 8 language versions. If you'd like to support more, you can follow the same link format. For example, to add Dutch: `<a href="https://www.readme-i18n.com/nocodb/nocodb?lang=nl">Nederlands</a>` 

Not sure about the translation quality? readme-i18n uses carefully engineered prompts and large language models, and it’s already being adopted by many popular projects. It’s worth giving it a try!

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
