### PR TITLE
fix: removeNullUnicode when JSON_EXTRACT

### DIFF
--- a/packages/nocodb/src/db/functionMappings/pg.ts
+++ b/packages/nocodb/src/db/functionMappings/pg.ts
@@ -419,7 +419,7 @@ END`,
 
     const removeNullUnicode = (source: string) => {
       // use four backspace so it will translate into two backspace in sql query
-      return `regexp_replace(${source}, '\\\\u0000', 'u0000')`;
+      return `regexp_replace(${source}, '\\\\u0000', 'u0000', 'g')`;
     };
     return {
       builder: knex.raw(


### PR DESCRIPTION
## Change Summary

fix: removeNullUnicode when JSON_EXTRACT. Ref https://github.com/nocodb/nocodb/issues/12377

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)