### PR TITLE
fix: keyabord event prevent issue if extension panel is open

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
@@ -93,12 +93,18 @@ export function useKeyboardNavigation({
       e.preventDefault()
       return true
     }
+
     if (isExpandedCellInputExist()) return
     if (isNcDropdownOpen()) return
     if (isCmdJActive() || cmdKActive()) return
+
     if (isDrawerOrModalExist() || isLinkDropdownExist() || isGeneralOverlayActive()) {
       // If Extension Pane is Active, ignore
       if (!isExtensionPaneActive()) return
+      else if (!isActiveElementInsideExtension() && isDrawerOrModalExist()) {
+        // If extension pane open and active drawer or modal is not extension modal then we have to return, else it will prevent keyboard events
+        return
+      }
     }
     const cmdOrCtrl = isMac() ? e.metaKey : e.ctrlKey
     const altOrOptionKey = e.altKey


### PR DESCRIPTION
## Change Summary

The issue occurred when an extension panel was open and users tried to interact with modals/drawers (like clearing input text). The _handleKeyDown function was incorrectly treating all events as grid interactions, preventing normal keyboard functionality in non-grid UI elements.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
