### PR TITLE
fix: update link to Commit Message Convention in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Please refer to [Development Setup](https://docs.nocodb.com/engineering/developm
 
 ### Committing Changes
 
-We encourage all contributors to commit messages following [Commit Message Convention](./COMMIT_CONVENTION.md).
+We encourage all contributors to commit messages following [Commit Message Convention](/.github/COMMIT_CONVENTION.md).
 
 ### Applying License
 


### PR DESCRIPTION
## Change Summary

  The Issue :

  The link to the COMMIT_CONVENTION.md file was broken when viewing the CONTRIBUTING.md file from the repository's main "Contributing" tab (displayed in the 
  header of the repository page). The relative link was being resolved from the repository root instead of from within the .github directory, which resulted in a 
  "404 Not Found" error for users trying to access the commit convention guidelines.

  The Fix

  This PR replaces the broken relative link with the full, absolute URL pointing to the COMMIT_CONVENTION.md file on the develop branch. Using an absolute URL is 
  the most robust solution, ensuring the link works correctly for all users across all of GitHub's different file-viewing contexts (the special "Contributing" 
  tab, the direct file browser, etc.).

 ## Change type

   - [ ] feat: (new feature for the user, not a new feature for build script)
   - [ ] fix: (bug fix for the user, not a fix to a build script)
   - [x] docs: (changes to the documentation)
   - [ ] style: (formatting, missing semi colons, etc; no production code change)
   - [ ] refactor: (refactoring production code, eg. renaming a variable)
   - [ ] test: (adding missing tests, refactoring tests; no production code change)
   - [ ] chore: (updating grunt tasks etc; no production code change)

##  Test/ Verification

  To verify the fix:
   1. Navigate to the main repository page and click on the "Contributing" tab in the header.
   2. Scroll to the "Committing Changes" section.
   3. Click the "Commit Message Convention" link and confirm it opens the correct document.
   4. Navigate directly to the /.github/CONTRIBUTING.md file via the file browser.
   5. Click the same link and confirm it still opens the correct document.
   
 ## Additional information / screenshots (optional)   
<img width="1568" height="546" alt="image" src="https://github.com/user-attachments/assets/df05ea64-d145-4382-9709-f8147b89ef78" />
<img width="1573" height="986" alt="image" src="https://github.com/user-attachments/assets/510f7988-edc5-4755-8058-ca1b90eabb96" />

