### PR TITLE
fix(nc-gui): Add comprehensive touch/tablet support using Pointer Events API

### DIFF
--- a/packages/nc-gui/components/cell/Currency/Editor.vue
+++ b/packages/nc-gui/components/cell/Currency/Editor.vue
@@ -142,7 +142,7 @@ onMounted(() => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @contextmenu.stop
   />
   <input
@@ -162,7 +162,7 @@ onMounted(() => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @contextmenu.stop
   />
 </template>

--- a/packages/nc-gui/components/cell/Currency/index.vue
+++ b/packages/nc-gui/components/cell/Currency/index.vue
@@ -149,7 +149,7 @@ const showInputField = computed(
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @contextmenu.stop
   />
   <input
@@ -169,7 +169,7 @@ const showInputField = computed(
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @contextmenu.stop
   />
 

--- a/packages/nc-gui/components/cell/Date/Editor.vue
+++ b/packages/nc-gui/components/cell/Date/Editor.vue
@@ -374,8 +374,8 @@ onMounted(() => {
         @blur="onBlur"
         @focus="onFocus"
         @keydown="handleKeydown($event, open)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/Date/index.vue
+++ b/packages/nc-gui/components/cell/Date/index.vue
@@ -348,8 +348,8 @@ const currentDate = ($event) => {
         @blur="onBlur"
         @focus="onFocus"
         @keydown="handleKeydown($event, open)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/DateTime/Editor.vue
+++ b/packages/nc-gui/components/cell/DateTime/Editor.vue
@@ -527,8 +527,8 @@ const minimizeMaxWidth = computed(() => {
             @focus="onFocus(true)"
             @blur="onBlur($event, true)"
             @keydown="handleKeydown($event, isOpen, true)"
-            @mouseup.stop
-            @mousedown.stop
+            @pointerup.stop
+            @pointerdown.stop
             @click.stop="clickHandler($event, true)"
             @input="handleUpdateValue($event, true)"
           />
@@ -557,8 +557,8 @@ const minimizeMaxWidth = computed(() => {
             @focus="onFocus(false)"
             @blur="onBlur($event, false)"
             @keydown="handleKeydown($event, open)"
-            @mouseup.stop
-            @mousedown.stop
+            @pointerup.stop
+            @pointerdown.stop
             @click.stop="clickHandler($event, false)"
             @input="handleUpdateValue($event, false)"
           />

--- a/packages/nc-gui/components/cell/DateTime/Editor.vue
+++ b/packages/nc-gui/components/cell/DateTime/Editor.vue
@@ -316,7 +316,7 @@ onUnmounted(() => {
   cellClickHook?.off(cellClickHandler)
 })
 
-const clickHandler = (e: MouseEvent, _isDatePicker = false) => {
+const clickHandler = (e: MouseEvent | PointerEvent, _isDatePicker = false) => {
   isDatePicker.value = _isDatePicker
 
   if (cellClickHook) {

--- a/packages/nc-gui/components/cell/DateTime/index.vue
+++ b/packages/nc-gui/components/cell/DateTime/index.vue
@@ -510,8 +510,8 @@ const minimizeMaxWidth = computed(() => {
             @focus="onFocus(true)"
             @blur="onBlur($event, true)"
             @keydown="handleKeydown($event, isOpen, true)"
-            @mouseup.stop
-            @mousedown.stop
+            @pointerup.stop
+            @pointerdown.stop
             @click.stop="clickHandler($event, true)"
             @input="handleUpdateValue($event, true)"
           />
@@ -541,8 +541,8 @@ const minimizeMaxWidth = computed(() => {
             @focus="onFocus(false)"
             @blur="onBlur($event, false)"
             @keydown="handleKeydown($event, open)"
-            @mouseup.stop
-            @mousedown.stop
+            @pointerup.stop
+            @pointerdown.stop
             @click.stop="clickHandler($event, false)"
             @input="handleUpdateValue($event, false)"
           />

--- a/packages/nc-gui/components/cell/DateTime/index.vue
+++ b/packages/nc-gui/components/cell/DateTime/index.vue
@@ -309,7 +309,7 @@ onUnmounted(() => {
   cellClickHook?.off(cellClickHandler)
 })
 
-const clickHandler = (e: MouseEvent, _isDatePicker = false) => {
+const clickHandler = (e: MouseEvent | PointerEvent, _isDatePicker = false) => {
   isDatePicker.value = _isDatePicker
 
   if (cellClickHook) {

--- a/packages/nc-gui/components/cell/Decimal/DecimalInput.vue
+++ b/packages/nc-gui/components/cell/Decimal/DecimalInput.vue
@@ -261,7 +261,7 @@ watch(vModel, (newValue) => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @beforeinput="onBeforeInput"
   />
 </template>

--- a/packages/nc-gui/components/cell/Decimal/index.vue
+++ b/packages/nc-gui/components/cell/Decimal/index.vue
@@ -113,7 +113,7 @@ const focus: VNodeRef = (el) =>
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
   <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
   <span v-else class="nc-cell-field">{{ displayValue }}</span>

--- a/packages/nc-gui/components/cell/Duration/Editor.vue
+++ b/packages/nc-gui/components/cell/Duration/Editor.vue
@@ -112,7 +112,7 @@ onMounted(() => {
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
 
     <div v-if="showWarningMessage && props.showValidationError" class="nc-cell-field duration-warning">

--- a/packages/nc-gui/components/cell/Duration/index.vue
+++ b/packages/nc-gui/components/cell/Duration/index.vue
@@ -114,7 +114,7 @@ const focus: VNodeRef = (el) =>
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
 
     <span v-else-if="modelValue === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>

--- a/packages/nc-gui/components/cell/Email/Editor.vue
+++ b/packages/nc-gui/components/cell/Email/Editor.vue
@@ -106,7 +106,7 @@ const showClicableLink = computed(() => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @paste.prevent="onPaste"
   />
   <div

--- a/packages/nc-gui/components/cell/Email/index.vue
+++ b/packages/nc-gui/components/cell/Email/index.vue
@@ -90,7 +90,7 @@ watch(
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
     @paste.prevent="onPaste"
   />
 

--- a/packages/nc-gui/components/cell/Float/Editor.vue
+++ b/packages/nc-gui/components/cell/Float/Editor.vue
@@ -62,7 +62,7 @@ const focus: VNodeRef = (el) =>
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
 </template>
 

--- a/packages/nc-gui/components/cell/Float/index.vue
+++ b/packages/nc-gui/components/cell/Float/index.vue
@@ -62,7 +62,7 @@ const focus: VNodeRef = (el) =>
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
   <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
   <span v-else class="nc-cell-field">{{ vModel }}</span>

--- a/packages/nc-gui/components/cell/GeoData.vue
+++ b/packages/nc-gui/components/cell/GeoData.vue
@@ -246,7 +246,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
                   @blur="handleBlur"
                   @keydown.stop
                   @selectstart.capture.stop
-                  @mousedown.stop
+                  @pointerdown.stop
                 />
               </a-form-item>
 
@@ -265,7 +265,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
                   @blur="handleBlur"
                   @keydown.stop
                   @selectstart.capture.stop
-                  @mousedown.stop
+                  @pointerdown.stop
                 />
               </a-form-item>
             </a-row>

--- a/packages/nc-gui/components/cell/GeoData.vue
+++ b/packages/nc-gui/components/cell/GeoData.vue
@@ -96,7 +96,7 @@ const openInOSM = () => {
   window.open(url, '_blank', "'noopener,noreferrer'")
 }
 
-const handleClose = (e: MouseEvent) => {
+const handleClose = (e: MouseEvent | PointerEvent) => {
   if (e.target instanceof HTMLElement && !e.target.closest('.nc-geodata-picker-overlay')) {
     isExpanded.value = false
   }

--- a/packages/nc-gui/components/cell/Integer/Editor.vue
+++ b/packages/nc-gui/components/cell/Integer/Editor.vue
@@ -105,7 +105,7 @@ onMounted(() => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
 </template>
 

--- a/packages/nc-gui/components/cell/Integer/index.vue
+++ b/packages/nc-gui/components/cell/Integer/index.vue
@@ -111,7 +111,7 @@ function onKeyDown(e: any) {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
   <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
   <span v-else class="nc-cell-field">{{ displayValue }}</span>

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -185,7 +185,7 @@ watch(isExpanded, (newVal, oldVal) => {
   if (oldVal && !newVal) canvasSelectCell?.trigger()
 })
 
-const stopPropagation = (event: MouseEvent) => {
+const stopPropagation = (event: MouseEvent | PointerEvent) => {
   event.stopPropagation()
 }
 
@@ -197,12 +197,12 @@ watch(inputWrapperRef, () => {
 
   if (isExpanded.value && modal?.parentElement) {
     modal.parentElement.addEventListener('click', stopPropagation)
-    modal.parentElement.addEventListener('mousedown', stopPropagation)
-    modal.parentElement.addEventListener('mouseup', stopPropagation)
+    modal.parentElement.addEventListener('pointerdown', stopPropagation)
+    modal.parentElement.addEventListener('pointerup', stopPropagation)
   } else if (modal?.parentElement) {
     modal.parentElement.removeEventListener('click', stopPropagation)
-    modal.parentElement.removeEventListener('mousedown', stopPropagation)
-    modal.parentElement.removeEventListener('mouseup', stopPropagation)
+    modal.parentElement.removeEventListener('pointerdown', stopPropagation)
+    modal.parentElement.removeEventListener('pointerup', stopPropagation)
   }
 })
 

--- a/packages/nc-gui/components/cell/Json.vue
+++ b/packages/nc-gui/components/cell/Json.vue
@@ -276,8 +276,8 @@ onUnmounted(() => {
     class="relative"
     :class="{ 'json-modal min-w-80': isExpanded, 'min-h-6 flex items-center': !isExpanded }"
   >
-    <div v-if="isExpanded" class="flex flex-col w-full" @mousedown.stop @mouseup.stop @click.stop>
-      <div class="flex flex-row justify-between items-center -mt-2 pb-3 nc-json-action" @mousedown.stop>
+    <div v-if="isExpanded" class="flex flex-col w-full" @pointerdown.stop @pointerup.stop @click.stop>
+      <div class="flex flex-row justify-between items-center -mt-2 pb-3 nc-json-action" @pointerdown.stop>
         <NcButton type="secondary" size="xsmall" class="!w-7 !h-7 !min-w-[fit-content]" @click.stop="closeJSONEditor">
           <component :is="iconMap.minimize" class="w-4 h-4" />
         </NcButton>

--- a/packages/nc-gui/components/cell/MultiSelect/Editor.vue
+++ b/packages/nc-gui/components/cell/MultiSelect/Editor.vue
@@ -279,7 +279,7 @@ const toggleMenu = () => {
   isOpen.value = editAllowed.value && !isOpen.value
 }
 
-const handleClose = (e: MouseEvent) => {
+const handleClose = (e: MouseEvent | PointerEvent) => {
   // close dropdown if clicked outside of dropdown
   if (
     isOpen.value &&

--- a/packages/nc-gui/components/cell/Percent/Editor.vue
+++ b/packages/nc-gui/components/cell/Percent/Editor.vue
@@ -139,7 +139,7 @@ onMounted(() => {
         @keydown.delete.stop
         @keydown.alt.stop
         @selectstart.capture.stop
-        @mousedown.stop
+        @pointerdown.stop
       />
     </template>
   </CellPercentProgressBar>
@@ -161,7 +161,7 @@ onMounted(() => {
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
   </div>
 </template>

--- a/packages/nc-gui/components/cell/Percent/Readonly.vue
+++ b/packages/nc-gui/components/cell/Percent/Readonly.vue
@@ -98,8 +98,8 @@ const showInput = computed(() => !readOnly.value && (!isGrid.value || isExpanded
         ...(!isExpandedFormOpen && { height: '4px' }),
       }"
       style="min-height: 4px"
-      @mouseover="onMouseover"
-      @mouseleave="onMouseleave"
+      @pointerover="onMouseover"
+      @pointerleave="onMouseleave"
       @focus="onWrapperFocus"
       @click="onWrapperFocus"
     >
@@ -124,8 +124,8 @@ const showInput = computed(() => !readOnly.value && (!isGrid.value || isExpanded
     :tabindex="readOnly ? -1 : 0"
     class="nc-filter-value-select w-full focus:outline-transparent relative z-3"
     :class="readOnly ? 'cursor-not-allowed pointer-events-none' : ''"
-    @mouseover="onMouseover"
-    @mouseleave="onMouseleave"
+    @pointerover="onMouseover"
+    @pointerleave="onMouseleave"
     @focus="onWrapperFocus"
     @click="onWrapperFocus"
   >

--- a/packages/nc-gui/components/cell/Percent/index.vue
+++ b/packages/nc-gui/components/cell/Percent/index.vue
@@ -153,8 +153,8 @@ const onTabPress = (e: KeyboardEvent) => {
     :tabindex="readOnly ? -1 : 0"
     class="nc-filter-value-select w-full focus:outline-transparent"
     :class="readOnly ? 'cursor-not-allowed pointer-events-none' : ''"
-    @mouseover="onMouseover"
-    @mouseleave="onMouseleave"
+    @pointerover="onMouseover"
+    @pointerleave="onMouseleave"
     @focus="onWrapperFocus"
   >
     <!-- eslint-disable vue/use-v-on-exact -->
@@ -175,7 +175,7 @@ const onTabPress = (e: KeyboardEvent) => {
       @keydown.tab="onTabPress"
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
     <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>
     <div v-else-if="percentMeta.is_progress === true && vModel !== null && vModel !== undefined && !isWorkflow" class="px-2">

--- a/packages/nc-gui/components/cell/PhoneNumber/Editor.vue
+++ b/packages/nc-gui/components/cell/PhoneNumber/Editor.vue
@@ -92,7 +92,7 @@ const showClicableLink = computed(() => {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
   <div
     v-if="showClicableLink"

--- a/packages/nc-gui/components/cell/PhoneNumber/index.vue
+++ b/packages/nc-gui/components/cell/PhoneNumber/index.vue
@@ -80,7 +80,7 @@ watch(
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
 
   <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase">{{ $t('general.null') }}</span>

--- a/packages/nc-gui/components/cell/RichText.vue
+++ b/packages/nc-gui/components/cell/RichText.vue
@@ -358,7 +358,7 @@ onClickOutside(editorDom, (e) => {
         @keydown.up.stop
         @keydown.delete.stop
         @selectstart.capture.stop
-        @mousedown.stop
+        @pointerdown.stop
         @keydown.esc="handleOnEscRichTextEditor($event, editor)"
       />
       <div v-if="isFormField && !readOnly" class="nc-form-field-bubble-menu-wrapper overflow-hidden">

--- a/packages/nc-gui/components/cell/RichText/SelectedBubbleMenuPopup.vue
+++ b/packages/nc-gui/components/cell/RichText/SelectedBubbleMenuPopup.vue
@@ -38,7 +38,7 @@ watchDebounced(
   },
 )
 
-const handleEditorMouseDown = (e: MouseEvent) => {
+const handleEditorMouseDown = (e: MouseEvent | PointerEvent) => {
   const domsInEvent = document.elementsFromPoint(e.clientX, e.clientY) as HTMLElement[]
   const isBubble = domsInEvent.some((dom) => dom?.classList?.contains('bubble-menu'))
   if (isBubble || isSelectAllShortcut.value) {
@@ -50,7 +50,7 @@ const handleEditorMouseDown = (e: MouseEvent) => {
   pageContent?.classList.add('bubble-menu-hidden')
 }
 
-const handleEditorMouseUp = (e: MouseEvent) => {
+const handleEditorMouseUp = (e: MouseEvent | PointerEvent) => {
   const domsInEvent = document.elementsFromPoint(e.clientX, e.clientY) as HTMLElement[]
   const isBubble = domsInEvent.some((dom) => dom?.classList?.contains('bubble-menu'))
 

--- a/packages/nc-gui/components/cell/RichText/SelectedBubbleMenuPopup.vue
+++ b/packages/nc-gui/components/cell/RichText/SelectedBubbleMenuPopup.vue
@@ -74,13 +74,13 @@ useEventListener('keydown', (e: KeyboardEvent) => {
 })
 
 onMounted(() => {
-  document.addEventListener('mouseup', handleEditorMouseUp)
-  document.addEventListener('mousedown', handleEditorMouseDown)
+  document.addEventListener('pointerup', handleEditorMouseUp)
+  document.addEventListener('pointerdown', handleEditorMouseDown)
 })
 
 onUnmounted(() => {
-  document.removeEventListener('mouseup', handleEditorMouseUp)
-  document.removeEventListener('mousedown', handleEditorMouseDown)
+  document.removeEventListener('pointerup', handleEditorMouseUp)
+  document.removeEventListener('pointerdown', handleEditorMouseDown)
 })
 </script>
 

--- a/packages/nc-gui/components/cell/SingleSelect/Editor.vue
+++ b/packages/nc-gui/components/cell/SingleSelect/Editor.vue
@@ -239,7 +239,7 @@ const toggleMenu = (e: Event) => {
   isOpen.value = editAllowed.value && !isOpen.value
 }
 
-const handleClose = (e: MouseEvent) => {
+const handleClose = (e: MouseEvent | PointerEvent) => {
   if (isOpen.value && aselect.value && !aselect.value.$el.contains(e.target)) {
     isOpen.value = false
   }

--- a/packages/nc-gui/components/cell/Text/Editor.vue
+++ b/packages/nc-gui/components/cell/Text/Editor.vue
@@ -66,7 +66,7 @@ function updateInput(e: any) {
     @keydown.delete.stop
     @keydown.alt.stop
     @selectstart.capture.stop
-    @mousedown.stop
+    @pointerdown.stop
   />
   <NcAutoSizeTextarea
     v-else

--- a/packages/nc-gui/components/cell/Text/index.vue
+++ b/packages/nc-gui/components/cell/Text/index.vue
@@ -50,7 +50,7 @@ const textareaValue = computed({
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
 
     <NcAutoSizeTextarea

--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -224,7 +224,7 @@ const onMouseMove = (e: MouseEvent) => {
   }
 }
 
-const onMouseUp = (e: MouseEvent) => {
+const onPointerUp = (e: MouseEvent | PointerEvent) => {
   if (!isDragging.value) return
 
   e.stopPropagation()
@@ -233,8 +233,9 @@ const onMouseUp = (e: MouseEvent) => {
   position.value = undefined
   mousePosition.value = undefined
 
-  document.removeEventListener('mousemove', onMouseMove)
-  document.removeEventListener('mouseup', onMouseUp)
+  document.removeEventListener('pointermove', onMouseMove)
+  document.removeEventListener('pointerup', onPointerUp)
+  document.removeEventListener('pointercancel', onPointerUp)
 }
 
 watch(
@@ -251,7 +252,7 @@ watch(
   { deep: true },
 )
 
-const dragStart = (e: MouseEvent) => {
+const dragStart = (e: MouseEvent | PointerEvent) => {
   if (isEditColumn.value) return
 
   const dom = document.querySelector('.nc-long-text-expanded-modal .ant-modal-content') as HTMLElement
@@ -261,8 +262,9 @@ const dragStart = (e: MouseEvent) => {
     left: e.clientX - dom.getBoundingClientRect().left + 16,
   }
 
-  document.addEventListener('mousemove', onMouseMove)
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointermove', onMouseMove)
+  document.addEventListener('pointerup', onPointerUp)
+  document.addEventListener('pointercancel', onPointerUp)
 
   isDragging.value = true
 }
@@ -283,7 +285,7 @@ watch(editEnabled, () => {
   }
 })
 
-const stopPropagation = (event: MouseEvent) => {
+const stopPropagation = (event: MouseEvent | PointerEvent) => {
   event.stopPropagation()
 }
 
@@ -295,12 +297,12 @@ watch(inputWrapperRef, () => {
 
   if (isVisible.value && modal?.parentElement) {
     modal.parentElement.addEventListener('click', stopPropagation)
-    modal.parentElement.addEventListener('mousedown', stopPropagation)
-    modal.parentElement.addEventListener('mouseup', stopPropagation)
+    modal.parentElement.addEventListener('pointerdown', stopPropagation)
+    modal.parentElement.addEventListener('pointerup', stopPropagation)
   } else if (modal?.parentElement) {
     modal.parentElement.removeEventListener('click', stopPropagation)
-    modal.parentElement.removeEventListener('mousedown', stopPropagation)
-    modal.parentElement.removeEventListener('mouseup', stopPropagation)
+    modal.parentElement.removeEventListener('pointerdown', stopPropagation)
+    modal.parentElement.removeEventListener('pointerup', stopPropagation)
   }
 })
 

--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -210,7 +210,7 @@ const onExpand = () => {
   isVisible.value = true
 }
 
-const onMouseMove = (e: MouseEvent) => {
+const onMouseMove = (e: MouseEvent | PointerEvent) => {
   if (!isDragging.value) return
 
   e.stopPropagation()

--- a/packages/nc-gui/components/cell/TextArea.vue
+++ b/packages/nc-gui/components/cell/TextArea.vue
@@ -578,7 +578,7 @@ useResizeObserver(inputWrapperRef, () => {
           @keydown.up.stop
           @keydown.delete.stop
           @selectstart.capture.stop
-          @mousedown.stop
+          @pointerdown.stop
         />
         <div v-if="!readOnly && props.isAi && isExpandedFormOpen" class="-mt-1">
           <div v-if="props.aiMeta?.isStale" ref="aiWarningRef">
@@ -749,7 +749,7 @@ useResizeObserver(inputWrapperRef, () => {
             'select-none': isDragging,
             'cursor-move': !isEditColumn,
           }"
-          @mousedown="dragStart"
+          @pointerdown="dragStart"
         >
           <SmartsheetHeaderCellIcon
             class="flex"

--- a/packages/nc-gui/components/cell/Time/Editor.vue
+++ b/packages/nc-gui/components/cell/Time/Editor.vue
@@ -372,8 +372,8 @@ onMounted(() => {
         @blur="onBlur"
         @focus="onFocus"
         @keydown="handleKeydown($event, isOpen)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/Time/index.vue
+++ b/packages/nc-gui/components/cell/Time/index.vue
@@ -353,8 +353,8 @@ const cellValue = computed(() => localState.value?.format(parseProp(column.value
         @blur="onBlur"
         @focus="onFocus"
         @keydown="handleKeydown($event, isOpen)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/Url/Editor.vue
+++ b/packages/nc-gui/components/cell/Url/Editor.vue
@@ -106,7 +106,7 @@ const showClicableLink = computed(() => {
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
     <div
       v-if="showClicableLink"

--- a/packages/nc-gui/components/cell/Url/index.vue
+++ b/packages/nc-gui/components/cell/Url/index.vue
@@ -95,7 +95,7 @@ watch(
       @keydown.delete.stop
       @keydown.alt.stop
       @selectstart.capture.stop
-      @mousedown.stop
+      @pointerdown.stop
     />
 
     <span v-else-if="vModel === null && showNull" class="nc-cell-field nc-null uppercase"> {{ $t('general.null') }}</span>

--- a/packages/nc-gui/components/cell/User/Editor.vue
+++ b/packages/nc-gui/components/cell/User/Editor.vue
@@ -260,7 +260,7 @@ function toggleMenu() {
   isOpen.value = editAllowed.value && !isOpen.value
 }
 
-const handleClose = (e: MouseEvent) => {
+const handleClose = (e: MouseEvent | PointerEvent) => {
   // close dropdown if clicked outside of dropdown
   if (
     isOpen.value &&

--- a/packages/nc-gui/components/cell/Year/Editor.vue
+++ b/packages/nc-gui/components/cell/Year/Editor.vue
@@ -321,8 +321,8 @@ onMounted(() => {
         :readonly="readOnly || !!isMobileMode"
         @blur="onBlur"
         @keydown="handleKeydown($event, open)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/Year/index.vue
+++ b/packages/nc-gui/components/cell/Year/index.vue
@@ -304,8 +304,8 @@ function handleSelectDate(value?: dayjs.Dayjs) {
         :readonly="readOnly"
         @blur="onBlur"
         @keydown="handleKeydown($event, open)"
-        @mouseup.stop
-        @mousedown.stop
+        @pointerup.stop
+        @pointerdown.stop
         @click="clickHandler"
         @input="handleUpdateValue"
       />

--- a/packages/nc-gui/components/cell/attachment/Preview/Image.vue
+++ b/packages/nc-gui/components/cell/attachment/Preview/Image.vue
@@ -124,7 +124,7 @@ const onTouchStart = (e: TouchEvent) => {
       :class="{
         'flex items-center justify-center': index >= props.srcs?.length,
       }"
-      @mousedown="onMouseDown"
+      @pointerdown="onMouseDown"
       @touchstart="onTouchStart"
     >
       <img

--- a/packages/nc-gui/components/cell/attachment/Preview/Image.vue
+++ b/packages/nc-gui/components/cell/attachment/Preview/Image.vue
@@ -91,28 +91,23 @@ const stopDrag = () => {
   isDragging.value = false
 }
 
-const stopPropagationIfScaled = (e: MouseEvent | TouchEvent) => {
+const stopPropagationIfScaled = (e: MouseEvent | PointerEvent | TouchEvent) => {
   if (scale.value <= 1 || !props.isCellPreview) return
   e.preventDefault()
   e.stopPropagation()
 }
 
-useEventListener(window, 'mousemove', (e: MouseEvent) => drag(e.clientX, e.clientY))
-useEventListener(window, 'mouseup', stopDrag)
-useEventListener(window, 'touchmove', (e: TouchEvent) => drag(e.touches[0].clientX, e.touches[0].clientY))
-useEventListener(window, 'touchend', stopDrag)
+useEventListener(window, 'pointermove', (e: PointerEvent) => drag(e.clientX, e.clientY))
+useEventListener(window, 'pointerup', stopDrag)
+useEventListener(window, 'pointercancel', stopDrag)
 
-const onMouseDown = (e: MouseEvent) => {
-  stopPropagationIfScaled(e)
-  startDrag(e.clientX, e.clientY)
-}
-const onTouchStart = (e: TouchEvent) => {
-  if (props.isCellPreview) {
+const onPointerDown = (e: PointerEvent) => {
+  if (e.pointerType === 'touch' && props.isCellPreview) {
     e.preventDefault()
   }
 
   stopPropagationIfScaled(e)
-  startDrag(e.touches[0].clientX, e.touches[0].clientY)
+  startDrag(e.clientX, e.clientY)
 }
 </script>
 
@@ -124,8 +119,7 @@ const onTouchStart = (e: TouchEvent) => {
       :class="{
         'flex items-center justify-center': index >= props.srcs?.length,
       }"
-      @pointerdown="onMouseDown"
-      @touchstart="onTouchStart"
+      @pointerdown="onPointerDown"
     >
       <img
         v-if="index < props.srcs?.length"

--- a/packages/nc-gui/components/cmd-j/index.vue
+++ b/packages/nc-gui/components/cmd-j/index.vue
@@ -135,7 +135,7 @@ watch(vOpen, () => {
               class="cmdk-action cmdj-action"
               :class="{ 'selected': selectedIndex === index, 'pl-4': result.type !== 'page' }"
               @click="navigateToResult(result)"
-              @mouseenter="selectedIndex = index"
+              @pointerenter="selectedIndex = index"
             >
               <div class="cmdk-action-content">
                 <div v-if="result.type === 'page'" class="pr-4">

--- a/packages/nc-gui/components/cmd-k/index.vue
+++ b/packages/nc-gui/components/cmd-k/index.vue
@@ -532,7 +532,7 @@ defineExpose({
                           height: `${ACTION_HEIGHT}px`,
                         }"
                         :class="{ selected: selected === item.data.id }"
-                        @mouseenter="setAction(item.data.id)"
+                        @pointerenter="setAction(item.data.id)"
                         @click="fireAction(item.data)"
                       >
                         <div class="cmdk-action-content w-full">

--- a/packages/nc-gui/components/dashboard/TreeView/Project/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Project/List.vue
@@ -328,7 +328,7 @@ useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
   }
 })
 
-const handleContext = (e: MouseEvent) => {
+const handleContext = (e: MouseEvent | PointerEvent) => {
   if (!document.querySelector('.source-context, .table-context')?.contains(e.target as Node)) {
     setMenuContext('main')
   }

--- a/packages/nc-gui/components/dashboard/TreeView/Project/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Project/List.vue
@@ -487,6 +487,7 @@ watch(isProjectsLoaded, () => {
                   handle=".base-title-node"
                   ghost-class="ghost"
                   :filter="isTouchEvent"
+                  :prevent-on-filter="false"
                   @change="onMove($event)"
                 >
                   <template #item="{ element: baseItem }">

--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -518,8 +518,8 @@ defineExpose({
                 'mr-1': !isProjectHeader,
               }"
               @click="onProjectClick(base)"
-              @mouseenter="showNodeTooltip = false"
-              @mouseleave="showNodeTooltip = true"
+              @pointerenter="showNodeTooltip = false"
+              @pointerleave="showNodeTooltip = true"
             >
               <div class="flex items-center select-none w-6 h-full">
                 <a-spin v-if="base.isLoading" class="!ml-1.25 !flex !flex-row !items-center !my-0.5 w-8" :indicator="indicator" />
@@ -596,8 +596,8 @@ defineExpose({
                     type="text"
                     :size="isProjectHeader ? 'small' : 'xxsmall'"
                     @click.stop
-                    @mouseenter="showNodeTooltip = false"
-                    @mouseleave="showNodeTooltip = true"
+                    @pointerenter="showNodeTooltip = false"
+                    @pointerleave="showNodeTooltip = true"
                   >
                     <GeneralIcon
                       :icon="isProjectHeader ? 'threeDotVertical' : 'threeDotHorizontal'"
@@ -636,8 +636,8 @@ defineExpose({
                   }"
                   :loading="isAddNewProjectChildEntityLoading"
                   @click.stop="addNewProjectChildEntity()"
-                  @mouseenter="showNodeTooltip = false"
-                  @mouseleave="showNodeTooltip = true"
+                  @pointerenter="showNodeTooltip = false"
+                  @pointerleave="showNodeTooltip = true"
                 >
                   <NcTooltip :title="$t('activity.createTable')" hide-on-click>
                     <GeneralIcon icon="plus" class="text-xl leading-5" style="-webkit-text-stroke: 0.15px" />
@@ -652,8 +652,8 @@ defineExpose({
                     '!opacity-100': isOptionsOpen,
                   }"
                   @click="onProjectClick(base, true, true)"
-                  @mouseenter="showNodeTooltip = false"
-                  @mouseleave="showNodeTooltip = true"
+                  @pointerenter="showNodeTooltip = false"
+                  @pointerleave="showNodeTooltip = true"
                 >
                   <GeneralIcon
                     icon="chevronRight"

--- a/packages/nc-gui/components/dashboard/TreeView/Table/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Table/List.vue
@@ -128,7 +128,7 @@ const initSortable = (el: Element) => {
     },
     revertOnSpill: true,
     filter: isTouchEvent,
-    preventOnFilter: false, // Allow click events to propagate on touch devices
+    preventOnFilter: false,
     ...getDraggableAutoScrollOptions({ scrollSensitivity: 50 }),
   })
 }

--- a/packages/nc-gui/components/dashboard/TreeView/Table/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Table/List.vue
@@ -128,6 +128,7 @@ const initSortable = (el: Element) => {
     },
     revertOnSpill: true,
     filter: isTouchEvent,
+    preventOnFilter: false, // Allow click events to propagate on touch devices
     ...getDraggableAutoScrollOptions({ scrollSensitivity: 50 }),
   })
 }

--- a/packages/nc-gui/components/dashboard/TreeView/Views/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Views/List.vue
@@ -193,7 +193,7 @@ const initSortable = (el: Element) => {
     animation: 150,
     revertOnSpill: true,
     filter: isTouchEvent,
-    preventOnFilter: false, // Allow click events to propagate on touch devices
+    preventOnFilter: false,
     ...getDraggableAutoScrollOptions({ scrollSensitivity: 50 }),
   })
 }

--- a/packages/nc-gui/components/dashboard/TreeView/Views/List.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Views/List.vue
@@ -193,6 +193,7 @@ const initSortable = (el: Element) => {
     animation: 150,
     revertOnSpill: true,
     filter: isTouchEvent,
+    preventOnFilter: false, // Allow click events to propagate on touch devices
     ...getDraggableAutoScrollOptions({ scrollSensitivity: 50 }),
   })
 }

--- a/packages/nc-gui/components/dashboard/TreeView/Views/Node.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Views/Node.vue
@@ -339,8 +339,8 @@ watch(isDropdownOpen, async () => {
           v-e="['c:view:emoji-picker']"
           class="flex min-w-6"
           :data-testid="`view-sidebar-drag-handle-${vModel.alias || vModel.title}`"
-          @mouseenter="showViewNodeTooltip = false"
-          @mouseleave="showViewNodeTooltip = true"
+          @pointerenter="showViewNodeTooltip = false"
+          @pointerleave="showViewNodeTooltip = true"
         >
           <LazyGeneralEmojiPicker
             class="nc-view-icon-parent"
@@ -423,8 +423,8 @@ watch(isDropdownOpen, async () => {
           <NcTooltip
             v-if="vModel.description?.length"
             placement="bottom"
-            @mouseenter="showViewNodeTooltip = false"
-            @mouseleave="showViewNodeTooltip = true"
+            @pointerenter="showViewNodeTooltip = false"
+            @pointerleave="showViewNodeTooltip = true"
           >
             <template #title>
               <div class="whitespace-pre-wrap break-words">{{ vModel.description }}</div>
@@ -447,8 +447,8 @@ watch(isDropdownOpen, async () => {
               }"
               @click.stop="isDropdownOpen = !isDropdownOpen"
               @dblclick.stop
-              @mouseenter="showViewNodeTooltip = false"
-              @mouseleave="showViewNodeTooltip = true"
+              @pointerenter="showViewNodeTooltip = false"
+              @pointerleave="showViewNodeTooltip = true"
             >
               <GeneralIcon icon="threeDotHorizontal" class="text-xl w-4.75" />
             </NcButton>

--- a/packages/nc-gui/components/dashboard/TreeView/index.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/index.vue
@@ -274,7 +274,7 @@ useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
   }
 })
 
-const handleContext = (e: MouseEvent) => {
+const handleContext = (e: MouseEvent | PointerEvent) => {
   if (!document.querySelector('.source-context, .table-context')?.contains(e.target as Node)) {
     setMenuContext('main')
   }

--- a/packages/nc-gui/components/dashboard/TreeView/index.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/index.vue
@@ -361,6 +361,7 @@ watch(
           handle=".base-title-node"
           ghost-class="ghost"
           :filter="isTouchEvent"
+          :prevent-on-filter="false"
           @change="onMove($event)"
         >
           <template #item="{ element: baseItem }">

--- a/packages/nc-gui/components/dashboard/View.vue
+++ b/packages/nc-gui/components/dashboard/View.vue
@@ -104,7 +104,7 @@ watch(
   },
 )
 
-function handleMouseMove(e: MouseEvent) {
+function handleMouseMove(e: MouseEvent | PointerEvent) {
   if (isMobileMode.value) return
   if (!wrapperRef.value) return
   if (isFullScreen.value) return

--- a/packages/nc-gui/components/dashboard/View.vue
+++ b/packages/nc-gui/components/dashboard/View.vue
@@ -150,12 +150,12 @@ function onWindowResize(e?: any): void {
 }
 
 onMounted(() => {
-  document.addEventListener('mousemove', handleMouseMove)
+  document.addEventListener('pointermove', handleMouseMove)
   window.addEventListener('resize', onWindowResize)
 })
 
 onBeforeUnmount(() => {
-  document.removeEventListener('mousemove', handleMouseMove)
+  document.removeEventListener('pointermove', handleMouseMove)
   window.removeEventListener('resize', onWindowResize)
 })
 

--- a/packages/nc-gui/components/dashboard/settings/data-sources/CreateBase.vue
+++ b/packages/nc-gui/components/dashboard/settings/data-sources/CreateBase.vue
@@ -589,7 +589,7 @@ const isIntgrationDisabled = (integration: IntegrationType = {}) => {
                             <a-divider style="margin: 4px 0" />
                             <div
                               class="px-1.5 flex items-center text-nc-content-brand text-sm cursor-pointer"
-                              @mousedown.prevent
+                              @pointerdown.prevent
                               @click="handleAddNewConnection"
                             >
                               <div class="w-full flex items-center gap-2 px-2 py-2 rounded-md hover:bg-nc-bg-gray-light">

--- a/packages/nc-gui/components/extensions/Extension.vue
+++ b/packages/nc-gui/components/extensions/Extension.vue
@@ -155,8 +155,8 @@ watch(
             }
           : {}
       "
-      @mousedown="isMouseDown = true"
-      @mouseup="isMouseDown = false"
+      @pointerdown="isMouseDown = true"
+      @pointerup="isMouseDown = false"
     >
       <ExtensionsExtensionHeader :is-fullscreen="false" />
 

--- a/packages/nc-gui/components/extensions/Extension.vue
+++ b/packages/nc-gui/components/extensions/Extension.vue
@@ -62,7 +62,7 @@ const fullscreenModalSize = computed(() => {
 })
 
 // close fullscreen on clicking extensionModalRef directly
-const closeFullscreen = (e: MouseEvent) => {
+const closeFullscreen = (e: MouseEvent | PointerEvent) => {
   if (e.target === extensionModalRef.value) {
     fullscreen.value = false
   }

--- a/packages/nc-gui/components/general/FlippingCard.vue
+++ b/packages/nc-gui/components/general/FlippingCard.vue
@@ -67,7 +67,7 @@ watch(flipped, () => {
 </script>
 
 <template>
-  <div class="flip-card" @click="onClick" @mouseover="onHover(true)" @mouseleave="onHover(false)">
+  <div class="flip-card" @click="onClick" @pointerover="onHover(true)" @pointerleave="onHover(false)">
     <div
       class="flipper"
       :style="{ '--flip-duration': `${props.duration || 800}ms`, 'transform': flipped ? 'rotateY(180deg)' : '' }"

--- a/packages/nc-gui/components/general/JoinCloud.vue
+++ b/packages/nc-gui/components/general/JoinCloud.vue
@@ -81,7 +81,7 @@ const onMouseover = async () => {
     </a>
 
     <a-tooltip arrow-point-at-center overlay-class-name="nc-join-cloud-tooltip">
-      <NcButton type="text" size="small" class="!rounded-l-none !rounded-r-lg" @mouseover="onMouseover">
+      <NcButton type="text" size="small" class="!rounded-l-none !rounded-r-lg" @pointerover="onMouseover">
         <GeneralIcon icon="help" class="!text-lg -mt-0.5 text-nc-content-gray-subtle" />
       </NcButton>
       <template #title>

--- a/packages/nc-gui/components/nc/Button.vue
+++ b/packages/nc-gui/components/nc/Button.vue
@@ -91,7 +91,7 @@ const onBlur = () => {
   isClicked.value = false
 }
 
-useEventListener(NcButton, 'mousedown', () => {
+useEventListener(NcButton, 'pointerdown', () => {
   isClicked.value = true
 })
 </script>

--- a/packages/nc-gui/components/nc/FullScreen/index.vue
+++ b/packages/nc-gui/components/nc/FullScreen/index.vue
@@ -100,7 +100,7 @@ function toggle(value?: boolean) {
   }
 }
 
-function shadeClick(e: MouseEvent) {
+function shadeClick(e: MouseEvent | PointerEvent) {
   if (e.target === wrapper.value && props.exitOnClickWrapper) {
     exit()
   }

--- a/packages/nc-gui/components/nc/Modal.vue
+++ b/packages/nc-gui/components/nc/Modal.vue
@@ -109,7 +109,7 @@ const visible = useVModel(props, 'visible', emits)
 
 const slots = useSlots()
 
-const stopPropagation = (event: MouseEvent) => {
+const stopPropagation = (event: MouseEvent | PointerEvent) => {
   event.stopPropagation()
 }
 
@@ -120,12 +120,12 @@ if (stopEventPropogation.value) {
 
     if (visible.value && modal?.parentElement) {
       // modal.parentElement.addEventListener('click', stopPropagation)
-      modal.parentElement.addEventListener('mousedown', stopPropagation)
-      // modal.parentElement.addEventListener('mouseup', stopPropagation)
+      modal.parentElement.addEventListener('pointerdown', stopPropagation)
+      // modal.parentElement.addEventListener('pointerup', stopPropagation)
     } else if (modal?.parentElement) {
       // modal.parentElement.removeEventListener('click', stopPropagation)
-      modal.parentElement.removeEventListener('mousedown', stopPropagation)
-      // modal.parentElement.removeEventListener('mouseup', stopPropagation)
+      modal.parentElement.removeEventListener('pointerdown', stopPropagation)
+      // modal.parentElement.removeEventListener('pointerup', stopPropagation)
     }
   })
 }

--- a/packages/nc-gui/components/nc/Popover.vue
+++ b/packages/nc-gui/components/nc/Popover.vue
@@ -149,14 +149,14 @@ const handleKeyDown = (event) => {
 }
 
 onMounted(() => {
-  if (props.closeOnClickOutside) document.addEventListener('mousedown', handleClickOutside)
+  if (props.closeOnClickOutside) document.addEventListener('pointerdown', handleClickOutside)
   if (props.closeOnEsc) document.addEventListener('keydown', handleKeyDown)
   window.addEventListener('resize', updatePopoverPosition)
   window.addEventListener('scroll', updatePopoverPosition)
 })
 
 onUnmounted(() => {
-  if (props.closeOnClickOutside) document.removeEventListener('mousedown', handleClickOutside)
+  if (props.closeOnClickOutside) document.removeEventListener('pointerdown', handleClickOutside)
   if (props.closeOnEsc) document.removeEventListener('keydown', handleKeyDown)
   window.removeEventListener('resize', updatePopoverPosition)
   window.removeEventListener('scroll', updatePopoverPosition)

--- a/packages/nc-gui/components/nc/Tooltip.vue
+++ b/packages/nc-gui/components/nc/Tooltip.vue
@@ -231,7 +231,7 @@ const onClick = () => {
         ...divStyles,
         ...attributes,
       }"
-      @mousedown="onClick"
+      @pointerdown="onClick"
     >
       <slot />
     </component>

--- a/packages/nc-gui/components/nc/form-builder/index.vue
+++ b/packages/nc-gui/components/nc/form-builder/index.vue
@@ -487,7 +487,7 @@ watch(
                         <a-divider style="margin: 4px 0" />
                         <div
                           class="px-1.5 flex items-center text-nc-content-brand text-sm cursor-pointer"
-                          @mousedown.prevent
+                          @pointerdown.prevent
                           @click="handleAddNewConnection(field)"
                         >
                           <div class="w-full flex items-center gap-2 px-2 py-2 rounded-md hover:bg-nc-bg-gray-light">

--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -165,7 +165,7 @@ const isNumericField = computed(() => {
 // disable contexxtmenu event propagation when cell is in
 // editable state and typable (e.g. text area)
 // this is to prevent the custom grid view context menu from opening
-const onContextmenu = (e: MouseEvent) => {
+const onContextmenu = (e: MouseEvent | PointerEvent) => {
   if (props.editEnabled && isTypableInputColumn(column.value)) {
     e.stopPropagation()
   }

--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -916,8 +916,8 @@ useEventListener(
 
 useEventListener(
   document,
-  'mousedown',
-  (e: MouseEvent) => {
+  'pointerdown',
+  (e: PointerEvent) => {
     if (
       (draggableRef.value?.targetDomElement && draggableRef.value?.targetDomElement.contains(e.target)) ||
       (e.target as HTMLElement)?.closest(
@@ -932,7 +932,7 @@ useEventListener(
   true,
 )
 
-const handleOnClick = (e: MouseEvent) => {
+const handleOnClick = (e: MouseEvent | PointerEvent) => {
   if (isSidebarVisible.value) return
 
   const target = e.target as HTMLElement

--- a/packages/nc-gui/components/smartsheet/TableDataCell.vue
+++ b/packages/nc-gui/components/smartsheet/TableDataCell.vue
@@ -17,7 +17,7 @@ provide(CellEventHookInj, cellEventHook)
 
 provide(CurrentCellInj, el)
 
-const handleClick = (event: MouseEvent) => {
+const handleClick = (event: MouseEvent | PointerEvent) => {
   cellClickHook.trigger(event)
   cellEventHook.trigger(event)
 }

--- a/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
@@ -356,26 +356,34 @@ const onResizeEnd = () => {
   resizeInProgress.value = false
   resizeDirection.value = null
   resizeRecord.value = null
-  document.removeEventListener('mousemove', onResize)
-  document.removeEventListener('mouseup', onResizeEnd)
+  document.removeEventListener('pointermove', onResize)
+  document.removeEventListener('pointerup', onResizeEnd)
+  document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-const onResizeStart = (direction: 'right' | 'left', event: MouseEvent, record: Row) => {
+/**
+ * Start resize operation. Uses Pointer Events API.
+ */
+const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
   resizeInProgress.value = true
   resizeDirection.value = direction
   resizeRecord.value = record
-  document.addEventListener('mousemove', onResize)
-  document.addEventListener('mouseup', onResizeEnd)
+  document.addEventListener('pointermove', onResize)
+  document.addEventListener('pointerup', onResizeEnd)
+  document.addEventListener('pointercancel', onResizeEnd)
 }
 
-const onDrag = (event: MouseEvent) => {
+const onDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit')) return
   if (!container.value || !dragRecord.value) return
   calculateNewRow(event, false)
 }
 
-const stopDrag = (event: MouseEvent) => {
+/**
+ * Stop drag operation. Uses Pointer Events API.
+ */
+const stopDrag = (event: MouseEvent | PointerEvent) => {
   event.preventDefault()
   clearTimeout(dragTimeout.value!)
 
@@ -401,11 +409,15 @@ const stopDrag = (event: MouseEvent) => {
 
   updateRowProperty(newRow, updateProperty, false)
 
-  document.removeEventListener('mousemove', onDrag)
-  document.removeEventListener('mouseup', stopDrag)
+  document.removeEventListener('pointermove', onDrag)
+  document.removeEventListener('pointerup', stopDrag)
+  document.removeEventListener('pointercancel', stopDrag)
 }
 
-const dragStart = (event: MouseEvent, record: Row) => {
+/**
+ * Start drag operation. Uses Pointer Events API.
+ */
+const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value) return
   let target = event.target as HTMLElement
 
@@ -440,19 +452,20 @@ const dragStart = (event: MouseEvent, record: Row) => {
     dragElement.value = target
     dragRecord.value = record
 
-    document.addEventListener('mousemove', onDrag)
-    document.addEventListener('mouseup', stopDrag)
+    document.addEventListener('pointermove', onDrag)
+    document.addEventListener('pointerup', stopDrag)
+    document.addEventListener('pointercancel', stopDrag)
   }, 200)
 
-  const onMouseUp = () => {
+  const onPointerUp = () => {
     clearTimeout(dragTimeout.value!)
-    document.removeEventListener('mouseup', onMouseUp)
+    document.removeEventListener('pointerup', onPointerUp)
     if (!isDragging.value) {
       emit('expandRecord', record)
     }
   }
 
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointerup', onPointerUp)
 }
 
 const isSpanningRecordExpanded = () => isExpanded.value
@@ -517,7 +530,7 @@ defineExpose({
             class="absolute group draggable-record pointer-events-auto nc-calendar-week-record-card"
             @mouseleave="hoverRecord = null"
             @mouseover="hoverRecord = record.rowMeta.id"
-            @mousedown.stop="dragStart($event, record)"
+            @pointerdown.stop="dragStart($event, record)"
           >
             <LazySmartsheetRow :row="record">
               <LazySmartsheetCalendarRecordCard

--- a/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
@@ -361,9 +361,6 @@ const onResizeEnd = () => {
   document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Start resize operation. Uses Pointer Events API.
- */
 const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
   resizeInProgress.value = true
@@ -380,9 +377,6 @@ const onDrag = (event: MouseEvent | PointerEvent) => {
   calculateNewRow(event, false)
 }
 
-/**
- * Stop drag operation. Uses Pointer Events API.
- */
 const stopDrag = (event: MouseEvent | PointerEvent) => {
   event.preventDefault()
   clearTimeout(dragTimeout.value!)
@@ -414,9 +408,6 @@ const stopDrag = (event: MouseEvent | PointerEvent) => {
   document.removeEventListener('pointercancel', stopDrag)
 }
 
-/**
- * Start drag operation. Uses Pointer Events API.
- */
 const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value) return
   let target = event.target as HTMLElement
@@ -528,8 +519,8 @@ defineExpose({
               ...record.rowMeta.style,
             }"
             class="absolute group draggable-record pointer-events-auto nc-calendar-week-record-card"
-            @mouseleave="hoverRecord = null"
-            @mouseover="hoverRecord = record.rowMeta.id"
+            @pointerleave="hoverRecord = null"
+            @pointerover="hoverRecord = record.rowMeta.id"
             @pointerdown.stop="dragStart($event, record)"
           >
             <LazySmartsheetRow :row="record">

--- a/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DateTimeSpanningContainer.vue
@@ -274,7 +274,7 @@ const useDebouncedRowUpdate = useDebounceFn((row: Row, updateProperty: string[],
 }, 500)
 
 // This function is used to calculate the new start and end date of a record when resizing
-const onResize = (event: MouseEvent) => {
+const onResize = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !container.value || !resizeRecord.value) return
 
   const { width, left } = container.value.getBoundingClientRect()

--- a/packages/nc-gui/components/smartsheet/calendar/DayView/DateField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DayView/DateField.vue
@@ -218,9 +218,9 @@ const newRecord = () => {
           class="mt-2"
           style="line-height: 18px"
           data-testid="nc-calendar-day-record-card"
-          @mouseleave="hoverRecord = null"
+          @pointerleave="hoverRecord = null"
           @click.prevent="emit('expandRecord', record)"
-          @mouseover="hoverRecord = record.rowMeta.id as string"
+          @pointerover="hoverRecord = record.rowMeta.id as string"
         >
           <LazySmartsheetRow :row="record">
             <LazySmartsheetCalendarRecordCard

--- a/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
@@ -725,10 +725,6 @@ const onResizeEnd = () => {
   document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Start resize operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const onResizeStart = (direction: 'right' | 'left', _event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
   if (record.rowMeta.range?.is_readonly) return
@@ -752,10 +748,6 @@ const onDrag = (event: MouseEvent) => {
   calculateNewRow(event)
 }
 
-/**
- * Stop drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const stopDrag = (event: MouseEvent | PointerEvent) => {
   event.preventDefault()
   clearTimeout(dragTimeout.value!)
@@ -783,10 +775,6 @@ const stopDrag = (event: MouseEvent | PointerEvent) => {
   document.removeEventListener('pointercancel', stopDrag)
 }
 
-/**
- * Start drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (isSyncedFromColumn.value) return
 
@@ -1213,8 +1201,8 @@ const expandRecord = (record: Row) => {
               }"
               class="absolute draggable-record transition group cursor-pointer pointer-events-auto"
               @pointerdown="dragStart($event, record)"
-              @mouseleave="hoverRecord = null"
-              @mouseover="hoverRecord = record.rowMeta.id as string"
+              @pointerleave="hoverRecord = null"
+              @pointerover="hoverRecord = record.rowMeta.id as string"
               @dragover.prevent
             >
               <LazySmartsheetRow :row="record">

--- a/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
@@ -720,18 +720,24 @@ const onResize = (event: MouseEvent) => {
 const onResizeEnd = () => {
   resizeDirection.value = null
   resizeRecord.value = null
-  document.removeEventListener('mousemove', onResize)
-  document.removeEventListener('mouseup', onResizeEnd)
+  document.removeEventListener('pointermove', onResize)
+  document.removeEventListener('pointerup', onResizeEnd)
+  document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-const onResizeStart = (direction: 'right' | 'left', _event: MouseEvent, record: Row) => {
+/**
+ * Start resize operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const onResizeStart = (direction: 'right' | 'left', _event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
   if (record.rowMeta.range?.is_readonly) return
 
   resizeDirection.value = direction
   resizeRecord.value = record
-  document.addEventListener('mousemove', onResize)
-  document.addEventListener('mouseup', onResizeEnd)
+  document.addEventListener('pointermove', onResize)
+  document.addEventListener('pointerup', onResizeEnd)
+  document.addEventListener('pointercancel', onResizeEnd)
 }
 
 const onDrag = (event: MouseEvent) => {
@@ -746,7 +752,11 @@ const onDrag = (event: MouseEvent) => {
   calculateNewRow(event)
 }
 
-const stopDrag = (event: MouseEvent) => {
+/**
+ * Stop drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const stopDrag = (event: MouseEvent | PointerEvent) => {
   event.preventDefault()
   clearTimeout(dragTimeout.value!)
   if (!isUIAllowed('dataEdit') || !isDragging.value || !container.value || !dragRecord.value) return
@@ -768,11 +778,16 @@ const stopDrag = (event: MouseEvent) => {
 
   $e('c:calendar:day:drag-record')
 
-  document.removeEventListener('mousemove', onDrag)
-  document.removeEventListener('mouseup', stopDrag)
+  document.removeEventListener('pointermove', onDrag)
+  document.removeEventListener('pointerup', stopDrag)
+  document.removeEventListener('pointercancel', stopDrag)
 }
 
-const dragStart = (event: MouseEvent, record: Row) => {
+/**
+ * Start drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (isSyncedFromColumn.value) return
 
   let target = event.target as HTMLElement
@@ -792,19 +807,20 @@ const dragStart = (event: MouseEvent, record: Row) => {
     dragRecord.value = record
     dragElement.value = target
 
-    document.addEventListener('mousemove', onDrag)
-    document.addEventListener('mouseup', stopDrag)
+    document.addEventListener('pointermove', onDrag)
+    document.addEventListener('pointerup', stopDrag)
+    document.addEventListener('pointercancel', stopDrag)
   }, 200)
 
-  const onMouseUp = () => {
+  const onPointerUp = () => {
     clearTimeout(dragTimeout.value!)
-    document.removeEventListener('mouseup', onMouseUp)
+    document.removeEventListener('pointerup', onPointerUp)
     if (!isDragging.value) {
       emit('expandRecord', record)
     }
   }
 
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointerup', onPointerUp)
 }
 
 // We support drag and drop from the sidebar to the day view of the date field
@@ -1196,7 +1212,7 @@ const expandRecord = (record: Row) => {
                     : 0.3,
               }"
               class="absolute draggable-record transition group cursor-pointer pointer-events-auto"
-              @mousedown="dragStart($event, record)"
+              @pointerdown="dragStart($event, record)"
               @mouseleave="hoverRecord = null"
               @mouseover="hoverRecord = record.rowMeta.id as string"
               @dragover.prevent

--- a/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DayView/DateTimeField.vue
@@ -637,7 +637,7 @@ const calculateNewRow = (event: MouseEvent, skipChangeCheck?: boolean) => {
   return { newRow, updateProperty }
 }
 
-const onResize = (event: MouseEvent) => {
+const onResize = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !container.value || !resizeRecord.value) return
   if (resizeRecord.value.rowMeta.range?.is_readonly) return
 
@@ -736,7 +736,7 @@ const onResizeStart = (direction: 'right' | 'left', _event: MouseEvent | Pointer
   document.addEventListener('pointercancel', onResizeEnd)
 }
 
-const onDrag = (event: MouseEvent) => {
+const onDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !container.value || !dragRecord.value) return
   const { top, bottom } = container.value.getBoundingClientRect()
 

--- a/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
@@ -597,10 +597,6 @@ const onResizeEnd = () => {
   document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Start resize operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit') || draggingId.value) return
 
@@ -616,10 +612,6 @@ const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerE
   document.addEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Stop drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const stopDrag = (event: MouseEvent | PointerEvent) => {
   clearTimeout(dragTimeout.value)
   if (!isUIAllowed('dataEdit') || !dragRecord.value || !isDragging.value) return
@@ -653,10 +645,6 @@ const stopDrag = (event: MouseEvent | PointerEvent) => {
   document.removeEventListener('pointercancel', stopDrag)
 }
 
-/**
- * Start drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value || !record.rowMeta.id || isSyncedFromColumn.value) return
   let target = event.target as HTMLElement
@@ -985,8 +973,8 @@ const addRecord = (date: dayjs.Dayjs) => {
             'cursor-pointer': !resizeInProgress,
           }"
           class="absolute group draggable-record transition pointer-events-auto"
-          @mouseleave="hoverRecord = null"
-          @mouseover="hoverRecord = record.rowMeta.id"
+          @pointerleave="hoverRecord = null"
+          @pointerover="hoverRecord = record.rowMeta.id"
           @pointerdown.stop="dragStart($event, record)"
         >
           <LazySmartsheetRow :row="record">

--- a/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
@@ -592,11 +592,16 @@ const onResizeEnd = () => {
   resizeDirection.value = undefined
   resizeRecord.value = null
 
-  document.removeEventListener('mousemove', onResize)
-  document.removeEventListener('mouseup', onResizeEnd)
+  document.removeEventListener('pointermove', onResize)
+  document.removeEventListener('pointerup', onResizeEnd)
+  document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-const onResizeStart = (direction: 'right' | 'left', event: MouseEvent, record: Row) => {
+/**
+ * Start resize operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit') || draggingId.value) return
 
   if (record.rowMeta.range?.is_readonly) return
@@ -606,11 +611,16 @@ const onResizeStart = (direction: 'right' | 'left', event: MouseEvent, record: R
   resizeDirection.value = direction
   resizeRecord.value = record
 
-  document.addEventListener('mousemove', onResize)
-  document.addEventListener('mouseup', onResizeEnd)
+  document.addEventListener('pointermove', onResize)
+  document.addEventListener('pointerup', onResizeEnd)
+  document.addEventListener('pointercancel', onResizeEnd)
 }
 
-const stopDrag = (event: MouseEvent) => {
+/**
+ * Stop drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const stopDrag = (event: MouseEvent | PointerEvent) => {
   clearTimeout(dragTimeout.value)
   if (!isUIAllowed('dataEdit') || !dragRecord.value || !isDragging.value) return
   if (dragRecord.value.rowMeta.range?.is_readonly) return
@@ -638,11 +648,16 @@ const stopDrag = (event: MouseEvent) => {
 
   $e('c:calendar:month:drag-record')
 
-  document.removeEventListener('mousemove', onDrag)
-  document.removeEventListener('mouseup', stopDrag)
+  document.removeEventListener('pointermove', onDrag)
+  document.removeEventListener('pointerup', stopDrag)
+  document.removeEventListener('pointercancel', stopDrag)
 }
 
-const dragStart = (event: MouseEvent, record: Row) => {
+/**
+ * Start drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value || !record.rowMeta.id || isSyncedFromColumn.value) return
   let target = event.target as HTMLElement
   isDragging.value = false
@@ -671,19 +686,20 @@ const dragStart = (event: MouseEvent, record: Row) => {
       y: event.clientY,
     }
 
-    document.addEventListener('mousemove', onDrag)
-    document.addEventListener('mouseup', stopDrag)
+    document.addEventListener('pointermove', onDrag)
+    document.addEventListener('pointerup', stopDrag)
+    document.addEventListener('pointercancel', stopDrag)
   }, 500)
 
-  const onMouseUp = () => {
+  const onPointerUp = () => {
     clearTimeout(dragTimeout.value)
-    document.removeEventListener('mouseup', onMouseUp)
+    document.removeEventListener('pointerup', onPointerUp)
     if (!isDragging.value) {
       emit('expandRecord', record)
     }
   }
 
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointerup', onPointerUp)
 }
 
 const dropEvent = (event: DragEvent) => {
@@ -971,7 +987,7 @@ const addRecord = (date: dayjs.Dayjs) => {
           class="absolute group draggable-record transition pointer-events-auto"
           @mouseleave="hoverRecord = null"
           @mouseover="hoverRecord = record.rowMeta.id"
-          @mousedown.stop="dragStart($event, record)"
+          @pointerdown.stop="dragStart($event, record)"
         >
           <LazySmartsheetRow :row="record">
             <LazySmartsheetCalendarRecordCard

--- a/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
@@ -506,7 +506,7 @@ const calculateNewRow = (event: MouseEvent, updateSideBar?: boolean, skipChangeC
   }
 }
 
-const onDrag = (event: MouseEvent) => {
+const onDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !dragRecord.value) return
 
   calculateNewRow(event, false)
@@ -516,7 +516,7 @@ const useDebouncedRowUpdate = useDebounceFn((row: Row, updateProperty: string[],
   updateRowProperty(row, updateProperty, isDelete)
 }, 500)
 
-const onResize = (event: MouseEvent) => {
+const onResize = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !resizeRecord.value) return
 
   const { top, height, width, left } = calendarGridContainer.value.getBoundingClientRect()

--- a/packages/nc-gui/components/smartsheet/calendar/RecordCard.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/RecordCard.vue
@@ -74,7 +74,7 @@ const rowColorInfo = computed(() => {
     <div
       v-if="(position === 'leftRounded' || position === 'rounded') && resize"
       class="mt-0.7 w-2 h-7.1 -left-1 absolute resize"
-      @mousedown.stop="emit('resizeStart', 'left', $event, record)"
+      @pointerdown.stop="emit('resizeStart', 'left', $event, record)"
     ></div>
 
     <div class="overflow-hidden items-center justify-center gap-2 flex w-full">
@@ -107,7 +107,7 @@ const rowColorInfo = computed(() => {
     <div
       v-if="(position === 'rightRounded' || position === 'rounded') && resize"
       class="absolute mt-0.3 h-7.1 w-2 right-0 resize"
-      @mousedown.stop="emit('resizeStart', 'right', $event, record)"
+      @pointerdown.stop="emit('resizeStart', 'right', $event, record)"
     ></div>
   </div>
 </template>

--- a/packages/nc-gui/components/smartsheet/calendar/VRecordCard.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/VRecordCard.vue
@@ -49,7 +49,7 @@ const rowColorInfo = computed(() => {
     <div
       v-if="resize"
       class="absolute w-full h-1 z-20 top-0 cursor-row-resize"
-      @mousedown.stop="emit('resizeStart', 'left', $event, record)"
+      @pointerdown.stop="emit('resizeStart', 'left', $event, record)"
     ></div>
     <div
       :class="{
@@ -84,7 +84,7 @@ const rowColorInfo = computed(() => {
     <div
       v-if="resize"
       class="absolute cursor-row-resize w-full bottom-0 w-full h-1"
-      @mousedown.stop="emit('resizeStart', 'right', $event, record)"
+      @pointerdown.stop="emit('resizeStart', 'right', $event, record)"
     ></div>
   </div>
 </template>

--- a/packages/nc-gui/components/smartsheet/calendar/WeekView/DateField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/WeekView/DateField.vue
@@ -287,10 +287,6 @@ const onResizeEnd = () => {
   document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Start resize operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
   resizeInProgress.value = true
@@ -394,10 +390,6 @@ const onDrag = (event: MouseEvent) => {
   calculateNewRow(event, false)
 }
 
-/**
- * Stop drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const stopDrag = (event: MouseEvent | PointerEvent) => {
   event.preventDefault()
   clearTimeout(dragTimeout.value!)
@@ -435,10 +427,6 @@ const stopDrag = (event: MouseEvent | PointerEvent) => {
   document.removeEventListener('pointercancel', stopDrag)
 }
 
-/**
- * Start drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value || isSyncedFromColumn.value) return
   let target = event.target as HTMLElement
@@ -586,8 +574,8 @@ const addRecord = (date: dayjs.Dayjs) => {
             lineHeight: '18px',
           }"
           class="absolute group draggable-record pointer-events-auto nc-calendar-week-record-card"
-          @mouseleave="hoverRecord = null"
-          @mouseover="hoverRecord = record.rowMeta.id"
+          @pointerleave="hoverRecord = null"
+          @pointerover="hoverRecord = record.rowMeta.id"
           @pointerdown.stop="dragStart($event, record)"
         >
           <LazySmartsheetRow :row="record">

--- a/packages/nc-gui/components/smartsheet/calendar/WeekView/DateField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/WeekView/DateField.vue
@@ -209,7 +209,7 @@ const useDebouncedRowUpdate = useDebounceFn((row: Row, updateProperty: string[],
 }, 500)
 
 // This function is used to calculate the new start and end date of a record when resizing
-const onResize = (event: MouseEvent) => {
+const onResize = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !container.value || !resizeRecord.value) return
 
   const { width, left } = container.value.getBoundingClientRect()
@@ -382,7 +382,7 @@ const calculateNewRow = (event: MouseEvent, updateSideBarData?: boolean) => {
   return { updateProperty, newRow }
 }
 
-const onDrag = (event: MouseEvent) => {
+const onDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit')) return
   if (!container.value || !dragRecord.value) return
   event.preventDefault()

--- a/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
@@ -727,11 +727,16 @@ const onResizeEnd = () => {
   resizeInProgress.value = false
   resizeDirection.value = null
   resizeRecord.value = null
-  document.removeEventListener('mousemove', onResize)
-  document.removeEventListener('mouseup', onResizeEnd)
+  document.removeEventListener('pointermove', onResize)
+  document.removeEventListener('pointerup', onResizeEnd)
+  document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-const onResizeStart = (direction: 'right' | 'left', event: MouseEvent, record: Row) => {
+/**
+ * Start resize operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
 
   if (record.rowMeta.range?.is_readonly) return
@@ -739,8 +744,9 @@ const onResizeStart = (direction: 'right' | 'left', event: MouseEvent, record: R
   resizeInProgress.value = true
   resizeDirection.value = direction
   resizeRecord.value = record
-  document.addEventListener('mousemove', onResize)
-  document.addEventListener('mouseup', onResizeEnd)
+  document.addEventListener('pointermove', onResize)
+  document.addEventListener('pointerup', onResizeEnd)
+  document.addEventListener('pointercancel', onResizeEnd)
 }
 
 // We calculate the new row based on the mouse position and update the record
@@ -853,7 +859,11 @@ const onDrag = (event: MouseEvent) => {
   calculateNewRow(event)
 }
 
-const stopDrag = (event: MouseEvent) => {
+/**
+ * Stop drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const stopDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !isDragging.value || !container.value || !dragRecord.value) return
 
   event.preventDefault()
@@ -869,11 +879,16 @@ const stopDrag = (event: MouseEvent) => {
 
   $e('c:calendar:week:drag-record')
 
-  document.removeEventListener('mousemove', onDrag)
-  document.removeEventListener('mouseup', stopDrag)
+  document.removeEventListener('pointermove', onDrag)
+  document.removeEventListener('pointerup', stopDrag)
+  document.removeEventListener('pointercancel', stopDrag)
 }
 
-const dragStart = (event: MouseEvent, record: Row) => {
+/**
+ * Start drag operation for calendar records.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value || isSyncedFromColumn.value) return
   let target = event.target as HTMLElement
 
@@ -891,19 +906,20 @@ const dragStart = (event: MouseEvent, record: Row) => {
     isDragging.value = true
     dragRecord.value = record
 
-    document.addEventListener('mousemove', onDrag)
-    document.addEventListener('mouseup', stopDrag)
+    document.addEventListener('pointermove', onDrag)
+    document.addEventListener('pointerup', stopDrag)
+    document.addEventListener('pointercancel', stopDrag)
   }, 200)
 
-  const onMouseUp = () => {
+  const onPointerUp = () => {
     clearTimeout(dragTimeout.value!)
-    document.removeEventListener('mouseup', onMouseUp)
+    document.removeEventListener('pointerup', onPointerUp)
     if (!isDragging.value) {
       emits('expandRecord', record)
     }
   }
 
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointerup', onPointerUp)
 }
 
 const dropEvent = (event: DragEvent) => {
@@ -1185,7 +1201,7 @@ watch(
               'w-1/7': maxVisibleDays === 7,
             }"
             class="absolute transition draggable-record group cursor-pointer pointer-events-auto"
-            @mousedown.stop="dragStart($event, record)"
+            @pointerdown.stop="dragStart($event, record)"
             @mouseleave="hoverRecord = null"
             @mouseover="hoverRecord = record.rowMeta.id"
             @dragover.prevent

--- a/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
@@ -732,10 +732,6 @@ const onResizeEnd = () => {
   document.removeEventListener('pointercancel', onResizeEnd)
 }
 
-/**
- * Start resize operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const onResizeStart = (direction: 'right' | 'left', event: MouseEvent | PointerEvent, record: Row) => {
   if (!isUIAllowed('dataEdit')) return
 
@@ -859,10 +855,6 @@ const onDrag = (event: MouseEvent) => {
   calculateNewRow(event)
 }
 
-/**
- * Stop drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const stopDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !isDragging.value || !container.value || !dragRecord.value) return
 
@@ -884,10 +876,6 @@ const stopDrag = (event: MouseEvent | PointerEvent) => {
   document.removeEventListener('pointercancel', stopDrag)
 }
 
-/**
- * Start drag operation for calendar records.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const dragStart = (event: MouseEvent | PointerEvent, record: Row) => {
   if (resizeInProgress.value || isSyncedFromColumn.value) return
   let target = event.target as HTMLElement
@@ -1202,8 +1190,8 @@ watch(
             }"
             class="absolute transition draggable-record group cursor-pointer pointer-events-auto"
             @pointerdown.stop="dragStart($event, record)"
-            @mouseleave="hoverRecord = null"
-            @mouseover="hoverRecord = record.rowMeta.id"
+            @pointerleave="hoverRecord = null"
+            @pointerover="hoverRecord = record.rowMeta.id"
             @dragover.prevent
           >
             <LazySmartsheetRow :row="record">

--- a/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/WeekView/DateTimeField.vue
@@ -646,7 +646,7 @@ const useDebouncedRowUpdate = useDebounceFn((row: Row, updateProperty: string[],
   updateRowProperty(row, updateProperty, isDelete)
 }, 500)
 
-const onResize = (event: MouseEvent) => {
+const onResize = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !container.value || !resizeRecord.value || !scrollContainer.value) return
   if (resizeRecord.value.rowMeta.range?.is_readonly) return
 
@@ -840,7 +840,7 @@ const calculateNewRow = (
   return { newRow, updatedProperty }
 }
 
-const onDrag = (event: MouseEvent) => {
+const onDrag = (event: MouseEvent | PointerEvent) => {
   if (!isUIAllowed('dataEdit') || !scrollContainer.value || !dragRecord.value) return
 
   const containerRect = scrollContainer.value.getBoundingClientRect()

--- a/packages/nc-gui/components/smartsheet/column/EditOrAdd.vue
+++ b/packages/nc-gui/components/smartsheet/column/EditOrAdd.vue
@@ -1233,7 +1233,7 @@ const unique = computed({
                   'ant-select-item-option-active-selected': showHoverEffectOnSelectedType && formState.uidt === opt.name,
                   '!text-nc-content-purple-dark': [AIPrompt, AIButton].includes(opt.name),
                 }"
-                @mouseover="handleResetHoverEffect"
+                @pointerover="handleResetHoverEffect"
               >
                 <NcTooltip
                   class="w-full flex gap-2 items-center justify-between"

--- a/packages/nc-gui/components/smartsheet/column/EditOrAdd.vue
+++ b/packages/nc-gui/components/smartsheet/column/EditOrAdd.vue
@@ -1429,8 +1429,8 @@ const unique = computed({
                       <GeneralIcon
                         icon="info"
                         class="h-3.5 w-3.5 text-nc-content-gray-muted"
-                        @mouseover="onMouseOverUniqueValuesInfoIcon = true"
-                        @mouseleave="onMouseOverUniqueValuesInfoIcon = false"
+                        @pointerover="onMouseOverUniqueValuesInfoIcon = true"
+                        @pointerleave="onMouseOverUniqueValuesInfoIcon = false"
                       />
                     </NcTooltip>
 

--- a/packages/nc-gui/components/smartsheet/column/FormulaInputHelper.vue
+++ b/packages/nc-gui/components/smartsheet/column/FormulaInputHelper.vue
@@ -885,7 +885,7 @@ const validationErrorDisplay = computed(() => {
               'cursor-not-allowed': item.unsupported,
             }"
             @click.prevent.stop="!item.unsupported && appendText(item)"
-            @mouseenter="suggestionPreviewed = item"
+            @pointerenter="suggestionPreviewed = item"
           >
             <a-list-item-meta>
               <template #title>

--- a/packages/nc-gui/components/smartsheet/expanded-form/Sidebar/Comments.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Sidebar/Comments.vue
@@ -327,7 +327,7 @@ onBeforeUnmount(() => {
             commentItem.id,
           ]"
           class="nc-comment-item"
-          @mouseover="handleResetHoverEffect"
+          @pointerover="handleResetHoverEffect"
         >
           <div
             :class="{

--- a/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
+++ b/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
@@ -2162,7 +2162,11 @@ const {
   cachedRows,
 })
 
-const startDragging = (row: Row, event: MouseEvent) => {
+/**
+ * Start row drag operation.
+ * Accepts both MouseEvent and PointerEvent for touch support.
+ */
+const startDragging = (row: Row, event: MouseEvent | PointerEvent) => {
   if (isPublicView.value) return
   row.rowMeta.isDragging = true
   cachedRows.value.set(row.rowMeta.rowIndex!, row)
@@ -2621,7 +2625,7 @@ const headerFilteredOrSortedClass = (colId: string) => {
                               size="xxsmall"
                               type="text"
                               :disabled="!!selectedRows.length || !!vSelectedAllRecords"
-                              @mousedown="startDragging(row, $event)"
+                              @pointerdown="startDragging(row, $event)"
                             >
                               <GeneralIcon
                                 :class="{
@@ -2728,8 +2732,8 @@ const headerFilteredOrSortedClass = (colId: string) => {
                               }
                             : {}
                         "
-                        @mousedown="handleMouseDown($event, row.rowMeta.rowIndex, 0)"
-                        @mouseover="handleMouseOver($event, row.rowMeta.rowIndex, 0)"
+                        @pointerdown="handleMouseDown($event, row.rowMeta.rowIndex, 0)"
+                        @pointerover="handleMouseOver($event, row.rowMeta.rowIndex, 0)"
                         @dblclick="makeEditable(row, fields[0])"
                         @contextmenu="showContextMenu($event, { row: row.rowMeta.rowIndex, col: 0 })"
                         @click="handleCellClick($event, row.rowMeta.rowIndex, 0)"
@@ -2832,8 +2836,8 @@ const headerFilteredOrSortedClass = (colId: string) => {
                               }
                             : {}
                         "
-                        @mousedown="handleMouseDown($event, row.rowMeta.rowIndex, colIndex)"
-                        @mouseover="handleMouseOver($event, row.rowMeta.rowIndex, colIndex)"
+                        @pointerdown="handleMouseDown($event, row.rowMeta.rowIndex, colIndex)"
+                        @pointerover="handleMouseOver($event, row.rowMeta.rowIndex, colIndex)"
                         @click="handleCellClick($event, row.rowMeta.rowIndex, colIndex)"
                         @dblclick="makeEditable(row, columnObj)"
                         @contextmenu="showContextMenu($event, { row: row.rowMeta.rowIndex, col: colIndex })"

--- a/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
+++ b/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
@@ -2162,10 +2162,6 @@ const {
   cachedRows,
 })
 
-/**
- * Start row drag operation.
- * Accepts both MouseEvent and PointerEvent for touch support.
- */
 const startDragging = (row: Row, event: MouseEvent | PointerEvent) => {
   if (isPublicView.value) return
   row.rowMeta.isDragging = true

--- a/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
+++ b/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
@@ -461,7 +461,7 @@ const contextMenu = computed({
   },
 })
 
-const showContextMenu = (e: MouseEvent, target?: { row: number; col: number }) => {
+const showContextMenu = (e: MouseEvent | PointerEvent, target?: { row: number; col: number }) => {
   if (isSqlView.value) return
   e.preventDefault()
   if (target) {
@@ -1899,7 +1899,7 @@ useScroll(gridWrapper, {
   behavior: 'smooth',
 })
 
-useEventListener(document, 'mousedown', (e) => {
+useEventListener(document, 'pointerdown', (e) => {
   if (e.offsetX > (e.target as HTMLElement)?.clientWidth || e.offsetY > (e.target as HTMLElement)?.clientHeight) {
     scrolling.value = true
   }
@@ -1909,7 +1909,7 @@ useEventListener(document, 'mousedown', (e) => {
   }
 })
 
-useEventListener(document, 'mouseup', () => {
+useEventListener(document, 'pointerup', () => {
   isGridCellMouseDown.value = false
   // wait for click event to finish before setting scrolling to false
   setTimeout(() => {
@@ -2084,7 +2084,7 @@ const expandAndLooseFocus = (row: Row, col: Record<string, any>) => {
   selectedRange.clear()
 }
 
-const handleCellClick = (event: MouseEvent, row: number, col: number) => {
+const handleCellClick = (event: MouseEvent | PointerEvent, row: number, col: number) => {
   const rowData = cachedRows.value.get(row)
 
   if (activeCell.row !== row) {

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -2379,8 +2379,8 @@ onKeyStroke('ArrowDown', onDown)
                         :data-title="fields[0].title"
                         :data-row-index="rowIndex"
                         :data-col-index="0"
-                        @mousedown="handleMouseDown($event, rowIndex, 0)"
-                        @mouseover="handleMouseOver($event, rowIndex, 0)"
+                        @pointerdown="handleMouseDown($event, rowIndex, 0)"
+                        @pointerover="handleMouseOver($event, rowIndex, 0)"
                         @click="handleCellClick($event, rowIndex, 0)"
                         @dblclick="makeEditable(row, fields[0])"
                         @contextmenu="showContextMenu($event, { row: rowIndex, col: 0 })"
@@ -2457,8 +2457,8 @@ onKeyStroke('ArrowDown', onDown)
                         :data-title="columnObj.title"
                         :data-row-index="rowIndex"
                         :data-col-index="colIndex"
-                        @mousedown="handleMouseDown($event, rowIndex, colIndex)"
-                        @mouseover="handleMouseOver($event, rowIndex, colIndex)"
+                        @pointerdown="handleMouseDown($event, rowIndex, colIndex)"
+                        @pointerover="handleMouseOver($event, rowIndex, colIndex)"
                         @click="handleCellClick($event, rowIndex, colIndex)"
                         @dblclick="makeEditable(row, columnObj)"
                         @contextmenu="showContextMenu($event, { row: rowIndex, col: colIndex })"
@@ -2522,7 +2522,7 @@ onKeyStroke('ArrowDown', onDown)
                   :class="{
                     '!border-r-2 !border-r-gray-100': visibleColLength === 1,
                   }"
-                  @mouseup.stop
+                  @pointerup.stop
                   @click="addEmptyRow()"
                 >
                   <td

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -231,7 +231,7 @@ const contextMenu = computed({
   },
 })
 
-const showContextMenu = (e: MouseEvent, target?: { row: number; col: number }) => {
+const showContextMenu = (e: MouseEvent | PointerEvent, target?: { row: number; col: number }) => {
   if (isSqlView.value) return
   e.preventDefault()
   if (target) {
@@ -1638,7 +1638,7 @@ useEventListener(scrollWrapper, 'scroll', (e) => {
   })
 })
 
-useEventListener(document, 'mousedown', (e) => {
+useEventListener(document, 'pointerdown', (e) => {
   if (e.offsetX > (e.target as HTMLElement)?.clientWidth || e.offsetY > (e.target as HTMLElement)?.clientHeight) {
     scrolling.value = true
   }
@@ -1648,7 +1648,7 @@ useEventListener(document, 'mousedown', (e) => {
   }
 })
 
-useEventListener(document, 'mouseup', () => {
+useEventListener(document, 'pointerup', () => {
   isGridCellMouseDown.value = false
   // wait for click event to finish before setting scrolling to false
   setTimeout(() => {
@@ -1832,7 +1832,7 @@ const expandAndLooseFocus = (row: Row, col: Record<string, any>) => {
   selectedRange.clear()
 }
 
-const handleCellClick = (event: MouseEvent, row: number, col: number) => {
+const handleCellClick = (event: MouseEvent | PointerEvent, row: number, col: number) => {
   const rowData = dataRef.value[row]
 
   if (isMobileMode.value) {

--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/index.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/index.ts
@@ -382,7 +382,7 @@ export function useGridCellHandler(params: {
   }
 
   const handleCellClick = async (ctx: {
-    event: MouseEvent
+    event: MouseEvent | PointerEvent
     row: Row
     column: CanvasGridColumn
     value: any
@@ -459,7 +459,7 @@ export function useGridCellHandler(params: {
   }
 
   const handleCellHover = async (ctx: {
-    event: MouseEvent
+    event: MouseEvent | PointerEvent
     row: Row
     column: CanvasGridColumn
     value: any

--- a/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
@@ -46,7 +46,7 @@ const onMouseMove = (e: MouseEvent) => {
   }
 }
 
-const onMouseUp = (e: MouseEvent) => {
+const onPointerUp = (e: MouseEvent | PointerEvent) => {
   if (!isDragging.value) return
 
   e.stopPropagation()
@@ -55,11 +55,12 @@ const onMouseUp = (e: MouseEvent) => {
   position.value = undefined
   mousePosition.value = undefined
 
-  document.removeEventListener('mousemove', onMouseMove)
-  document.removeEventListener('mouseup', onMouseUp)
+  document.removeEventListener('pointermove', onMouseMove)
+  document.removeEventListener('pointerup', onPointerUp)
+  document.removeEventListener('pointercancel', onPointerUp)
 }
 
-const dragStart = (e: MouseEvent) => {
+const dragStart = (e: MouseEvent | PointerEvent) => {
   const dom = document.querySelector('.nc-long-text-expanded .ant-modal-content') as HTMLElement
   if (!dom) return
 
@@ -68,8 +69,9 @@ const dragStart = (e: MouseEvent) => {
     left: e.clientX - dom.getBoundingClientRect().left + 16,
   }
 
-  document.addEventListener('mousemove', onMouseMove)
-  document.addEventListener('mouseup', onMouseUp)
+  document.addEventListener('pointermove', onMouseMove)
+  document.addEventListener('pointerup', onPointerUp)
+  document.addEventListener('pointercancel', onPointerUp)
   isDragging.value = true
 }
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
@@ -210,7 +210,7 @@ const urls = replaceUrlsWithLink(result)
       <div
         v-if="column"
         class="flex flex-row gap-x-1 items-center font-medium pl-3 pb-2.5 pt-3 border-b-1 border-nc-border-gray-light overflow-hidden cursor-move select-none"
-        @mousedown="dragStart"
+        @pointerdown="dragStart"
       >
         <SmartsheetHeaderIcon :column="column" class="flex" />
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/components/ExpandedText.vue
@@ -32,7 +32,7 @@ const isSizeUpdated = ref(false)
  */
 const skipSizeUpdate = ref(true)
 
-const onMouseMove = (e: MouseEvent) => {
+const onMouseMove = (e: MouseEvent | PointerEvent) => {
   if (!isDragging.value) return
 
   e.stopPropagation()

--- a/packages/nc-gui/components/smartsheet/grid/canvas/components/Scroller.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/components/Scroller.vue
@@ -197,10 +197,6 @@ const handleWheel = (e: WheelEvent) => {
   updateScroll(scrollTop.value + (canScrollVertically ? deltaY : 0), scrollLeft.value + (canScrollHorizontally ? deltaX : 0))
 }
 
-/**
- * Start dragging the scrollbar thumb.
- * Uses Pointer Events API for unified mouse/touch/pen handling.
- */
 const startDragging = (axis: 'vertical' | 'horizontal', event: PointerEvent) => {
   event.preventDefault()
   event.stopPropagation()

--- a/packages/nc-gui/components/smartsheet/grid/canvas/components/Scroller.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/components/Scroller.vue
@@ -197,35 +197,31 @@ const handleWheel = (e: WheelEvent) => {
   updateScroll(scrollTop.value + (canScrollVertically ? deltaY : 0), scrollLeft.value + (canScrollHorizontally ? deltaX : 0))
 }
 
-const startDragging = (axis: 'vertical' | 'horizontal', event: DragEvent | TouchEvent) => {
+/**
+ * Start dragging the scrollbar thumb.
+ * Uses Pointer Events API for unified mouse/touch/pen handling.
+ */
+const startDragging = (axis: 'vertical' | 'horizontal', event: PointerEvent) => {
   event.preventDefault()
   event.stopPropagation()
 
   isDragging.value = true
   currentDragAxis.value = axis
 
-  // normalize touch vs mouse
-  const clientY = (event as TouchEvent).touches ? (event as TouchEvent).touches[0].clientY : (event as MouseEvent).clientY
-  const clientX = (event as TouchEvent).touches ? (event as TouchEvent).touches[0].clientX : (event as MouseEvent).clientX
-
-  dragStartPosition.value = axis === 'vertical' ? clientY : clientX
+  dragStartPosition.value = axis === 'vertical' ? event.clientY : event.clientX
   dragStartScroll.value = axis === 'vertical' ? scrollTop.value : scrollLeft.value
 
-  // add both mouse + touch listeners
-  document.addEventListener('mousemove', handleDrag)
-  document.addEventListener('mouseup', stopDragging)
-  document.addEventListener('touchmove', handleDrag, { passive: false })
-  document.addEventListener('touchend', stopDragging)
+  // Use pointer events for unified input handling
+  document.addEventListener('pointermove', handleDrag)
+  document.addEventListener('pointerup', stopDragging)
+  document.addEventListener('pointercancel', stopDragging)
 }
 
-function handleDrag(event: MouseEvent | TouchEvent) {
+function handleDrag(event: PointerEvent) {
   if (!isDragging.value || !contentWrapper.value || !wrapperRef.value) return
 
-  // normalize again
-  const clientY = (event as TouchEvent).touches ? (event as TouchEvent).touches[0].clientY : (event as MouseEvent).clientY
-  const clientX = (event as TouchEvent).touches ? (event as TouchEvent).touches[0].clientX : (event as MouseEvent).clientX
-
-  const delta = currentDragAxis.value === 'vertical' ? clientY - dragStartPosition.value : clientX - dragStartPosition.value
+  const delta =
+    currentDragAxis.value === 'vertical' ? event.clientY - dragStartPosition.value : event.clientX - dragStartPosition.value
 
   const scrollRatio =
     currentDragAxis.value === 'vertical'
@@ -242,13 +238,13 @@ function handleDrag(event: MouseEvent | TouchEvent) {
     updateScroll(undefined, newScroll)
   }
 }
+
 function stopDragging() {
   isDragging.value = false
   currentDragAxis.value = null
-  document.removeEventListener('mousemove', handleDrag)
-  document.removeEventListener('mouseup', stopDragging)
-  document.removeEventListener('touchmove', handleDrag)
-  document.removeEventListener('touchend', stopDragging)
+  document.removeEventListener('pointermove', handleDrag)
+  document.removeEventListener('pointerup', stopDragging)
+  document.removeEventListener('pointercancel', stopDragging)
 }
 
 const handleTrackClick = (axis: 'vertical' | 'horizontal', event: any) => {
@@ -448,8 +444,9 @@ onUnmounted(() => {
   }
 })
 onBeforeUnmount(() => {
-  document.removeEventListener('mousemove', handleDrag)
-  document.removeEventListener('mouseup', stopDragging)
+  document.removeEventListener('pointermove', handleDrag)
+  document.removeEventListener('pointerup', stopDragging)
+  document.removeEventListener('pointercancel', stopDragging)
 })
 
 defineExpose({
@@ -488,8 +485,7 @@ defineExpose({
         ref="verticalScrollbar"
         class="custom-scrollbar-thumb vertical"
         :style="{ height: `${verticalThumbHeight}%`, transform: `translateY(${verticalThumbPosition}px)` }"
-        @mousedown="startDragging('vertical', $event)"
-        @touchstart.prevent="startDragging('vertical', $event)"
+        @pointerdown="startDragging('vertical', $event)"
       ></div>
     </div>
 
@@ -503,8 +499,7 @@ defineExpose({
         ref="horizontalScrollbar"
         class="custom-scrollbar-thumb horizontal"
         :style="{ width: `${horizontalThumbWidth}%`, transform: `translateX(${horizontalThumbPosition}px)` }"
-        @mousedown="startDragging('horizontal', $event)"
-        @touchstart.prevent="startDragging('horizontal', $event)"
+        @pointerdown="startDragging('horizontal', $event)"
       ></div>
     </div>
   </div>

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useCanvasTable.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useCanvasTable.ts
@@ -1055,8 +1055,8 @@ export function useCanvasTable({
   }
 
   const {
-    handleMouseMove: resizeMouseMove,
-    handleMouseDown: startResize,
+    handlePointerMove: resizePointerMove,
+    handlePointerDown: startResize,
     resizeableColumn,
     isResizing,
   } = useColumnResize(
@@ -1526,7 +1526,7 @@ export function useCanvasTable({
     elementMap,
     makeCellEditable,
     // Handler
-    resizeMouseMove,
+    resizePointerMove,
     startResize,
 
     // Mouse Selection

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnReorder.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnReorder.ts
@@ -46,7 +46,11 @@ export function useColumnReorder(
     return null
   }
 
-  const handleDrag = (e: MouseEvent) => {
+  /**
+   * Handle pointer move for column drag.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const handleDrag = (e: PointerEvent) => {
     if (!isDragging.value || !dragStart.value) return
 
     const rect = canvasRef.value?.getBoundingClientRect()
@@ -76,12 +80,17 @@ export function useColumnReorder(
     dragStart.value = null
     dragOver.value = null
 
-    window.removeEventListener('mousemove', handleDrag)
-    window.removeEventListener('mouseup', dragEndHandler)
+    window.removeEventListener('pointermove', handleDrag)
+    window.removeEventListener('pointerup', dragEndHandler)
+    window.removeEventListener('pointercancel', dragEndHandler)
 
     requestAnimationFrame(drawCanvas)
   }
 
+  /**
+   * Start column drag operation.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
   const startDrag = (x: number) => {
     if (isLocked.value || !isViewOperationsAllowed.value) return
     const col = findColumnAtPosition(x)
@@ -92,8 +101,9 @@ export function useColumnReorder(
         index: columns.value.findIndex((c) => c.id === col.id),
         startX: x,
       }
-      window.addEventListener('mousemove', handleDrag)
-      window.addEventListener('mouseup', dragEndHandler)
+      window.addEventListener('pointermove', handleDrag)
+      window.addEventListener('pointerup', dragEndHandler)
+      window.addEventListener('pointercancel', dragEndHandler)
     }
   }
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnReorder.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnReorder.ts
@@ -48,7 +48,6 @@ export function useColumnReorder(
 
   /**
    * Handle pointer move for column drag.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
    */
   const handleDrag = (e: PointerEvent) => {
     if (!isDragging.value || !dragStart.value) return
@@ -89,7 +88,6 @@ export function useColumnReorder(
 
   /**
    * Start column drag operation.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
    */
   const startDrag = (x: number) => {
     if (isLocked.value || !isViewOperationsAllowed.value) return

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnResize.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnResize.ts
@@ -62,10 +62,6 @@ export function useColumnResize(
     return null
   })
 
-  /**
-   * Handle pointer move for column resize.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const handlePointerMove = (e: PointerEvent) => {
     try {
       const rect = canvasRef.value?.getBoundingClientRect()
@@ -98,10 +94,6 @@ export function useColumnResize(
     window.removeEventListener('pointercancel', handlePointerUp)
   }
 
-  /**
-   * Handle pointer down to start column resize.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const handlePointerDown = (e: PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect || isLocked.value || !isViewOperationsAllowed.value) return

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnResize.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useColumnResize.ts
@@ -62,7 +62,11 @@ export function useColumnResize(
     return null
   })
 
-  const handleMouseMove = (e: MouseEvent) => {
+  /**
+   * Handle pointer move for column resize.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const handlePointerMove = (e: PointerEvent) => {
     try {
       const rect = canvasRef.value?.getBoundingClientRect()
       if (!rect) return
@@ -79,7 +83,7 @@ export function useColumnResize(
         onResize?.(activeColumn.value.id, newWidth)
       }
     } catch (error) {
-      console.error('Error in handleMouseMove:', error)
+      console.error('Error in handlePointerMove:', error)
       cleanupResize()
     }
   }
@@ -89,11 +93,16 @@ export function useColumnResize(
     activeColumn.value = null
     mousePosition.value = null
 
-    window.removeEventListener('mousemove', handleMouseMove)
-    window.removeEventListener('mouseup', handleMouseUp)
+    window.removeEventListener('pointermove', handlePointerMove)
+    window.removeEventListener('pointerup', handlePointerUp)
+    window.removeEventListener('pointercancel', handlePointerUp)
   }
 
-  const handleMouseDown = (e: MouseEvent) => {
+  /**
+   * Handle pointer down to start column resize.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const handlePointerDown = (e: PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect || isLocked.value || !isViewOperationsAllowed.value) return
 
@@ -115,11 +124,12 @@ export function useColumnResize(
       startX: mousePosition.value?.x || 0,
     }
 
-    window.addEventListener('mousemove', handleMouseMove)
-    window.addEventListener('mouseup', handleMouseUp)
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerUp)
   }
 
-  function handleMouseUp() {
+  function handlePointerUp() {
     const shouldTriggerResize = isResizing.value && activeColumn.value && mousePosition.value
 
     if (shouldTriggerResize && activeColumn.value && mousePosition.value) {
@@ -138,8 +148,8 @@ export function useColumnResize(
     isResizing,
     activeColumn,
     resizeableColumn,
-    handleMouseMove,
-    handleMouseDown,
+    handlePointerMove,
+    handlePointerDown,
     RESIZE_HANDLE_WIDTH,
     cleanupResize,
   }

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useFillHandler.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useFillHandler.ts
@@ -105,7 +105,7 @@ export function useFillHandler({
     return dx * dx + dy * dy <= radius * radius
   }
 
-  const handleFillStart = (e: MouseEvent) => {
+  const handleFillStart = (e: MouseEvent | PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect) return
     isFillEnded.value = false
@@ -137,7 +137,7 @@ export function useFillHandler({
     triggerReRender()
   }
 
-  const handleFillMove = (e: MouseEvent) => {
+  const handleFillMove = (e: MouseEvent | PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect) return
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useMouseSelection.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useMouseSelection.ts
@@ -68,7 +68,11 @@ export function useMouseSelection({
     return { row, col: -1, path: path ?? [] }
   }
 
-  const handleMouseDown = (e: MouseEvent) => {
+  /**
+   * Handle pointer down event for cell selection.
+   * Works with mouse, touch, and pen input via Pointer Events API.
+   */
+  const handleMouseDown = (e: MouseEvent | PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect || e.button !== 0) return
 
@@ -92,7 +96,10 @@ export function useMouseSelection({
     }
   }
 
-  const handleMouseMove = (e: MouseEvent) => {
+  /**
+   * Handle pointer move event for selection tracking.
+   */
+  const handleMouseMove = (e: MouseEvent | PointerEvent) => {
     if (!isSelecting.value) return
 
     const rect = canvasRef.value?.getBoundingClientRect()
@@ -124,6 +131,10 @@ export function useMouseSelection({
       triggerReRender()
     }
   }
+
+  /**
+   * Handle pointer up event to finalize selection.
+   */
   const handleMouseUp = () => {
     isSelecting.value = false
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useMouseSelection.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useMouseSelection.ts
@@ -68,10 +68,6 @@ export function useMouseSelection({
     return { row, col: -1, path: path ?? [] }
   }
 
-  /**
-   * Handle pointer down event for cell selection.
-   * Works with mouse, touch, and pen input via Pointer Events API.
-   */
   const handleMouseDown = (e: MouseEvent | PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect || e.button !== 0) return
@@ -96,9 +92,6 @@ export function useMouseSelection({
     }
   }
 
-  /**
-   * Handle pointer move event for selection tracking.
-   */
   const handleMouseMove = (e: MouseEvent | PointerEvent) => {
     if (!isSelecting.value) return
 
@@ -132,9 +125,6 @@ export function useMouseSelection({
     }
   }
 
-  /**
-   * Handle pointer up event to finalize selection.
-   */
   const handleMouseUp = () => {
     isSelecting.value = false
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useRowReOrder.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useRowReOrder.ts
@@ -55,7 +55,11 @@ export function useRowReorder({
     }
   }
 
-  const handleDragStart = (e: MouseEvent) => {
+  /**
+   * Start row drag operation.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const handleDragStart = (e: PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect) return
 
@@ -82,11 +86,12 @@ export function useRowReorder({
     currentDragY.value = e.clientY
     draggedRowGroupPath.value = element.groupPath
 
-    window.addEventListener('mousemove', handleDrag)
-    window.addEventListener('mouseup', handleDragEnd)
+    window.addEventListener('pointermove', handleDrag)
+    window.addEventListener('pointerup', handleDragEnd)
+    window.addEventListener('pointercancel', handleDragEnd)
   }
 
-  function handleDrag(e: MouseEvent) {
+  function handleDrag(e: PointerEvent) {
     currentDragY.value = e.clientY
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect) return
@@ -106,14 +111,15 @@ export function useRowReorder({
     triggerRefreshCanvas()
 
     const edgeThreshold = 100
-    const mouseY = e.clientY - rect.top
+    const pointerY = e.clientY - rect.top
 
-    if (mouseY < edgeThreshold) {
+    if (pointerY < edgeThreshold) {
       scrollToCell(Math.max(0, targetRowIndex.value - 2), 0)
-    } else if (mouseY > rect.height - edgeThreshold) {
+    } else if (pointerY > rect.height - edgeThreshold) {
       scrollToCell(Math.min(totalRows.value - 1, targetRowIndex.value + 2), 0)
     }
   }
+
   async function handleDragEnd() {
     if (draggedRowIndex.value !== null && draggedRowIndex.value + 1 !== targetRowIndex.value) {
       const { totalRows } = getDataCache(draggedRowGroupPath.value)
@@ -133,8 +139,9 @@ export function useRowReorder({
     draggedRowIndex.value = null
     targetRowIndex.value = null
     draggedRowGroupPath.value = null
-    window.removeEventListener('mousemove', handleDrag)
-    window.removeEventListener('mouseup', handleDragEnd)
+    window.removeEventListener('pointermove', handleDrag)
+    window.removeEventListener('pointerup', handleDragEnd)
+    window.removeEventListener('pointercancel', handleDragEnd)
     triggerRefreshCanvas()
   }
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useRowReOrder.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useRowReOrder.ts
@@ -55,10 +55,6 @@ export function useRowReorder({
     }
   }
 
-  /**
-   * Start row drag operation.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const handleDragStart = (e: PointerEvent) => {
     const rect = canvasRef.value?.getBoundingClientRect()
     if (!rect) return

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -878,10 +878,6 @@ function extractHoverMetaColRegions(row: Row, group?: CanvasGroup) {
   return { isAtMaxSelection, isCheckboxDisabled, regions, currentX }
 }
 
-/**
- * Handle row meta column clicks (checkbox, reorder, expand/comment).
- * Accepts both MouseEvent and PointerEvent for touch support.
- */
 const handleRowMetaClick = ({
   e,
   row,

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -878,6 +878,10 @@ function extractHoverMetaColRegions(row: Row, group?: CanvasGroup) {
   return { isAtMaxSelection, isCheckboxDisabled, regions, currentX }
 }
 
+/**
+ * Handle row meta column clicks (checkbox, reorder, expand/comment).
+ * Accepts both MouseEvent and PointerEvent for touch support.
+ */
 const handleRowMetaClick = ({
   e,
   row,
@@ -885,7 +889,7 @@ const handleRowMetaClick = ({
   onlyDrag,
   group,
 }: {
-  e: MouseEvent
+  e: MouseEvent | PointerEvent
   row: Row
   x: number
   onlyDrag?: boolean
@@ -931,8 +935,10 @@ const handleRowMetaClick = ({
       break
 
     case 'reorder':
-      if (e.detail === 1 && isRowReOrderEnabled.value) {
-        onMouseDownRowReorderStart(e)
+      // For touch events, e.detail may not be set correctly, so check if it's 1 or undefined/0
+      // Touch events synthesized as clicks may have detail=0 or detail=1
+      if ((e.detail === 1 || e.detail === 0 || !('detail' in e)) && isRowReOrderEnabled.value) {
+        onMouseDownRowReorderStart(e as PointerEvent)
       }
       break
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -1000,6 +1000,8 @@ let lastTapPosition = { x: 0, y: 0 }
 const DOUBLE_TAP_DELAY = 300
 const DOUBLE_TAP_THRESHOLD = 10
 
+const iosFocusProxyRef = ref<HTMLInputElement>()
+
 async function handlePointerDown(e: PointerEvent) {
   const _elementMap = new CanvasElement(elementMap.elements)
   pointerUpListener = (ev) => handlePointerUp(ev, _elementMap)
@@ -1263,11 +1265,15 @@ async function handlePointerUp(e: PointerEvent, _elementMap: CanvasElement) {
       if (timeSinceLastTap < DOUBLE_TAP_DELAY && distance < DOUBLE_TAP_THRESHOLD) {
         // Double-tap detected - make cell editable
         if (y > headerRowHeight.value && y < height.value - 36 && x > rowMetaColumnWidth.value) {
-          const element = _elementMap.findElementAt(x, y, [ElementTypes.ROW])
+          const element =
+            _elementMap.findElementAt(x, y, [ElementTypes.ROW]) || elementMap.findElementAt(x, y, [ElementTypes.ROW])
           const row = element?.row
           if (row) {
             const clickedColumn = findColumnAtPosition(x)
             if (clickedColumn && !clickedColumn.virtual) {
+              if (iosFocusProxyRef.value) {
+                iosFocusProxyRef.value.focus()
+              }
               makeCellEditable(row, clickedColumn)
               await nextTick()
               const inputEl = document.querySelector('.nc-cell-field input, .nc-cell-field textarea') as HTMLInputElement
@@ -1280,6 +1286,8 @@ async function handlePointerUp(e: PointerEvent, _elementMap: CanvasElement) {
         }
         lastTapTime = 0
         lastTapPosition = { x: 0, y: 0 }
+
+        if (editEnabled.value) return
       } else {
         lastTapTime = now
         lastTapPosition = { x, y }
@@ -2317,7 +2325,7 @@ function addEmptyColumn(columnOrderData: Pick<ColumnReqType, 'column_order'> | n
   }
 }
 
-function handleEditColumn(_e: MouseEvent, isDescription = false, column: ColumnType, clickedXOffset?: number) {
+function handleEditColumn(_e: MouseEvent | PointerEvent, isDescription = false, column: ColumnType, clickedXOffset?: number) {
   if (
     isUIAllowed('fieldEdit') &&
     !isMobileMode.value &&
@@ -2637,7 +2645,7 @@ const toggleGroupExpandAll = (path: number[], isExpand?: boolean) => {
 
 onClickOutside(
   wrapperRef,
-  (e: MouseEvent) => {
+  (e: MouseEvent | PointerEvent) => {
     const element = e.target as HTMLElement
     if (
       isDrawerOrModalExist() ||
@@ -2880,6 +2888,12 @@ watch(
             <Tooltip v-if="tooltipStore.tooltipText" ref="tooltipRef" :tooltip-style="floatingStyles" />
           </Transition>
         </Teleport>
+        <input
+          ref="iosFocusProxyRef"
+          aria-hidden="true"
+          tabindex="-1"
+          style="position: fixed; left: -9999px; top: -9999px; width: 1px; height: 1px"
+        />
         <NcDropdown
           v-model:visible="isContextMenuOpen"
           :trigger="['contextmenu']"

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -2891,9 +2891,7 @@ watch(
             oncontextmenu="return false"
             @pointerdown="handlePointerDown"
             @pointermove="handlePointerMove"
-            @pointerup="handlePointerUp"
             @pointerleave="handlePointerLeave"
-            @pointercancel="handlePointerUp"
           >
           </canvas>
           <template #overlay>

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -992,11 +992,17 @@ let prevMenuState: {
   columnOrder?: unknown
 } = {}
 
-let mouseUpListener = null
-async function handleMouseDown(e: MouseEvent) {
+let pointerUpListener: ((e: PointerEvent) => void) | null = null
+let lastTapTime = 0
+let lastTapPosition = { x: 0, y: 0 }
+const DOUBLE_TAP_DELAY = 300
+const DOUBLE_TAP_THRESHOLD = 10
+
+async function handlePointerDown(e: PointerEvent) {
   const _elementMap = new CanvasElement(elementMap.elements)
-  mouseUpListener = (e) => handleMouseUp(e, _elementMap)
-  document.addEventListener('mouseup', mouseUpListener)
+  pointerUpListener = (ev) => handlePointerUp(ev, _elementMap)
+  document.addEventListener('pointerup', pointerUpListener)
+  document.addEventListener('pointercancel', pointerUpListener)
 
   // keep it for later use inside mouseup event for showing/hiding dropdown based on the previous state
   prevMenuState = {
@@ -1230,15 +1236,53 @@ function clearColAutoScrollTimer() {
   }
 }
 
-async function handleMouseUp(e: MouseEvent, _elementMap: CanvasElement) {
+async function handlePointerUp(e: PointerEvent, _elementMap: CanvasElement) {
   e.preventDefault()
 
   clearColAutoScrollTimer()
 
-  if (mouseUpListener) {
-    document.removeEventListener('mouseup', mouseUpListener)
-    mouseUpListener = null
+  if (pointerUpListener) {
+    document.removeEventListener('pointerup', pointerUpListener)
+    document.removeEventListener('pointercancel', pointerUpListener)
+    pointerUpListener = null
     selectedRowInfo = { index: null, path: [], isSelectionStarted: false }
+  }
+
+  // Handle double-tap for touch devices to enable cell editing
+  if (e.pointerType === 'touch') {
+    const rect = canvasRef.value?.getBoundingClientRect()
+    if (rect) {
+      const x = e.clientX - rect.left
+      const y = e.clientY - rect.top
+      const now = Date.now()
+      const timeSinceLastTap = now - lastTapTime
+      const distance = Math.sqrt((x - lastTapPosition.x) ** 2 + (y - lastTapPosition.y) ** 2)
+
+      if (timeSinceLastTap < DOUBLE_TAP_DELAY && distance < DOUBLE_TAP_THRESHOLD) {
+        // Double-tap detected - make cell editable
+        if (y > headerRowHeight.value && y < height.value - 36 && x > rowMetaColumnWidth.value) {
+          const element = _elementMap.findElementAt(x, y, [ElementTypes.ROW])
+          const row = element?.row
+          if (row) {
+            const clickedColumn = findColumnAtPosition(x)
+            if (clickedColumn && !clickedColumn.virtual) {
+              makeCellEditable(row, clickedColumn)
+              await nextTick()
+              const inputEl = document.querySelector('.nc-cell-field input, .nc-cell-field textarea') as HTMLInputElement
+              if (inputEl) {
+                inputEl.focus()
+                inputEl.click()
+              }
+            }
+          }
+        }
+        lastTapTime = 0
+        lastTapPosition = { x: 0, y: 0 }
+      } else {
+        lastTapTime = now
+        lastTapPosition = { x, y }
+      }
+    }
   }
 
   await onMouseUpFillHandlerEnd()
@@ -1843,7 +1887,7 @@ const getHeaderTooltipRegions = (
   return regions
 }
 
-const handleMouseMove = (e: MouseEvent) => {
+const handlePointerMove = (e: PointerEvent) => {
   clearColAutoScrollTimer()
 
   const rect = canvasRef.value?.getBoundingClientRect()
@@ -2114,11 +2158,11 @@ const handleMouseMove = (e: MouseEvent) => {
   }
 }
 
-const handleMouseLeave = () => {
+const handlePointerLeave = () => {
   setCursor('auto')
   hideTooltip()
 
-  // Reset hover row on mouse leave from canvas
+  // Reset hover row on pointer leave from canvas
   hoverRow.value = {
     path: [],
     rowIndex: -2,
@@ -2841,13 +2885,15 @@ watch(
         >
           <canvas
             ref="canvasRef"
-            class="sticky top-0 left-0"
+            class="sticky top-0 left-0 touch-none"
             :height="`${height}px`"
             :width="`${width}px`"
             oncontextmenu="return false"
-            @mousedown="handleMouseDown"
-            @mousemove="handleMouseMove"
-            @mouseleave="handleMouseLeave"
+            @pointerdown="handlePointerDown"
+            @pointermove="handlePointerMove"
+            @pointerup="handlePointerUp"
+            @pointerleave="handlePointerLeave"
+            @pointercancel="handlePointerUp"
           >
           </canvas>
           <template #overlay>

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -286,7 +286,7 @@ const {
   canvasRef,
   triggerRefreshCanvas,
   resizeableColumn,
-  resizeMouseMove,
+  resizePointerMove,
   isDragging,
   startDrag,
   startResize,
@@ -2034,7 +2034,7 @@ const handlePointerMove = (e: PointerEvent) => {
   } else {
     const y = e.clientY - rect.top
     if (y <= headerRowHeight.value && resizeableColumn.value) {
-      resizeMouseMove(e)
+      resizePointerMove(e)
     } else if (mousePosition.y > height.value - 36) {
       if (!isViewOperationsAllowed.value) return
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
@@ -149,7 +149,11 @@ export const MouseClickType = {
   RIGHT_CLICK: 'right',
 } as const
 
-export function getMouseClickType(e: MouseEvent) {
+/**
+ * Determines the click type from a pointer/mouse event.
+ * Works with both MouseEvent and PointerEvent (PointerEvent extends MouseEvent).
+ */
+export function getMouseClickType(e: MouseEvent | PointerEvent) {
   if (e.button === 2) return MouseClickType.RIGHT_CLICK
 
   if (e.ctrlKey && e.button === 0 && e.detail === 1) {

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
@@ -149,11 +149,6 @@ export const MouseClickType = {
   RIGHT_CLICK: 'right',
 } as const
 
-/**
- * Determines the click type from a pointer/mouse event.
- * Works with both MouseEvent and PointerEvent (PointerEvent extends MouseEvent).
- * For touch events, detail may be 0 or undefined, so we treat those as single clicks.
- */
 export function getMouseClickType(e: MouseEvent | PointerEvent) {
   if (e.button === 2) return MouseClickType.RIGHT_CLICK
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
@@ -152,15 +152,23 @@ export const MouseClickType = {
 /**
  * Determines the click type from a pointer/mouse event.
  * Works with both MouseEvent and PointerEvent (PointerEvent extends MouseEvent).
+ * For touch events, detail may be 0 or undefined, so we treat those as single clicks.
  */
 export function getMouseClickType(e: MouseEvent | PointerEvent) {
   if (e.button === 2) return MouseClickType.RIGHT_CLICK
 
-  if (e.ctrlKey && e.button === 0 && e.detail === 1) {
+  // For touch events (pointerType === 'touch'), detail might be 0 or undefined
+  const isTouch = 'pointerType' in e && e.pointerType === 'touch'
+
+  if (e.ctrlKey && e.button === 0 && (e.detail === 1 || (isTouch && e.detail === 0))) {
     return MouseClickType.RIGHT_CLICK
   }
 
   if (e.button === 0) {
+    // For touch events, treat detail=0 as single click since touch doesn't have native double-tap detection
+    if (isTouch && (e.detail === 0 || e.detail === undefined)) {
+      return MouseClickType.SINGLE_CLICK
+    }
     return e.detail === 1 ? MouseClickType.SINGLE_CLICK : MouseClickType.DOUBLE_CLICK
   }
 

--- a/packages/nc-gui/components/smartsheet/grid/useRowDragging.ts
+++ b/packages/nc-gui/components/smartsheet/grid/useRowDragging.ts
@@ -18,7 +18,7 @@ export const useRowDragging = ({
     isFailed?: boolean,
     path?: Array<number>,
   ) => Promise<void>
-  onDragStart?: (row: Row, e: MouseEvent) => void
+  onDragStart?: (row: Row, e: MouseEvent | PointerEvent) => void
   rowHeight: ComputedRef<number>
   rowSlice: { start: number; end: number }
   totalRows: Ref<number>
@@ -32,7 +32,7 @@ export const useRowDragging = ({
   const mouseStart = ref(0)
   const draggingTop = ref(0)
   const targetTop = ref(32)
-  const lastMoveEvent = ref<null | MouseEvent>(null)
+  const lastMoveEvent = ref<null | MouseEvent | PointerEvent>(null)
   const autoScrolling = ref(false)
   const animationFrameId = ref<number | null>(null)
 
@@ -72,7 +72,11 @@ export const useRowDragging = ({
     }
   }
 
-  const moveHandler = (event: MouseEvent | null, startAutoScroll = false) => {
+  /**
+   * Handle pointer/mouse move for row dragging.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const moveHandler = (event: MouseEvent | PointerEvent | null, startAutoScroll = false) => {
     try {
       if (event !== null) {
         event.preventDefault()
@@ -163,7 +167,11 @@ export const useRowDragging = ({
     }
   }
 
-  const mouseUp = async (event: MouseEvent) => {
+  /**
+   * Handle pointer/mouse up to end row dragging.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const pointerUp = async (event: MouseEvent | PointerEvent) => {
     try {
       event.preventDefault()
       cancel()
@@ -195,8 +203,9 @@ export const useRowDragging = ({
         animationFrameId.value = null
       }
 
-      window.removeEventListener('mousemove', moveHandler)
-      window.removeEventListener('mouseup', mouseUp)
+      window.removeEventListener('pointermove', moveHandler)
+      window.removeEventListener('pointerup', pointerUp)
+      window.removeEventListener('pointercancel', pointerUp)
     } catch (error) {
       console.error('Error in cancel:', error)
     }
@@ -206,7 +215,11 @@ export const useRowDragging = ({
     return rowIndex * rowHeight.value
   }
 
-  const startDragging = (_row: Row, event: MouseEvent) => {
+  /**
+   * Start row drag operation.
+   * Uses Pointer Events API for unified mouse/touch/pen handling.
+   */
+  const startDragging = (_row: Row, event: MouseEvent | PointerEvent) => {
     try {
       const originalElement = (event.target as HTMLElement).closest(`[data-testid="grid-row-${_row.rowMeta.rowIndex}"]`)
       if (!originalElement) return
@@ -226,8 +239,9 @@ export const useRowDragging = ({
 
       moveHandler(event)
 
-      window.addEventListener('mousemove', moveHandler)
-      window.addEventListener('mouseup', mouseUp)
+      window.addEventListener('pointermove', moveHandler)
+      window.addEventListener('pointerup', pointerUp)
+      window.addEventListener('pointercancel', pointerUp)
     } catch (error) {
       console.error('Error in startDragging:', error)
       cancel()

--- a/packages/nc-gui/components/smartsheet/grid/useRowDragging.ts
+++ b/packages/nc-gui/components/smartsheet/grid/useRowDragging.ts
@@ -72,10 +72,6 @@ export const useRowDragging = ({
     }
   }
 
-  /**
-   * Handle pointer/mouse move for row dragging.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const moveHandler = (event: MouseEvent | PointerEvent | null, startAutoScroll = false) => {
     try {
       if (event !== null) {
@@ -167,10 +163,6 @@ export const useRowDragging = ({
     }
   }
 
-  /**
-   * Handle pointer/mouse up to end row dragging.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const pointerUp = async (event: MouseEvent | PointerEvent) => {
     try {
       event.preventDefault()
@@ -215,10 +207,6 @@ export const useRowDragging = ({
     return rowIndex * rowHeight.value
   }
 
-  /**
-   * Start row drag operation.
-   * Uses Pointer Events API for unified mouse/touch/pen handling.
-   */
   const startDragging = (_row: Row, event: MouseEvent | PointerEvent) => {
     try {
       const originalElement = (event.target as HTMLElement).closest(`[data-testid="grid-row-${_row.rowMeta.rowIndex}"]`)

--- a/packages/nc-gui/components/smartsheet/toolbar/Filter/InputLite.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/Filter/InputLite.vue
@@ -214,7 +214,7 @@ const isSingleOrMultiSelect = computed(() => {
     v-else
     class="bg-nc-bg-default border-1 flex flex-grow min-h-4 h-full px-1 items-center nc-filter-input-wrapper !rounded-lg"
     :class="{ 'px-2': hasExtraPadding, 'border-nc-border-brand': isInputBoxOnFocus, '!max-w-100': isSingleOrMultiSelect }"
-    @mouseup.stop
+    @pointerup.stop
   >
     <component
       :is="filterUIType ? componentMap[filterUIType] : Text"

--- a/packages/nc-gui/components/smartsheet/toolbar/FilterInput.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/FilterInput.vue
@@ -214,7 +214,7 @@ const isSingleOrMultiSelect = computed(() => {
     v-else
     class="bg-nc-bg-default border-1 flex flex-grow min-w-0 min-h-4 h-full px-1 items-center nc-filter-input-wrapper !rounded-lg"
     :class="{ 'px-2': hasExtraPadding, 'border-nc-border-brand': isInputBoxOnFocus, '!max-w-100': isSingleOrMultiSelect }"
-    @mouseup.stop
+    @pointerup.stop
   >
     <component
       :is="filterType ? componentMap[filterType] : Text"

--- a/packages/nc-gui/components/virtual-cell/Formula.vue
+++ b/packages/nc-gui/components/virtual-cell/Formula.vue
@@ -36,7 +36,7 @@ const isStringDataType = computed(() => {
   )
 })
 
-const openLongText = (event: MouseEvent) => {
+const openLongText = (event: MouseEvent | PointerEvent) => {
   if (!isStringDataType.value) return
 
   const target = event.target as HTMLElement

--- a/packages/nc-gui/components/virtual-cell/Lookup.vue
+++ b/packages/nc-gui/components/virtual-cell/Lookup.vue
@@ -301,7 +301,7 @@ const cellHeight = computed(() =>
     : `2.85rem`,
 )
 
-const handleCloseDropdown = (e: MouseEvent) => {
+const handleCloseDropdown = (e: MouseEvent | PointerEvent) => {
   if (e.target && e.target.closest('.nc-attachment-item')) {
     e.stopPropagation()
     dropdownVisible.value = false

--- a/packages/nc-gui/components/workspace/project/AiCreateProject.vue
+++ b/packages/nc-gui/components/workspace/project/AiCreateProject.vue
@@ -394,8 +394,8 @@ onMounted(() => {
                   'nc-disabled': !aiIntegrationAvailable || (aiLoading && callFunction === 'onPredictSchema'),
                 }"
                 :disabled="!aiIntegrationAvailable || (aiLoading && callFunction === 'onPredictSchema')"
-                @mouseover="handleMouseOverTag(prompt.description)"
-                @mouseleave="handleMouseLeaveTag"
+                @pointerover="handleMouseOverTag(prompt.description)"
+                @pointerleave="handleMouseLeaveTag"
                 @click="handleUpdatePrompt(prompt.description)"
               >
                 <div class="flex flex-row items-center gap-1 py-1 text-sm">

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -309,10 +309,6 @@ export function useMultiSelect(
     return map
   })
 
-  /**
-   * Handle pointer/mouse move over cells for selection.
-   * Accepts both MouseEvent and PointerEvent for compatibility.
-   */
   function handleMouseOver(event: MouseEvent | PointerEvent, row: number, col: number) {
     if (isFillMode.value) {
       const rw = isArrayStructure ? (unref(data) as Row[])[row] : (unref(data) as Map<number, Row>).get(row)
@@ -348,10 +344,6 @@ export function useMultiSelect(
     event.preventDefault()
   }
 
-  /**
-   * Handle pointer/mouse down for starting cell selection.
-   * Accepts both MouseEvent and PointerEvent for compatibility.
-   */
   function handleMouseDown(event: MouseEvent | PointerEvent, row: number, col: number) {
     // if there was a right click on selected range, don't restart the selection
     if (
@@ -390,10 +382,6 @@ export function useMultiSelect(
     }
   }
 
-  /**
-   * Handle cell click for activating a cell.
-   * Accepts both MouseEvent and PointerEvent for compatibility.
-   */
   const handleCellClick = (event: MouseEvent | PointerEvent, row: number, col: number) => {
     // if shift key is pressed, don't change the active cell (unless there is no active cell)
     if (!event.shiftKey || activeCell.col === null || activeCell.row === null) {
@@ -520,10 +508,6 @@ export function useMultiSelect(
     )
   }
 
-  /**
-   * Handle pointer/mouse up for ending selection.
-   * Accepts both MouseEvent and PointerEvent for compatibility.
-   */
   const handleMouseUp = (_event: MouseEvent | PointerEvent) => {
     if (isFillMode.value) {
       try {
@@ -1888,10 +1872,6 @@ export function useMultiSelect(
     }
   }
 
-  /**
-   * Handle fill handle pointer/mouse down for starting fill mode.
-   * Accepts both MouseEvent and PointerEvent for compatibility.
-   */
   function fillHandleMouseDown(event: MouseEvent | PointerEvent) {
     if (event?.button !== MAIN_MOUSE_PRESSED) {
       return
@@ -1944,11 +1924,9 @@ export function useMultiSelect(
   }
 
   useEventListener(document, 'keydown', handleKeyDown)
-  // Use pointerup for unified mouse/touch support
   useEventListener(document, 'pointerup', handleMouseUp)
   useEventListener(document, 'paste', handlePaste)
 
-  // Use pointerdown for unified mouse/touch support on fill handle
   useEventListener(fillHandle, 'pointerdown', fillHandleMouseDown)
 
   return {

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -309,7 +309,11 @@ export function useMultiSelect(
     return map
   })
 
-  function handleMouseOver(event: MouseEvent, row: number, col: number) {
+  /**
+   * Handle pointer/mouse move over cells for selection.
+   * Accepts both MouseEvent and PointerEvent for compatibility.
+   */
+  function handleMouseOver(event: MouseEvent | PointerEvent, row: number, col: number) {
     if (isFillMode.value) {
       const rw = isArrayStructure ? (unref(data) as Row[])[row] : (unref(data) as Map<number, Row>).get(row)
 
@@ -344,7 +348,11 @@ export function useMultiSelect(
     event.preventDefault()
   }
 
-  function handleMouseDown(event: MouseEvent, row: number, col: number) {
+  /**
+   * Handle pointer/mouse down for starting cell selection.
+   * Accepts both MouseEvent and PointerEvent for compatibility.
+   */
+  function handleMouseDown(event: MouseEvent | PointerEvent, row: number, col: number) {
     // if there was a right click on selected range, don't restart the selection
     if (
       (event?.button !== MAIN_MOUSE_PRESSED || (event?.button === MAIN_MOUSE_PRESSED && event.ctrlKey)) &&
@@ -382,7 +390,11 @@ export function useMultiSelect(
     }
   }
 
-  const handleCellClick = (event: MouseEvent, row: number, col: number) => {
+  /**
+   * Handle cell click for activating a cell.
+   * Accepts both MouseEvent and PointerEvent for compatibility.
+   */
+  const handleCellClick = (event: MouseEvent | PointerEvent, row: number, col: number) => {
     // if shift key is pressed, don't change the active cell (unless there is no active cell)
     if (!event.shiftKey || activeCell.col === null || activeCell.row === null) {
       makeActive(row, col)
@@ -508,7 +520,11 @@ export function useMultiSelect(
     )
   }
 
-  const handleMouseUp = (_event: MouseEvent) => {
+  /**
+   * Handle pointer/mouse up for ending selection.
+   * Accepts both MouseEvent and PointerEvent for compatibility.
+   */
+  const handleMouseUp = (_event: MouseEvent | PointerEvent) => {
     if (isFillMode.value) {
       try {
         const localAiMode = Boolean(aiMode.value)
@@ -1872,7 +1888,11 @@ export function useMultiSelect(
     }
   }
 
-  function fillHandleMouseDown(event: MouseEvent) {
+  /**
+   * Handle fill handle pointer/mouse down for starting fill mode.
+   * Accepts both MouseEvent and PointerEvent for compatibility.
+   */
+  function fillHandleMouseDown(event: MouseEvent | PointerEvent) {
     if (event?.button !== MAIN_MOUSE_PRESSED) {
       return
     }
@@ -1924,10 +1944,12 @@ export function useMultiSelect(
   }
 
   useEventListener(document, 'keydown', handleKeyDown)
-  useEventListener(document, 'mouseup', handleMouseUp)
+  // Use pointerup for unified mouse/touch support
+  useEventListener(document, 'pointerup', handleMouseUp)
   useEventListener(document, 'paste', handlePaste)
 
-  useEventListener(fillHandle, 'mousedown', fillHandleMouseDown)
+  // Use pointerdown for unified mouse/touch support on fill handle
+  useEventListener(fillHandle, 'pointerdown', fillHandleMouseDown)
 
   return {
     isCellActive,

--- a/packages/nc-gui/helpers/tiptap-markdown/extensions/nodes/mention/expression/WorkflowVariablePicker.vue
+++ b/packages/nc-gui/helpers/tiptap-markdown/extensions/nodes/mention/expression/WorkflowVariablePicker.vue
@@ -296,7 +296,7 @@ defineExpose({
   <div
     class="nc-workflow-variable-picker flex bg-nc-bg-default border-1 border-nc-border-gray-medium rounded-lg shadow-lg overflow-hidden"
     style="width: 560px; max-height: 400px"
-    @mousedown.stop
+    @pointerdown.stop
   >
     <div class="nc-variable-picker-nodes w-[220px] border-r border-nc-border-gray-medium flex flex-col">
       <div class="px-3 py-2 text-sm font-semibold text-nc-content-gray-emphasis border-b border-nc-border-gray-light">

--- a/packages/nc-gui/helpers/tiptap-markdown/extensions/nodes/mention/field/FieldMentionList.vue
+++ b/packages/nc-gui/helpers/tiptap-markdown/extensions/nodes/mention/field/FieldMentionList.vue
@@ -103,7 +103,7 @@ export default {
 <template>
   <div
     class="w-64 bg-nc-bg-default scroll-smooth nc-mention-list nc-scrollbar-thin border-1 border-nc-border-gray-medium rounded-lg max-h-64 !py-2 px-2 shadow-lg"
-    @mousedown.stop
+    @pointerdown.stop
   >
     <template v-if="items.length">
       <div

--- a/packages/nc-gui/helpers/tiptap/functionality/markdown/md-link-rule-setup.ts
+++ b/packages/nc-gui/helpers/tiptap/functionality/markdown/md-link-rule-setup.ts
@@ -35,9 +35,9 @@ function mdLinkRuleSetupExt(md: MarkdownIt, { openLinkOnClick = false }: { openL
       if (relIndex < 0) {
         tokens[idx]!.attrPush(['rel', 'noopener noreferrer nofollow'])
       }
-      const onClickIndex = tokens[idx]!.attrIndex('onmousedown')
+      const onClickIndex = tokens[idx]!.attrIndex('onpointerdown')
       if (onClickIndex < 0) {
-        tokens[idx]!.attrPush(['onmousedown', '(function(event) { event.preventDefault();})(event)'])
+        tokens[idx]!.attrPush(['onpointerdown', '(function(event) { event.preventDefault();})(event)'])
       }
 
       const clickIndex = tokens[idx]!.attrIndex('onclick')

--- a/packages/nc-gui/plugins/resizeDirective.ts
+++ b/packages/nc-gui/plugins/resizeDirective.ts
@@ -1,3 +1,6 @@
+/**
+ * Vertical resize directive using Pointer Events API for touch/mouse/pen support.
+ */
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.directive('xc-ver-resize', {
     created: (el: Element) => {
@@ -10,10 +13,11 @@ export default defineNuxtPlugin((nuxtApp) => {
       resizer.style.top = '0'
       resizer.style.right = '-1px'
       resizer.style.zIndex = '999'
+      resizer.style.touchAction = 'none' // Prevent browser touch handling
 
       // add resizer to element
       el.appendChild(resizer)
-      resizer.addEventListener('mousedown', initDrag, false)
+      resizer.addEventListener('pointerdown', initDrag, false)
 
       const instance = getCurrentInstance()
 
@@ -27,8 +31,8 @@ export default defineNuxtPlugin((nuxtApp) => {
       let startX: number
       let startWidth: number
 
-      // bind event handlers
-      function initDrag(e: MouseEvent) {
+      // bind event handlers - uses Pointer Events for unified input handling
+      function initDrag(e: PointerEvent) {
         if (el.classList.contains('no-resize')) {
           return
         }
@@ -36,8 +40,9 @@ export default defineNuxtPlugin((nuxtApp) => {
         document.body.style.cursor = 'col-resize'
         startX = e.clientX
         startWidth = parseInt(document.defaultView?.getComputedStyle(el)?.width || '0', 10)
-        document.documentElement.addEventListener('mousemove', doDrag, false)
-        document.documentElement.addEventListener('mouseup', stopDrag, false)
+        document.documentElement.addEventListener('pointermove', doDrag, false)
+        document.documentElement.addEventListener('pointerup', stopDrag, false)
+        document.documentElement.addEventListener('pointercancel', stopDrag, false)
         emit('xcstartresizing', startWidth)
       }
 
@@ -46,7 +51,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       let width: number | string
 
       // emit event on dragging
-      function doDrag(e: MouseEvent) {
+      function doDrag(e: PointerEvent) {
         width = `${startWidth + e.clientX - startX}px`
         emit('xcresizing', width)
       }
@@ -55,8 +60,9 @@ export default defineNuxtPlugin((nuxtApp) => {
       function stopDrag() {
         resizer.classList.remove('primary')
         document.body.style.cursor = ''
-        document.documentElement.removeEventListener('mousemove', doDrag, false)
-        document.documentElement.removeEventListener('mouseup', stopDrag, false)
+        document.documentElement.removeEventListener('pointermove', doDrag, false)
+        document.documentElement.removeEventListener('pointerup', stopDrag, false)
+        document.documentElement.removeEventListener('pointercancel', stopDrag, false)
         emit('xcresize', width)
         emit('xcresized')
       }
@@ -65,7 +71,7 @@ export default defineNuxtPlugin((nuxtApp) => {
       const resizer = el.querySelector('.resizer')
 
       if (resizer) {
-        resizer.removeEventListener('mousedown', (el as any).initDrag, false)
+        resizer.removeEventListener('pointerdown', (el as any).initDrag, false)
       }
     },
   })

--- a/packages/nc-gui/plugins/resizeDirective.ts
+++ b/packages/nc-gui/plugins/resizeDirective.ts
@@ -1,6 +1,3 @@
-/**
- * Vertical resize directive using Pointer Events API for touch/mouse/pen support.
- */
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.directive('xc-ver-resize', {
     created: (el: Element) => {


### PR DESCRIPTION
## Change Summary

This PR adds comprehensive touch and tablet support to NocoDB by migrating from Mouse Events to the W3C Pointer Events API. This enables unified input handling for mouse, touch, and pen devices across the entire frontend.

**Problem:** Many interactive elements in NocoDB (canvas grid, sidebar, calendar, cell editors) were not responding to touch interactions on tablets and touch-enabled devices. Users reported that:
- Table items in the sidebar couldn't be tapped to open
- Canvas grid cells couldn't be selected or edited via touch
- Row reorder, checkbox, and expand buttons didn't work with touch
- Calendar drag/resize operations failed on touch devices
- Native keyboard wouldn't open when tapping input fields

**Solution:** Systematically migrate all mouse event handlers to Pointer Events API, which provides unified handling for all input types (mouse, touch, pen) as a W3C standard.

## Change Type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Changes Made

### 1. Canvas Grid (`packages/nc-gui/components/smartsheet/grid/canvas/`)
- Replaced `@mousedown`, `@mousemove`, `@mouseleave` with `@pointerdown`, `@pointermove`, `@pointerleave`, `@pointercancel`
- Added `touch-none` CSS class to prevent default browser touch behaviors
- Implemented double-tap detection for cell editing on touch devices
- Added iOS focus proxy input element to trigger native keyboard on double-tap
- Fixed double-tap cell editing by falling back to main elementMap when scoped map misses
- Prevented re-processing after edit mode is activated on double-tap
- Fixed `getMouseClickType` utility to correctly handle `e.detail` for touch events (which can be `0` or `undefined`)
- Updated `handleRowMetaClick` for touch-compatible checkbox, reorder, and expand interactions
- Updated type annotations to accept `MouseEvent | PointerEvent` in handleEditColumn, onClickOutside, cell handlers, ExpandedText, and useFillHandler

### 2. Grid Composables
- `useMouseSelection.ts` → Updated to accept `MouseEvent | PointerEvent`
- `useRowReOrder.ts` → Migrated to pointer events for row drag-and-drop
- `useColumnResize.ts` → Migrated for touch-friendly column resizing
- `useColumnReOrder.ts` → Migrated for touch-friendly column reordering
- `useRowDragging.ts` → Migrated for grid row dragging support

### 3. Grid Table Components (`packages/nc-gui/components/smartsheet/grid/`)
- `Table.vue` and `InfiniteTable.vue` → Replaced `useEventListener` mousedown/mouseup with pointerdown/pointerup for scrollbar detection and cell mouse-down tracking
- Updated `showContextMenu` and `handleCellClick` type annotations to accept `MouseEvent | PointerEvent`

### 4. Sidebar/TreeView (`packages/nc-gui/components/dashboard/TreeView/`)
- Added `preventOnFilter: false` to Sortable.js configurations to allow click events to propagate on touch devices
- Replaced `@mouseenter`/`@mouseleave` with `@pointerenter`/`@pointerleave` in `ProjectNode.vue` and `Views/Node.vue`
- Updated `handleContext` type annotations in `TreeView/index.vue` and `TreeView/Project/List.vue`
- Fixed table/view list items not responding to touch

### 5. Calendar Components (`packages/nc-gui/components/smartsheet/calendar/`)
- `MonthView.vue` - Updated `onDrag` and `onResize` type annotations for Pointer Events
- `WeekView/DateTimeField.vue` - Updated `onDrag` and `onResize` type annotations
- `WeekView/DateField.vue` - Updated `onDrag` and `onResize` type annotations
- `DayView/DateTimeField.vue` - Updated `onDrag` and `onResize` type annotations
- `DateTimeSpanningContainer.vue` - Updated `onResize` type annotation

### 6. Cell Components (`packages/nc-gui/components/cell/`)
- **Image Preview** (`attachment/Preview/Image.vue`): Unified separate `onMouseDown` + `onTouchStart` handlers into single `onPointerDown`; replaced `mousemove`/`mouseup`/`touchmove`/`touchend` listeners with `pointermove`/`pointerup`/`pointercancel`
- **DateTime editors**: Updated `clickHandler` type annotations
- **GeoData, MultiSelect, SingleSelect, User editors**: Updated `handleClose` type annotations
- **RichText** (`SelectedBubbleMenuPopup.vue`): Updated `handleEditorMouseDown`/`handleEditorMouseUp` type annotations
- **TextArea**: Updated `onMouseMove` type annotation for modal drag handler
- All cell types updated with `MouseEvent | PointerEvent` type annotations

### 7. Core Components
- `nc/Button.vue` - Replaced `mousedown` listener with `pointerdown`
- `nc/FullScreen/index.vue` - Updated `shadeClick` type annotation
- `extensions/Extension.vue` - Updated `closeFullscreen` type annotation
- `smartsheet/Cell.vue` - Updated `onContextmenu` type annotation
- `smartsheet/Form.vue` - Replaced `mousedown` listener with `pointerdown`, updated `handleOnClick` type
- `smartsheet/TableDataCell.vue` - Updated `handleClick` type annotation
- `smartsheet/column/EditOrAdd.vue` - Replaced `@mouseover`/`@mouseleave` with `@pointerover`/`@pointerleave`
- `dashboard/View.vue` - Updated `handleMouseMove` type annotation for sidebar resize tracking

### 8. Virtual Cells & Helpers
- `virtual-cell/Formula.vue` - Updated `openLongText` type annotation
- `virtual-cell/Lookup.vue` - Updated `handleCloseDropdown` type annotation
- `WorkflowVariablePicker.vue` - Replaced `@mousedown.stop` with `@pointerdown.stop`
- `md-link-rule-setup.ts` - Replaced `onmousedown` attribute with `onpointerdown` in tiptap markdown link rules

### 9. Other Components (from earlier commits)
- `cmd-k/index.vue` and `cmd-j/index.vue`
- `smartsheet/toolbar/FilterInput.vue` and `Filter/InputLite.vue`
- `smartsheet/column/FormulaInputHelper.vue`
- `general/FlippingCard.vue` and `JoinCloud.vue`
- `workspace/project/AiCreateProject.vue`
- `resizeDirective.ts` plugin - Migrated for touch-friendly element resizing
- `nc/Modal.vue` - Updated event propagation handling
- `nc/Popover.vue` - Updated click-outside detection
- `nc/Tooltip.vue` - Updated pointer event handling

## Test/Verification

### Manual Testing Performed:
1. **Sidebar Navigation** - Tap on table items in sidebar → Opens table ✅
2. **Canvas Grid Selection** - Tap on cells → Selects cell ✅
3. **Cell Editing** - Double-tap on cell → Opens editor with keyboard ✅
4. **Row Checkbox** - Tap checkbox → Toggles selection ✅
5. **Row Expand** - Tap expand button → Opens expanded form ✅
6. **Row Reorder** - Touch and drag reorder handle → Reorders row ✅
7. **Column Resize** - Touch and drag column border → Resizes column ✅
8. **Scrollbar Dragging** - Touch scrollbar → Scrolls grid ✅

### Recommended Testing:
- Test on iPad/tablet device with Safari and Chrome
- Test on Android tablet
- Test with Windows touch-enabled laptop
- Verify mouse interactions still work correctly (regression testing)

## Technical Details

### Why Pointer Events API?
- **W3C Standard**: Pointer Events is the official W3C recommendation for unified input handling
- **Browser Support**: Supported in all modern browsers (Chrome 55+, Firefox 59+, Safari 13+, Edge 12+)
- **Single Codebase**: One event handler works for mouse, touch, and pen input
- **Properties**: Provides `pointerType` property to distinguish input type when needed

### Key Implementation Notes:
1. Added `touch-action: none` (via `touch-none` class) on canvas to prevent browser touch gestures
2. Added `pointercancel` handlers alongside `pointerup` for robust touch handling
3. Fixed Sortable.js `filter` option with `preventOnFilter: false` to allow events to propagate
4. Updated type annotations to accept `MouseEvent | PointerEvent` for TypeScript compatibility
5. Added iOS focus proxy input element to trigger native keyboard from canvas double-tap
6. Unified separate mouse + touch handlers into single pointer event handlers (e.g., Image preview)

## Additional Information

### Commits (21 total):
1. `4c0ed0d1c8` - Canvas grid → Pointer Events API
2. `88dc23d65b` - TreeView sidebar hover events
3. `bc812a5336` - Grid Scroller (scrollbar dragging)
4. `dc26db0775` - Fix redundant pointerup handler bug
5. `0797ef4423` - useRowReOrder (row drag-and-drop)
6. `958f86082f` - Column resize/reorder composables
7. `7f3fd765a9` - Grid cell selection
8. `8a37313369` - Calendar MonthView/WeekView
9. `ee4f5b7fdd` - Row meta column touch (checkbox, expand)
10. `50a5e73f7d` - useRowDragging, DateField, DayView
11. `3b5f13ef44` - DateTimeSpanningContainer
12. `b93543c1d5` - Sortable.js fix for sidebar tables
13. `d16b2005b3` - addEventListener mouse → pointer (plugins, modals)
14. `ccdba5e494` - All remaining template events (56 files)
15. `3e68dc289c` - Canvas grid iOS focus proxy and double-tap fix
16. `282ccbbfe3` - Grid Table/InfiniteTable pointer event migration
17. `c8dcfc12dd` - Calendar component type annotations
18. `a6357e9458` - Cell components pointer event migration
19. `1186d0497a` - Dashboard TreeView/View pointer event migration
20. `f129435a76` - Core UI components pointer event migration
21. `2c8445bd99` - Virtual cells and tiptap helpers pointer event migration

### Files Changed: 95 files (+493, -394)

### Breaking Changes: None expected - Pointer Events API is backward compatible with mouse interactions.

### Related Issues:
- [🐛 Bug: Responsiveness/Control Issues on iPad (Non-Laptop/Mobile Devices) #11158](https://github.com/nocodb/nocodb/issues/11158)

---

**Note to Reviewers:** This is a large PR due to the systematic nature of the migration. Each commit is focused on a specific area (canvas, calendar, cells, etc.) to make reviewing easier. The changes are mostly mechanical replacements of event names, with some additional logic for touch-specific behaviors (like double-tap detection and iOS keyboard focus proxy).
