### PR TITLE
Upgrade alpine image to 3.21

### DIFF
--- a/packages/nocodb/Dockerfile.local
+++ b/packages/nocodb/Dockerfile.local
@@ -37,7 +37,7 @@ RUN pnpm install --prod --shamefully-hoist --reporter=silent \
 ########
 # Runner
 ########
-FROM alpine:3.20
+FROM alpine:3.21
 WORKDIR /usr/src/app
 
 ENV NC_DOCKER=0.6 \


### PR DESCRIPTION
## Change Summary


This pull request updates the base image version in the `Dockerfile.local` for the `nocodb` package to ensure compatibility and leverage improvements in the newer version.

Environment updates:

* `packages/nocodb/Dockerfile.local`: Updated the base image from `alpine:3.20` to `alpine:3.21` to incorporate the latest fixes and features of the Alpine Linux distribution.

## Additional information / screenshots

<img width="805" height="117" alt="Screenshot 2025-07-17 at 4 20 04 AM" src="https://github.com/user-attachments/assets/5f07b3e4-a053-430f-a447-cf7646708880" />

