### PR TITLE
feat: nc-db-max-connection-pool-env

### DIFF
--- a/packages/nocodb/src/db/sql-migrator/lib/templates/mysql.template.ts
+++ b/packages/nocodb/src/db/sql-migrator/lib/templates/mysql.template.ts
@@ -14,6 +14,7 @@ export default {
             password: 'password',
             database: 'default_dev',
           },
+          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',
@@ -33,6 +34,7 @@ export default {
             password: 'password',
             database: 'default_test',
           },
+          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',

--- a/packages/nocodb/src/db/sql-migrator/lib/templates/mysql.template.ts
+++ b/packages/nocodb/src/db/sql-migrator/lib/templates/mysql.template.ts
@@ -14,7 +14,7 @@ export default {
             password: 'password',
             database: 'default_dev',
           },
-          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
+          pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',
@@ -34,7 +34,7 @@ export default {
             password: 'password',
             database: 'default_test',
           },
-          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
+          pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',

--- a/packages/nocodb/src/db/sql-migrator/lib/templates/pg.template.ts
+++ b/packages/nocodb/src/db/sql-migrator/lib/templates/pg.template.ts
@@ -14,6 +14,7 @@ export default {
             password: 'password',
             database: 'default_dev',
           },
+          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',
@@ -32,6 +33,7 @@ export default {
             password: 'password',
             database: 'default_test',
           },
+          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',

--- a/packages/nocodb/src/db/sql-migrator/lib/templates/pg.template.ts
+++ b/packages/nocodb/src/db/sql-migrator/lib/templates/pg.template.ts
@@ -14,7 +14,7 @@ export default {
             password: 'password',
             database: 'default_dev',
           },
-          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
+          pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',
@@ -33,7 +33,7 @@ export default {
             password: 'password',
             database: 'default_test',
           },
-          pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 10 },
+          pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 10 },
           meta: {
             tn: 'nc_evolutions',
             dbAlias: 'primary',

--- a/packages/nocodb/src/utils/nc-config/constants.ts
+++ b/packages/nocodb/src/utils/nc-config/constants.ts
@@ -23,7 +23,11 @@ export const defaultConnectionConfig: any = {
 export const defaultConnectionOptions = {
   pool: {
     min: 0,
-    max: +process.env.NC_DB_POOL_MAX || 10,
+    max: (() => {
+      const poolSize = parseInt(process.env.DB_MAX_POOL_SIZE || '10', 10);
+      if (Number.isNaN(poolSize) || poolSize < 1) return 10;
+      return Math.min(poolSize, 100);
+    })(),
   },
 };
 

--- a/packages/nocodb/src/utils/nc-config/constants.ts
+++ b/packages/nocodb/src/utils/nc-config/constants.ts
@@ -24,7 +24,7 @@ export const defaultConnectionOptions = {
   pool: {
     min: 0,
     max: (() => {
-      const poolSize = parseInt(process.env.DB_MAX_POOL_SIZE || '10', 10);
+      const poolSize = parseInt(process.env.NC_DB_MAX_POOL_SIZE || '10', 10);
       if (Number.isNaN(poolSize) || poolSize < 1) return 10;
       return Math.min(poolSize, 100);
     })(),

--- a/packages/nocodb/tests/unit/TestDbMngr.ts
+++ b/packages/nocodb/tests/unit/TestDbMngr.ts
@@ -19,6 +19,7 @@ export default class TestDbMngr {
     host: 'localhost',
     port: 3306,
     client: 'mysql2',
+    pool: { min: 0, max: parseInt(process.env.DB_MAX_POOL_SIZE ?? '5', 10) },
   };
 
   public static pgConnection = {
@@ -27,6 +28,7 @@ export default class TestDbMngr {
     host: 'localhost',
     port: 5432,
     client: 'pg',
+    pool: { min: 0, max: parseInt(process.env.DB_MAX_POOL_SIZE ?? '1', 10) },
   };
 
   public static connection: {

--- a/packages/nocodb/tests/unit/TestDbMngr.ts
+++ b/packages/nocodb/tests/unit/TestDbMngr.ts
@@ -19,7 +19,7 @@ export default class TestDbMngr {
     host: 'localhost',
     port: 3306,
     client: 'mysql2',
-    pool: { min: 0, max: parseInt(process.env.DB_MAX_POOL_SIZE ?? '5', 10) },
+    pool: { min: 0, max: parseInt(process.env.NC_DB_MAX_POOL_SIZE ?? '5', 10) },
   };
 
   public static pgConnection = {
@@ -28,7 +28,7 @@ export default class TestDbMngr {
     host: 'localhost',
     port: 5432,
     client: 'pg',
-    pool: { min: 0, max: parseInt(process.env.DB_MAX_POOL_SIZE ?? '1', 10) },
+    pool: { min: 0, max: parseInt(process.env.NC_DB_MAX_POOL_SIZE ?? '1', 10) },
   };
 
   public static connection: {

--- a/tests/playwright/tests/utils/config.ts
+++ b/tests/playwright/tests/utils/config.ts
@@ -10,7 +10,7 @@ const knexConfig = {
       multipleStatements: true,
     },
     searchPath: ['public', 'information_schema'],
-    pool: { min: 0, max: 1 },
+    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 1 },
   },
   mysql: {
     client: 'mysql2',
@@ -22,7 +22,7 @@ const knexConfig = {
       database: 'sakila',
       multipleStatements: true,
     },
-    pool: { min: 0, max: 5 },
+    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 5 },
   },
   sqlite: {
     client: 'sqlite3',
@@ -30,7 +30,7 @@ const knexConfig = {
       filename: './mydb.sqlite3',
     },
     useNullAsDefault: true,
-    pool: { min: 0, max: 5 },
+    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 5 },
   },
 };
 

--- a/tests/playwright/tests/utils/config.ts
+++ b/tests/playwright/tests/utils/config.ts
@@ -10,7 +10,7 @@ const knexConfig = {
       multipleStatements: true,
     },
     searchPath: ['public', 'information_schema'],
-    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 1 },
+    pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 1 },
   },
   mysql: {
     client: 'mysql2',
@@ -22,7 +22,7 @@ const knexConfig = {
       database: 'sakila',
       multipleStatements: true,
     },
-    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 5 },
+    pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 5 },
   },
   sqlite: {
     client: 'sqlite3',
@@ -30,7 +30,7 @@ const knexConfig = {
       filename: './mydb.sqlite3',
     },
     useNullAsDefault: true,
-    pool: { min: 0, max: +process.env.DB_MAX_POOL_SIZE || 5 },
+    pool: { min: 0, max: +process.env.NC_DB_MAX_POOL_SIZE || 5 },
   },
 };
 


### PR DESCRIPTION
closes: #9973

## Change Summary

Provide summary of changes with issue number if any.

✅ Added support for configuring database connection pool size via an environment variable.
✅ Updated the default database configuration to read `NC_DB_MAX_POOL_SIZE`.
✅ If `NC_DB_MAX_POOL_SIZE` is set, the max property of the connection pool uses this value; otherwise, it defaults to 10.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

Provide summary of changes.

The changes allow users to:

- Scale database connection pools dynamically by setting `NC_DB_MAX_POOL_SIZE` in their environment.
- Retain default connection pool size of 10 if the environment variable is not set.
- All pool configurations now use a consistent and safe parsing approach for the environment variable,