### PR TITLE
fix: skip button field on airtable import

### DIFF
--- a/packages/nocodb/src/modules/jobs/jobs/at-import/at-import.processor.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/at-import/at-import.processor.ts
@@ -625,6 +625,18 @@ export class AtImportProcessor {
             continue;
           }
 
+          // not supported datatype: pure button field
+          // allow button based fields
+          if (ncCol.uidt === UITypes.Button) {
+            updateMigrationSkipLog(
+              tblSchema[i].name,
+              ncName.title,
+              col.type,
+              'column type not supported yet',
+            );
+            continue;
+          }
+
           // change from default 'tinytext' as airtable allows more than 255 characters
           // for single line text column type
           if (col.type === 'text') ncCol.dt = 'text';


### PR DESCRIPTION
## Change Summary

fix: skip button field on airtable import. Closes: https://github.com/nocodb/nocodb/issues/11775

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)