### PR TITLE
fix: use view column order when downloading csv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NC_DB=pg://nc_pg:5432?u=postgres&p=password123&d=ncdb


### PR DESCRIPTION
## Change Summary

fix: use view column order when downloading csv. Ref: https://github.com/nocodb/nocodb/issues/11813

## Change type

- [ ] fix: (bug fix for the user, not a fix to a build script)