### PR TITLE
docs(swaggerV2): fix typo in example JSON key casing

### DIFF
--- a/packages/nocodb/src/services/api-docs/swaggerV2/templates/paths.ts
+++ b/packages/nocodb/src/services/api-docs/swaggerV2/templates/paths.ts
@@ -408,7 +408,7 @@ function getPaginatedResponseType(type: string) {
           $ref: `#/components/schemas/${type}`,
         },
       },
-      PageInfo: {
+      pageInfo: {
         $ref: `#/components/schemas/Paginated`,
       },
     },


### PR DESCRIPTION
## Change Summary

Correct casing of an example JSON key in the Swagger V2 documentation. 
The previous key casing was incorrect, which could confuse users when following the example.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Verified that the corrected JSON key matches the actual API response and the example now works as expected.

## Additional information / screenshots (optional)

<img width="99%" alt="list" src="https://github.com/user-attachments/assets/36dccdee-3006-415e-9e0e-a240ff74722d" />
<img width="49%" alt="Before" src="https://github.com/user-attachments/assets/a9fdeec7-ec95-4c1d-9f4a-8dce0f662d32" />
<img width="49%" alt="After" src="https://github.com/user-attachments/assets/65ed6ca9-b359-47ef-aeac-450919ce5a52" />