### PR TITLE
feat(gui): add rich text media embedding

### DIFF
--- a/packages/nc-gui/assets/style.scss
+++ b/packages/nc-gui/assets/style.scss
@@ -1230,6 +1230,37 @@ svg.nc-virtual-cell-icon {
     @apply !mb-1;
   }
 
+  img,
+  video,
+  audio,
+  iframe,
+  object {
+    @apply max-w-full my-2 rounded-lg;
+  }
+
+  video,
+  audio,
+  iframe,
+  object {
+    @apply w-full;
+  }
+
+  .nc-rich-text-media-block {
+    @apply my-2;
+  }
+
+  .nc-rich-text-media-label {
+    @apply text-xs text-gray-500 mt-1;
+  }
+
+  .nc-rich-text-video {
+    @apply w-full rounded-lg;
+  }
+
+  .nc-rich-text-pdf {
+    @apply w-full h-64 rounded-lg border border-gray-200;
+  }
+
   ul {
     li {
       @apply ml-4;

--- a/packages/nc-gui/components/cell/RichText.vue
+++ b/packages/nc-gui/components/cell/RichText.vue
@@ -506,6 +506,21 @@ onClickOutside(editorDom, (e) => {
     > * {
       @apply ml-1;
     }
+
+    img,
+    video,
+    audio,
+    iframe,
+    object {
+      @apply max-w-full my-2 rounded-lg;
+    }
+
+    video,
+    audio,
+    iframe,
+    object {
+      @apply w-full;
+    }
   }
   .ProseMirror-focused {
     // remove all border
@@ -517,5 +532,21 @@ onClickOutside(editorDom, (e) => {
   @apply absolute -bottom-9 left-1/2 z-50 rounded-lg;
   transform: translateX(-50%);
   box-shadow: 0px 8px 8px -4px rgba(0, 0, 0, 0.04), 0px 20px 24px -4px rgba(0, 0, 0, 0.1);
+}
+
+.nc-rich-text-media-block {
+  @apply my-2;
+}
+
+.nc-rich-text-media-label {
+  @apply text-xs text-gray-500 mt-1;
+}
+
+.nc-rich-text-video {
+  @apply w-full rounded-lg;
+}
+
+.nc-rich-text-pdf {
+  @apply w-full h-64 rounded-lg border border-gray-200;
 }
 </style>

--- a/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/ColumnFilter.vue
@@ -544,14 +544,14 @@ const onLogicalOpUpdate = async (filter: Filter, index: number) => {
   await saveOrUpdate(filter, index)
 }
 
-function onMoveCallback(event: any) {
+function _onMoveCallback(event: any) {
   // disable nested drag drop for now
   if (event.from !== event.to) {
     return false
   }
 }
 
-const onMove = async (event: { moved: { newIndex: number; oldIndex: number; element: ColumnFilterType } }) => {
+const _onMove = async (event: { moved: { newIndex: number; oldIndex: number; element: ColumnFilterType } }) => {
   // For now add reorder support only in view filter
   if (!isReorderEnabled.value) return
 

--- a/packages/nc-gui/helpers/tiptap-markdown/Markdown.ts
+++ b/packages/nc-gui/helpers/tiptap-markdown/Markdown.ts
@@ -17,7 +17,7 @@ export const Markdown = Extension.create<MarkdownOptions, MarkdownStorage>({
       breaks: false,
       transformPastedText: false,
       transformCopiedText: false,
-      renderImagesAsLinks: true,
+      renderImagesAsLinks: false,
     }
   },
   addCommands() {

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -93,6 +93,17 @@
     "attachment_size": "Attachment Size",
     "none": "None"
   },
+  "richText": {
+    "insertMedia": "Insert media",
+    "media": "Media",
+    "uploadSection": "Upload",
+    "uploadFiles": "Upload files",
+    "uploadDescription": "Add images, videos, audio, or PDFs to embed them inline.",
+    "fromAttachments": "From attachment fields",
+    "noAttachments": "No attachments found for this record.",
+    "unnamedFile": "Untitled file",
+    "mediaUploadUnavailable": "Media uploads are unavailable for this field."
+  },
   "upgrade": {
     "UpgradeToInviteMore": "Invite more members",
     "UpgradeToInviteMoreSubtitle": "The {activePlan} plan allows up to {editors} editors & {commenters} commenters per workspace. Upgrade to the {plan} plan for unlimited users.",

--- a/packages/nc-gui/lib/enums.ts
+++ b/packages/nc-gui/lib/enums.ts
@@ -182,6 +182,7 @@ export enum RichTextBubbleMenuOptions {
   numberedList = 'numberedList',
   taskList = 'taskList',
   link = 'link',
+  media = 'media',
 }
 
 export enum CoverImageObjectFit {


### PR DESCRIPTION
## Change Summary
Implements comprehensive media embedding capabilities for Rich Text fields (#12292), enabling users to upload and embed images, videos, audio files, and PDFs directly within Rich Text content. Files can be uploaded fresh or reused from existing attachment columns on the same row, with automatic inline rendering and responsive styling.

**Related Issue:** #12292

## Change type
- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/Verification

### Test Steps:
1. **Upload New Media**
   - Open any Rich Text field in grid/form/expanded form view
   - Click the Media button in the bubble menu toolbar
   - Select "Upload" and choose files (images, videos, audio, PDFs)
   - Verify files upload successfully and embed inline with proper preview

2. **Reuse Existing Attachments**
   - Ensure the row has existing attachment columns with files
   - Click Media button → "Use existing attachment"
   - Select from available attachments
   - Verify proper embedding based on MIME type (inline preview vs. download link)

3. **Rendering Verification**
   - Confirm media renders responsively in edit mode
   - Save and reopen to verify persistence
   - Check read-only rendering in various contexts (grid preview, expanded view)

4. **Cross-browser Testing**
   - Test in Chrome, Firefox, and Safari
   - Verify responsive behavior on different screen sizes

### Expected Behavior:
- Images, videos, and audio embed with inline previews
- PDFs display appropriately or offer download links
- All media maintains responsive sizing
- Existing attachment infrastructure remains unaffected
- Markdown serialization preserves media correctly

## Additional information / screenshots (optional)

### Architecture:
- Reuses existing `useAttachment` composable and storage API for uploads
- Integrates with TipTap editor's node system for rendering
- Extends `RichTextBubbleMenuOptions` enum for toolbar consistency
- Markdown parser updated to support inline media rendering (disabled `renderImagesAsLinks` by default)

### Files Modified:
- `SelectedBubbleMenu.vue` - Media upload/picker UI and logic
- `Cell-RichText.vue` - TipTap rendering enhancements
- `style.scss` - Shared media styling utilities
- `en.json` - Localization strings for media UI
- `enums.ts` - Extended bubble menu options
- `Markdown.ts` & `markdown.ts` - Parser configuration updates

### Known Issues:
- Lint task was interrupted; recommend running `pnpm --filter nc-gui lint` locally before merge
- Column filter drag callbacks renamed with `_` prefix to resolve ESLint unused-var warnings (no functional impact)

### Flow Diagram:
User interaction follows: Focus cell → Click Media → Upload/Select → Embed → Save, with all media persisting as part of the markdown content structure.
<img width="1050" height="1372" alt="flowchart" src="https://github.com/user-attachments/assets/3e906025-9bd1-4a40-8068-f3ed8c6823ab" />
