### PR TITLE
chore(nix): add fetcherVersion to pnpm.fetchDeps

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -110,8 +110,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = pnpm.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-ZGvsnSBOM/yW2aqBwsv/rE/7S6Pg1MvdCiCjbNZv/dw=";
-    fetcherVersion = 1;
+    hash = "sha256-SyBO1mb/lmelEMgpxyQ1ugbsxIlKf/2xjzJSHif4cVM=";
+    fetcherVersion = 2;
   };
 
   meta = {


### PR DESCRIPTION
## Change Summary

Fixes: https://github.com/nocodb/nocodb/issues/12276

Tested on my branch. Fixed the issue, plus the mismatch issue.

But I'm getting:
```
       > /build/source
       > Fetching Node.js 22.12.0 ...
       >  WARN  GET https://nodejs.org/download/release/v22.12.0/SHASUMS256.txt error (EAI_AGAIN). Will retry in 10 seconds. 2 retries left.
       >  WARN  GET https://nodejs.org/download/release/v22.12.0/SHASUMS256.txt error (EAI_AGAIN). Will retry in 1 minute. 1 retries left.
       >  EAI_AGAIN  request to https://nodejs.org/download/release/v22.12.0/SHASUMS256.txt failed, reason: getaddrinfo EAI_AGAIN nodejs.org
       >
       > FetchError: request to https://nodejs.org/download/release/v22.12.0/SHASUMS256.txt failed, reason: getaddrinfo EAI_AGAIN nodejs.org
       >     at ClientRequest.<anonymous> (/nix/store/r2n3dbbp0djly6wjxx43sbffaq3abjpy-pnpm-10.15.0/libexec/pnpm/dist/pnpm.cjs:41642:18)
       >     at ClientRequest.emit (node:events:518:28)
       >     at emitErrorEvent (node:_http_client:104:11)
       >     at TLSSocket.socketErrorListener (node:_http_client:518:5)
       >     at TLSSocket.emit (node:events:530:35)
       >     at emitErrorNT (node:internal/streams/destroy:170:8)
       >     at emitErrorCloseNT (node:internal/streams/destroy:129:3)
       >     at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
```
Seems like another issue though.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)