### PR TITLE
feat: auto-test-config

### DIFF
--- a/packages/nc-gui/composables/useAccountSetupStore.ts
+++ b/packages/nc-gui/composables/useAccountSetupStore.ts
@@ -56,6 +56,19 @@ const [useProvideAccountSetupStore, useAccountSetupStore] = createInjectionState
     loadingAction.value = Action.Save
 
     try {
+      if (activePlugin.value) {
+        const testRes = await $api.plugin.test({
+          input: JSON.stringify(activePluginFormData.value),
+          title: activePlugin.value.title,
+          category: activePlugin.value.category,
+        } as PluginTestReqType)
+
+        if (!testRes) {
+          message.error(t('msg.info.invalidCredentials'))
+          return
+        }
+      }
+
       await $api.plugin.update(activePlugin.value?.id, {
         input: JSON.stringify(activePluginFormData.value),
         active: true,

--- a/packages/nocodb/src/services/plugins.service.ts
+++ b/packages/nocodb/src/services/plugins.service.ts
@@ -38,6 +38,15 @@ export class PluginsService {
   }) {
     validatePayload('swagger.json#/components/schemas/PluginReq', param.plugin);
 
+    const pluginInfo = await Plugin.get(param.pluginId);
+    if (pluginInfo?.title && pluginInfo.category) {
+      await NcPluginMgrv2.test({
+        title: pluginInfo.title,
+        category: pluginInfo.category,
+        input: param.plugin.input,
+      });
+    }
+
     const plugin = await Plugin.update(param.pluginId, param.plugin);
 
     this.appHooksService.emit(


### PR DESCRIPTION
closes: #11751

## Change Summary

Provide summary of changes with issue number if any.

Frontend check:

- Runs immediately when the user hits Save in the GUI.
- Provides instant feedback (invalidCredentials message).
- Prevents frustrating round-trips where the user saves, then only later sees a failure.

Backend check

- Acts as the last line of defense.
- Even if someone skips the GUI and uses the API directly, invalid configs won’t be stored.
- Ensures data integrity across all clients (CLI, API, integrations).

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
