### PR TITLE
fix: does not contain any of filter

### DIFF
--- a/packages/nocodb/src/db/field-handler/utils/handlerUtils.ts
+++ b/packages/nocodb/src/db/field-handler/utils/handlerUtils.ts
@@ -26,6 +26,8 @@ export const negatedMapping = {
   neq: { comparison_op: 'eq' },
   blank: { comparison_op: 'notblank' },
   notchecked: { comparison_op: 'checked' },
+  nanyof: { comparison_op: 'anyof' },
+  nallof: { comparison_op: 'allof' },
 };
 
 export function getAlias(aliasCount: { count: number }) {


### PR DESCRIPTION
## Change Summary

Closes: #12580  

Where the "does not contain any of" filter did not correctly exclude values on Lookup fields in NocoDB. The root cause was the missing negated operators in the negatedMapping object used by the filter processing logic. This fix adds the mappings for nanyof and nallof to their positive counterparts (anyof and allof), enabling the proper evaluation of negated filters for Lookup fields.

## Change type
fix: Bug fix for user-facing filter behavior on Lookup fields.

## Test/ Verification
- Verified reproduction steps manually by linking two tables (Leads and Events) with Single Select and Lookup fields.- 
- Applied the "does not contain any of" filter on the Lookup field and confirmed correct rows were included/excluded after the fix.
- Ran existing automated tests related to filters and confirmed no regressions.


## Additional information / screenshots (optional)

https://github.com/user-attachments/assets/9f98a909-2aa4-4f9d-b2bd-71b4bf12a991
