### PR TITLE
fix: when duplicate table, include row coloring info when view is default

### DIFF
--- a/packages/nocodb/src/models/View.ts
+++ b/packages/nocodb/src/models/View.ts
@@ -1389,6 +1389,7 @@ export default class View implements ViewType {
       expanded_record_mode?: ExpandedFormModeType;
       attachment_mode_column_id?: string;
       fk_custom_url_id?: string;
+      row_coloring_mode?: ROW_COLORING_MODE;
     },
     includeCreatedByAndUpdateBy = false,
     ncMeta = Noco.ncMeta,
@@ -1402,6 +1403,7 @@ export default class View implements ViewType {
       'password',
       'meta',
       'uuid',
+      'row_coloring_mode',
       ...(isEE ? ['fk_custom_url_id'] : []),
       ...(includeCreatedByAndUpdateBy ? ['owned_by', 'created_by'] : []),
       ...(isEE ? ['expanded_record_mode', 'attachment_mode_column_id'] : []),

--- a/packages/nocodb/src/modules/jobs/jobs/export-import/import.service.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/export-import/import.service.ts
@@ -21,8 +21,8 @@ import type {
   LinksColumn,
   LinkToAnotherRecordColumn,
   User,
-  View,
 } from '~/models';
+import { View } from '~/models';
 import { RowColorViewHelpers } from '~/helpers/rowColorViewHelpers';
 import { sanitizeColumnName } from '~/helpers';
 import { NcError } from '~/helpers/catchError';
@@ -1700,6 +1700,10 @@ export class ImportService {
     if (vw.is_default) {
       const view = views.find((a) => a.is_default);
       if (view) {
+        // update meta and coloring mode to default view
+        if (vw.row_coloring_mode || Object.keys(vw.meta ?? {}).length > 0) {
+          await View.update(context, view.id, vw);
+        }
         const gridData = withoutNull(vw.view);
         if (gridData) {
           await this.gridsService.gridViewUpdate(context, {


### PR DESCRIPTION
## Change Summary

fix: when duplicate table, include row coloring info when view is default

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)