### PR TITLE
fix(sdk): use generated filter delete helper

### DIFF
--- a/packages/nocodb-sdk/src/lib/filter/filterUtils.ts
+++ b/packages/nocodb-sdk/src/lib/filter/filterUtils.ts
@@ -923,7 +923,7 @@ export const deleteFilterWithSub = async (
       result = [...result, ...(await deleteFilterWithSub($api, child))];
     }
   }
-  await $api.dbTableFilter.delete(filter.id);
+  await $api.dbTableFilter.dbTableFilterDelete(filter.id);
   result.push(filter.id);
   return result;
 };


### PR DESCRIPTION
## Change Summary
- Fix nocodb-sdk build failure by calling the generated `$api.dbTableFilter.dbTableFilterDelete(...)` helper instead of the removed `$api.dbTableFilter.delete(...)`.
- Resolves 🐛 Bug #12635 (“Build failure in nocodb-sdk: dbTableFilter.delete no longer exists”).

## Change Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [ ] chore

## Test / Verification
- `pnpm --filter nocodb-sdk run build` ✅

## Additional information / screenshots:
<img width="877" height="508" alt="image" src="https://github.com/user-attachments/assets/e669c015-a8cf-423c-ada9-3eeeb6ba46db" />
