### PR TITLE
Allow configuring max text length via env

### DIFF
--- a/packages/nocodb/README.md
+++ b/packages/nocodb/README.md
@@ -230,6 +230,8 @@ By default, SQLite is used for storing metadata. However, you can specify your d
 
 Please refer to the [Environment variables](https://docs.nocodb.com/getting-started/self-hosted/environment-variables)
 
+- `NC_MAX_TEXT_LENGTH`: Maximum allowed length for long text and JSON field values (default: `100000`).
+
 # Development Setup
 
 Please refer to [Development Setup](https://docs.nocodb.com/engineering/development-setup)

--- a/packages/nocodb/src/constants/index.ts
+++ b/packages/nocodb/src/constants/index.ts
@@ -16,7 +16,17 @@ if (!NC_REFRESH_TOKEN_EXP_IN_DAYS || NC_REFRESH_TOKEN_EXP_IN_DAYS <= 0) {
   throw new Error('NC_REFRESH_TOKEN_EXP_IN_DAYS must be a positive number');
 }
 
-export const NC_MAX_TEXT_LENGTH = 100000;
+const NC_MAX_TEXT_LENGTH_ENV = process.env.NC_MAX_TEXT_LENGTH;
+const parsedNcMaxTextLength =
+  NC_MAX_TEXT_LENGTH_ENV !== undefined
+    ? Number(NC_MAX_TEXT_LENGTH_ENV)
+    : 100000;
+
+if (!Number.isFinite(parsedNcMaxTextLength) || parsedNcMaxTextLength <= 0) {
+  throw new Error('NC_MAX_TEXT_LENGTH must be a positive number');
+}
+
+export const NC_MAX_TEXT_LENGTH = parsedNcMaxTextLength;
 
 export const NC_EMAIL_ASSETS_BASE_URL = 'https://cdn.nocodb.com/emails/v2';
 

--- a/packages/nocodb/tests/unit/error/index.test.ts
+++ b/packages/nocodb/tests/unit/error/index.test.ts
@@ -1,9 +1,11 @@
 import 'mocha';
 import { runOnSet } from '../utils/runOnSet';
 import { pgErrorExtractorTest } from './db-error-extractor/pg-error-extractor.test';
+import { maxTextLengthConfigTest } from './max-text-length-config.test';
 
 function _errorTests() {
   pgErrorExtractorTest();
+  maxTextLengthConfigTest();
 }
 
 export const errorTests = runOnSet(2, function () {

--- a/packages/nocodb/tests/unit/error/max-text-length-config.test.ts
+++ b/packages/nocodb/tests/unit/error/max-text-length-config.test.ts
@@ -1,0 +1,63 @@
+import path from 'path';
+import { expect } from 'chai';
+
+const constantsModulePath = path.resolve(__dirname, '../../../src/constants');
+
+const clearConstantsCache = () => {
+  const moduleId = require.resolve(constantsModulePath);
+  if (require.cache[moduleId]) {
+    delete require.cache[moduleId];
+  }
+};
+
+const loadMaxTextLength = () =>
+  require(constantsModulePath).NC_MAX_TEXT_LENGTH as number;
+
+export function maxTextLengthConfigTest() {
+  describe('NC_MAX_TEXT_LENGTH configuration', () => {
+    let originalEnv: string | undefined;
+
+    before(() => {
+      originalEnv = process.env.NC_MAX_TEXT_LENGTH;
+    });
+
+    beforeEach(() => {
+      clearConstantsCache();
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NC_MAX_TEXT_LENGTH;
+      } else {
+        process.env.NC_MAX_TEXT_LENGTH = originalEnv;
+      }
+      clearConstantsCache();
+    });
+
+    after(() => {
+      if (originalEnv === undefined) {
+        delete process.env.NC_MAX_TEXT_LENGTH;
+      } else {
+        process.env.NC_MAX_TEXT_LENGTH = originalEnv;
+      }
+      clearConstantsCache();
+    });
+
+    it('defaults to 100000 when env not provided', () => {
+      delete process.env.NC_MAX_TEXT_LENGTH;
+      expect(loadMaxTextLength()).to.equal(100000);
+    });
+
+    it('uses env override when provided', () => {
+      process.env.NC_MAX_TEXT_LENGTH = '200000';
+      expect(loadMaxTextLength()).to.equal(200000);
+    });
+
+    it('throws for invalid env value', () => {
+      process.env.NC_MAX_TEXT_LENGTH = '0';
+      expect(() => loadMaxTextLength()).to.throw(
+        'NC_MAX_TEXT_LENGTH must be a positive number',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Change Summary

Fixes #12500

- Allow NC_MAX_TEXT_LENGTH to be configured via environment variable with validation so boot fails fast on invalid values.
- Updated data API error handling to respect the runtime limit and documented the new env knob for self-host deploys.
- Added unit coverage that reloads constants to verify default, override, and invalid configuration paths.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [x] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
