### PR TITLE
feat: case-insensitive-search-api

### DIFF
--- a/packages/nocodb/src/utils/data-transformation.builder.ts
+++ b/packages/nocodb/src/utils/data-transformation.builder.ts
@@ -61,6 +61,42 @@ export class ApiV3DataTransformationBuilder<
     return this;
   }
 
+  filterLike<S = Input, T = Output>(
+    field: string,
+    value: string,
+    caseInsensitive = true,
+  ): this {
+    this.transformations.push((data: S) => {
+      if (Array.isArray(data)) {
+        return data.filter((item) => {
+          const fieldValue = item[field as keyof typeof item];
+          if (typeof fieldValue === 'string') {
+            const filterVal = caseInsensitive ? value.toLowerCase() : value;
+            const itemVal = caseInsensitive
+              ? fieldValue.toLowerCase()
+              : fieldValue;
+            if (filterVal.startsWith('%') && filterVal.endsWith('%')) {
+              return itemVal.includes(
+                filterVal.substring(1, filterVal.length - 1),
+              );
+            } else if (filterVal.startsWith('%')) {
+              return itemVal.endsWith(filterVal.substring(1));
+            } else if (filterVal.endsWith('%')) {
+              return itemVal.startsWith(
+                filterVal.substring(0, filterVal.length - 1),
+              );
+            } else {
+              return itemVal === filterVal;
+            }
+          }
+          return false;
+        }) as unknown as T;
+      }
+      return data as unknown as T;
+    });
+    return this;
+  }
+
   metaTransform<S = Input, T = Output>({
     snakeCase = true,
     camelCase = false,


### PR DESCRIPTION
closes: #9874

## Change Summary

Provide summary of changes with issue number if any.

✅ Added filterLike method in ApiV3DataTransformationBuilder to support filtering arrays by string values.
✅ Implemented case-insensitive matching by normalizing both field values and search term with toLowerCase().
✅ Added support for SQL-like wildcard patterns (%value, value%, %value%) for flexible partial matches.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

The changes allow users to:

- Perform case-insensitive filtering on string fields in API v3 responses.
- Use partial match patterns (starts with, ends with, contains) similar to SQL LIKE.
- Ensure consistent behavior regardless of capitalization in stored data (e.g., "John@Example.com" matches "john@example.com").
