### PR TITLE
fix: minor ui correction #6013

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -1297,9 +1297,9 @@ async function handleMouseUp(e: MouseEvent, _elementMap: CanvasElement) {
           return
         } else {
           const columnWidth = parseCellWidth(clickedColumn.width)
-          const iconOffsetX = xOffset + columnWidth - 24
+          const iconOffsetX = xOffset + columnWidth - 24 + groupByColumns.value.length * 13
           // check if clicked on the column menu icon
-          if (y <= COLUMN_HEADER_HEIGHT_IN_PX && y > 0 && iconOffsetX <= x && iconOffsetX + 14 >= x) {
+          if (iconOffsetX <= x && iconOffsetX + 14 >= x) {
             if (isFieldNotEditable) return
 
             // if menu already in open state then close it on second click


### PR DESCRIPTION
## Change Summary

- Grid with Group By – The context menu for the display value field does not open when clicking on the chevron.
- Grid without Group By – The field context menu only opens when clicking precisely on the dropdown chevron. Clicking on the surrounding area, even though the cursor changes to a pointer, has no effect.


## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

