### PR TITLE
fix: validate plugin input before update to prevent invalid plugin save

### DIFF
--- a/packages/nocodb/src/services/plugins.service.ts
+++ b/packages/nocodb/src/services/plugins.service.ts
@@ -37,6 +37,14 @@ export class PluginsService {
     req: NcRequest;
   }) {
     validatePayload('swagger.json#/components/schemas/PluginReq', param.plugin);
+    const pluginInfo = await Plugin.get(param.pluginId);
+    if (pluginInfo?.title && pluginInfo.category) {
+      await NcPluginMgrv2.test({
+        title: pluginInfo.title,
+        category: pluginInfo.category,
+        input: param.plugin.input,
+      });
+    }
 
     const plugin = await Plugin.update(param.pluginId, param.plugin);
 


### PR DESCRIPTION
## Change Summary

Fixes [#11751](https://github.com/nocodb/nocodb/issues/11751)

This PR ensures that plugin input is validated using `NcPluginMgrv2.test()` **before saving**, preventing invalid configurations from being stored.

Previously, a plugin could be saved without testing — leading to invalid configurations that only cause errors later during execution.

## Change type

- [x] fix (bug fix for the user, not a fix to a build script)

## Test/ Verification

### Code added:
```ts
const pluginInfo = await Plugin.get(param.pluginId);
if (pluginInfo?.title && pluginInfo.category) {
  await NcPluginMgrv2.test({
    title: pluginInfo.title,
    category: pluginInfo.category,
    input: param.plugin.input,
  });
}
