### PR TITLE
fix: handle IME composition for Korean input in table title rename

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView/Table/Node.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Table/Node.vue
@@ -516,7 +516,26 @@ async function onRename() {
             }"
             @blur="onRename"
             @keydown.stop="onKeyDown($event)"
+            @compositionstart="onCompositionStart"
+            @compositionend="onCompositionEnd"
+            @input="onInputHandler"
           />
+const isComposing = ref(false)
+
+      function onCompositionStart() {
+        isComposing.value = true
+      }
+      
+      function onCompositionEnd(e: CompositionEvent) {
+        isComposing.value = false
+        formState.title = (e.target as HTMLInputElement).value
+      }
+      
+      function onInputHandler(e: InputEvent) {
+        if (!isComposing.value) {
+          formState.title = (e.target as HTMLInputElement).value
+        }
+      }
         </a-form>
         <NcTooltip
           v-else


### PR DESCRIPTION
#Change Summary
 1. Fixes issue #12421: Cursor jumps to the end when inserting Korean text in the middle of form titles.
 2. Added proper IME (Input Method Editor) composition event handling to the table title input in the sidebar ([Node.vue](https://studious-space-garbanzo-5gq65x54j6jr347wr.github.dev/)).
 3. Korean and other IME-based text can now be inserted at the cursor position without cutting or moving to the end.
Change type (bug fix for the user, not a fix to a build script)

#Test/ Verification
 1. Manually tested by renaming a table and inserting Korean text in the middle of the title.
 2. Verified that the text is inserted at the correct cursor position and the cursor does not jump to the end.
 3. No regression for English or other direct-input languages.

#Additional information / screenshots (optional)
See issue #12421 for user-reported details and screenshots