### PR TITLE
Fix: Lock pre-filled as readonly is not working for virtual links/ltar fields

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -49,6 +49,8 @@ const isForm = inject(IsFormInj, ref(false))
 
 const isUnderLTAR = inject(IsUnderLTARInj, ref(false))
 
+const isUnderLookup = inject(IsUnderLookupInj, ref(false))
+
 const isGrid = inject(IsGridInj, ref(false))
 
 const isPublic = inject(IsPublicInj, ref(false))
@@ -248,7 +250,13 @@ const showReadonlyField = computed(() => {
 })
 
 const showLockedOverlay = computed(() => {
+  /**
+   * We have to show lock overlay only on root level of the cell
+   * else overlay will cover area of rendered cell and actual value will not be visible
+   */
   return (
+    !isUnderLookup.value &&
+    !isUnderLTAR.value &&
     ((isPublic.value && readOnly.value && !isForm.value) || isSystemColumn(column.value)) &&
     cellType.value !== 'attachment' &&
     cellType.value !== 'textarea' &&

--- a/packages/nc-gui/components/virtual-cell/BelongsTo.vue
+++ b/packages/nc-gui/components/virtual-cell/BelongsTo.vue
@@ -47,7 +47,7 @@ const { relatedTableMeta, loadRelatedTableMeta, relatedTableDisplayValueProp, re
 await loadRelatedTableMeta()
 
 const hasEditPermission = computed(() => {
-  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || isForm.value
+  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || (isForm.value && !readOnly.value)
 })
 
 const value = computed(() => {
@@ -165,6 +165,7 @@ onUnmounted(() => {
               "
               :column="belongsToColumn"
               :show-unlink-button="true"
+              :readonly="readOnly"
               @unlink="unlinkRef(value)"
             />
           </template>

--- a/packages/nc-gui/components/virtual-cell/BelongsTo.vue
+++ b/packages/nc-gui/components/virtual-cell/BelongsTo.vue
@@ -165,7 +165,6 @@ onUnmounted(() => {
               "
               :column="belongsToColumn"
               :show-unlink-button="true"
-              :readonly="readOnly"
               @unlink="unlinkRef(value)"
             />
           </template>

--- a/packages/nc-gui/components/virtual-cell/HasMany.vue
+++ b/packages/nc-gui/components/virtual-cell/HasMany.vue
@@ -215,7 +215,6 @@ onUnmounted(() => {
             :column="hasManyColumn"
             :show-unlink-button="false"
             :truncate="false"
-            :readonly="readOnly"
             @unlink="unlinkRef(cell.item)"
           />
 

--- a/packages/nc-gui/components/virtual-cell/HasMany.vue
+++ b/packages/nc-gui/components/virtual-cell/HasMany.vue
@@ -56,7 +56,7 @@ const { relatedTableMeta, loadRelatedTableMeta, relatedTableDisplayValueProp, un
 await loadRelatedTableMeta()
 
 const hasEditPermission = computed(() => {
-  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || isForm.value
+  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || (isForm.value && !readOnly.value)
 })
 
 const localCellValue = computed<any[]>(() => {
@@ -215,6 +215,7 @@ onUnmounted(() => {
             :column="hasManyColumn"
             :show-unlink-button="false"
             :truncate="false"
+            :readonly="readOnly"
             @unlink="unlinkRef(cell.item)"
           />
 

--- a/packages/nc-gui/components/virtual-cell/Links.vue
+++ b/packages/nc-gui/components/virtual-cell/Links.vue
@@ -58,7 +58,7 @@ const relatedTableDisplayColumn = computed(
 loadRelatedTableMeta()
 
 const hasEditPermission = computed(() => {
-  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || isForm.value
+  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || (isForm.value && !readOnly.value)
 })
 
 const textVal = computed(() => {
@@ -203,8 +203,8 @@ onUnmounted(() => {
             class="text-center nc-datatype-link underline-transparent nc-canvas-links-text font-weight-500"
             :class="{ '!text-gray-300': !textVal }"
             :tabindex="readOnly ? -1 : 0"
-            @click.stop.prevent="isForm && !isExpandedFormOpen ? openListDlg() : openChildList()"
-            @keydown.enter.stop.prevent="isForm && !isExpandedFormOpen ? openListDlg() : openChildList"
+            @click.stop.prevent="isForm && !isExpandedFormOpen && hasEditPermission ? openListDlg() : openChildList()"
+            @keydown.enter.stop.prevent="isForm && !isExpandedFormOpen && hasEditPermission ? openListDlg() : openChildList"
           >
             {{ textVal }}
           </component>

--- a/packages/nc-gui/components/virtual-cell/ManyToMany.vue
+++ b/packages/nc-gui/components/virtual-cell/ManyToMany.vue
@@ -213,7 +213,6 @@ onUnmounted(() => {
             :column="m2mColumn"
             :show-unlink-button="false"
             :truncate="false"
-            :readonly="readOnly"
             @unlink="unlinkRef(cell.item)"
           />
 

--- a/packages/nc-gui/components/virtual-cell/ManyToMany.vue
+++ b/packages/nc-gui/components/virtual-cell/ManyToMany.vue
@@ -55,7 +55,7 @@ const { relatedTableMeta, loadRelatedTableMeta, relatedTableDisplayValueProp, un
 await loadRelatedTableMeta()
 
 const hasEditPermission = computed(() => {
-  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || isForm.value
+  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || (isForm.value && !readOnly.value)
 })
 
 const localCellValue = computed<any[]>(() => {
@@ -213,6 +213,7 @@ onUnmounted(() => {
             :column="m2mColumn"
             :show-unlink-button="false"
             :truncate="false"
+            :readonly="readOnly"
             @unlink="unlinkRef(cell.item)"
           />
 

--- a/packages/nc-gui/components/virtual-cell/OneToOne.vue
+++ b/packages/nc-gui/components/virtual-cell/OneToOne.vue
@@ -47,7 +47,7 @@ const { relatedTableMeta, loadRelatedTableMeta, relatedTableDisplayValueProp, re
 await loadRelatedTableMeta()
 
 const hasEditPermission = computed(() => {
-  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || isForm.value
+  return (!readOnly.value && isUIAllowed('dataEdit') && !isUnderLookup.value) || (isForm.value && !readOnly.value)
 })
 
 const addIcon = computed(() => (cellValue?.value ? 'maximize' : 'plus'))
@@ -162,6 +162,7 @@ onUnmounted(() => {
             "
             :column="belongsToColumn"
             :show-unlink-button="true"
+            :readonly="readOnly"
             @unlink="unlinkRef(value)"
           />
         </template>

--- a/packages/nc-gui/components/virtual-cell/OneToOne.vue
+++ b/packages/nc-gui/components/virtual-cell/OneToOne.vue
@@ -162,7 +162,6 @@ onUnmounted(() => {
             "
             :column="belongsToColumn"
             :show-unlink-button="true"
-            :readonly="readOnly"
             @unlink="unlinkRef(value)"
           />
         </template>

--- a/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
+++ b/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
@@ -44,7 +44,7 @@ const reloadTrigger = inject(ReloadRowDataHookInj, createEventHook())
 const reloadViewDataTrigger = inject(ReloadViewDataHookInj, createEventHook())
 
 const isClickDisabled = computed(() => {
-  return !active.value && !isExpandedForm.value
+  return (!active.value && !isExpandedForm.value) || isPublic.value || isForm.value || readonlyProp.value
 })
 
 const { open } = useExpandedFormDetached()
@@ -53,31 +53,32 @@ function openExpandedForm() {
   if (isClickDisabled.value) return
 
   const rowId = extractPkFromRow(item.value, relatedTableMeta.value.columns as ColumnType[])
-  if (!isPublic.value && !readonlyProp.value && rowId) {
-    open({
-      isOpen: true,
-      row: { row: item.value, rowMeta: {}, oldRow: { ...item.value } },
-      meta: relatedTableMeta.value,
-      rowId,
-      useMetaFields: true,
-      maintainDefaultViewOrder: true,
-      loadRow: !isPublic.value,
-      skipReload: true,
-      createdRecord: onCreatedRecord,
+
+  if (!rowId) return
+
+  open({
+    isOpen: true,
+    row: { row: item.value, rowMeta: {}, oldRow: { ...item.value } },
+    meta: relatedTableMeta.value,
+    rowId,
+    useMetaFields: true,
+    maintainDefaultViewOrder: true,
+    loadRow: !isPublic.value,
+    skipReload: true,
+    createdRecord: onCreatedRecord,
+  })
+
+  function onCreatedRecord() {
+    reloadTrigger?.trigger({
+      shouldShowLoading: false,
     })
 
-    function onCreatedRecord() {
-      reloadTrigger?.trigger({
-        shouldShowLoading: false,
-      })
-
-      reloadViewDataTrigger?.trigger({
-        shouldShowLoading: false,
-        isFromLinkRecord: true,
-        relatedTableMetaId: relatedTableMeta.value.id,
-        rowId: rowId!,
-      })
-    }
+    reloadViewDataTrigger?.trigger({
+      shouldShowLoading: false,
+      isFromLinkRecord: true,
+      relatedTableMetaId: relatedTableMeta.value.id,
+      rowId: rowId!,
+    })
   }
 }
 </script>

--- a/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
+++ b/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
@@ -17,9 +17,9 @@ const props = withDefaults(defineProps<Props>(), {
   truncate: true,
 })
 
-const { item, value, column, readonly: readonlyProp } = toRefs(props)
-
 const emit = defineEmits(['unlink'])
+
+const { item, value, column, readonly: readonlyProp } = toRefs(props)
 
 const { relatedTableMeta, externalBaseUserRoles } = useLTARStoreOrThrow()!
 

--- a/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
+++ b/packages/nc-gui/components/virtual-cell/components/ItemChip.vue
@@ -12,7 +12,12 @@ interface Props {
   truncate?: boolean
 }
 
-const { value, item, column, showUnlinkButton, border = true, readonly: readonlyProp, truncate = true } = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  border: true,
+  truncate: true,
+})
+
+const { item, value, column, readonly: readonlyProp } = toRefs(props)
 
 const emit = defineEmits(['unlink'])
 
@@ -21,6 +26,8 @@ const { relatedTableMeta, externalBaseUserRoles } = useLTARStoreOrThrow()!
 const { isUIAllowed } = useRoles()
 
 provide(IsUnderLTARInj, ref(true))
+
+provide(MetaInj, relatedTableMeta)
 
 const readOnly = inject(ReadonlyInj, ref(false))
 
@@ -45,11 +52,11 @@ const { open } = useExpandedFormDetached()
 function openExpandedForm() {
   if (isClickDisabled.value) return
 
-  const rowId = extractPkFromRow(item, relatedTableMeta.value.columns as ColumnType[])
-  if (!isPublic.value && !readonlyProp && rowId) {
+  const rowId = extractPkFromRow(item.value, relatedTableMeta.value.columns as ColumnType[])
+  if (!isPublic.value && !readonlyProp.value && rowId) {
     open({
       isOpen: true,
-      row: { row: item, rowMeta: {}, oldRow: { ...item } },
+      row: { row: item.value, rowMeta: {}, oldRow: { ...item.value } },
       meta: relatedTableMeta.value,
       rowId,
       useMetaFields: true,

--- a/packages/nc-gui/components/virtual-cell/components/ListItem.vue
+++ b/packages/nc-gui/components/virtual-cell/components/ListItem.vue
@@ -159,7 +159,7 @@ const attachments: ComputedRef<Attachment[]> = computed(() => {
             </div>
           </div>
         </div>
-        <div v-if="!isForm && !isPublic" class="flex-none flex items-center w-7" @clcik.stop>
+        <div v-if="!isForm && !isPublic" class="flex-none flex items-center w-7" @click.stop>
           <NcTooltip class="flex" hide-on-click>
             <template #title>{{ $t('title.expand') }}</template>
 
@@ -173,7 +173,7 @@ const attachments: ComputedRef<Attachment[]> = computed(() => {
             </button>
           </NcTooltip>
         </div>
-        <template v-if="(!isPublic && !readOnly) || isForm">
+        <template v-if="(!isPublic && !readOnly) || (isForm && !readOnly)">
           <PermissionsTooltip
             class="z-10 flex"
             :entity="PermissionEntity.FIELD"

--- a/tests/playwright/pages/Dashboard/Grid/Column/index.ts
+++ b/tests/playwright/pages/Dashboard/Grid/Column/index.ts
@@ -115,8 +115,11 @@ export class ColumnPageObject extends BasePage {
       await this.grid.get().locator(`th[data-title="${insertAfterColumnTitle}"] .nc-ui-dt-dropdown`).click();
       await this.rootPage.locator('li[role="menuitem"]:has-text("Insert right"):visible').click();
     } else {
+      await this.grid.get().locator('.nc-column-add').waitFor({ state: 'visible' });
       await this.grid.get().locator('.nc-column-add').click();
     }
+
+    await this.get().waitFor({ state: 'visible' });
 
     await this.rootPage.waitForTimeout(500);
     await this.fillTitle({ title });

--- a/tests/playwright/pages/Dashboard/TreeView.ts
+++ b/tests/playwright/pages/Dashboard/TreeView.ts
@@ -156,6 +156,8 @@ export class TreeViewPage extends BasePage {
       await this.get().locator(`[data-testid="nc-tbl-title-${title}"]`).click({
         // x:10, y:10
       });
+
+      await this.rootPage.waitForLoadState('networkidle');
     }
   }
 

--- a/tests/playwright/pages/Dashboard/common/Cell/index.ts
+++ b/tests/playwright/pages/Dashboard/common/Cell/index.ts
@@ -97,6 +97,7 @@ export class CellPageObject extends BasePage {
 
       if (type && [UITypes.Date, UITypes.Time, UITypes.Year, UITypes.DateTime].includes(type)) {
         await this.rootPage.keyboard.press('Enter');
+        await this.rootPage.locator('.nc-dropdown.active').waitFor({ state: 'hidden' });
       }
     } else {
       await this.get({ index, columnHeader }).locator('textarea').fill(text);

--- a/tests/playwright/pages/Dashboard/common/Topbar/index.ts
+++ b/tests/playwright/pages/Dashboard/common/Topbar/index.ts
@@ -37,6 +37,7 @@ export class TopbarPage extends BasePage {
   }
 
   async clickShare() {
+    await this.btn_share.waitFor({ state: 'visible' });
     await this.btn_share.click();
   }
 

--- a/tests/playwright/tests/db/columns/columnFormula.spec.ts
+++ b/tests/playwright/tests/db/columns/columnFormula.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 import { DashboardPage } from '../../../pages/Dashboard';
 import setup, { NcContext, unsetup } from '../../../setup';
-import { enableQuickRun, isMysql, isPg, isSqlite } from '../../../setup/db';
+import { enableQuickRun, isPg } from '../../../setup/db';
 
 // Add formula to be verified here & store expected results for 5 rows
 // Column data from City table (Sakila DB)
@@ -274,7 +274,7 @@ test.describe('Virtual Columns', () => {
         type: 'Formula',
         formula: formulaData[i].formula,
       });
-      console.log(`running test function: ${formulaData[i].formula}`);
+
       if (formulaData[i].unSupDbType?.includes(dbType)) {
         // assert for message not supported or greyed out save button.
         await dashboard.grid.column.checkMessageAndClose({ errorMessage: new RegExp('Function .* is not available') });


### PR DESCRIPTION
## Change Summary

- ref: #12467 
- Fixed: In shared view bt, link to another record cell value not visible in expanded form
  - Just visibility issue, it was hidden under lock cell overlay which has to be present only at rool level of cell not nested level 
<img width="1705" height="955" alt="Screenshot 2025-10-04 at 4 02 22 PM" src="https://github.com/user-attachments/assets/3a8d9ab9-d1e0-4029-8e40-289adcc196b1" />


## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
