### PR TITLE
fix: run Docker containers as non-root user for improved security

### DIFF
--- a/packages/nocodb/Dockerfile
+++ b/packages/nocodb/Dockerfile
@@ -87,7 +87,18 @@ COPY --link ./docker/litestream.yml /etc/litestream.yml
 COPY --link --from=builder /usr/src/app/ /usr/src/app/
 COPY --link --from=builder /usr/src/appEntry/ /usr/src/appEntry/
 
+# Create data directory and set ownership for non-root user
+RUN mkdir -p /usr/app/data \
+    && chown -R node:node /usr/src/app \
+    && chown -R node:node /usr/src/appEntry \
+    && chown -R node:node /usr/app/data \
+    && chown node:node /etc/litestream.yml
+
 EXPOSE 8080
+
+# Run as non-root user
+USER node
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Start Nocodb

--- a/packages/nocodb/Dockerfile.timely
+++ b/packages/nocodb/Dockerfile.timely
@@ -117,7 +117,18 @@ COPY --link --from=builder     /usr/src/appEntry/                 /usr/src/appEn
 COPY --link --from=bin-builder /usr/src/app/node_modules/sqlite3/ /usr/src/app/node_modules/sqlite3/
 COPY --link --from=bin-builder /usr/src/app/node_modules/sharp/   /usr/src/app/node_modules/sharp/
 
+# Create data directory and set ownership for non-root user
+RUN mkdir -p /usr/app/data \
+    && chown -R node:node /usr/src/app \
+    && chown -R node:node /usr/src/appEntry \
+    && chown -R node:node /usr/app/data \
+    && chown node:node /etc/litestream.yml
+
 EXPOSE 8080
+
+# Run as non-root user
+USER node
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Start NocoDB


### PR DESCRIPTION
Vulnerability identified and PR provided by [Kolega.dev](http://kolega.dev/) (https://kolega.dev/)

Add USER directive to run containers as node user (UID 1000) instead of root, reducing privilege escalation risk. Resolves CWE-269 and CWE-250 vulnerabilities.

## Change Summary

Added USER directive to run Docker containers as non-root user (UID 1000) instead of root, reducing privilege escalation risk. Resolves **CWE-269** (Improper Privilege Management) and **CWE-250** (Execution with Unnecessary Privileges) vulnerabilities.

**Fixes two security findings:**
- **Rule **: missing-user-entrypoint - ENTRYPOINT now runs as non-root
- **Rule **: missing-user - CMD now runs as non-root

**Files modified:**
- `packages/nocodb/Dockerfile`
- `packages/nocodb/Dockerfile.timely`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

**Build and verify container runs as non-root:**
```bash
cd packages/nocodb
docker build -t nocodb:test .
docker run --rm nocodb:test id
# Expected output: uid=1000(node) gid=1000(node) groups=1000(node)

docker run --rm nocodb:test whoami
# Expected output: node (not root)
```

**Verify application functionality:**
- Start container with volume mounts
- Verify database files can be created in `/usr/app/data/`
- Test Litestream backup/restore functionality
- Confirm all application features work correctly with reduced privileges

## Additional information / screenshots (optional)

**Security Context:**
- **Severity:** High
- **Impact:** If an attacker gains code execution within the container, they now have limited privileges instead of full root access
- **Backward Compatibility:** ✅ Fully compatible - UID 1000 is standard for Node.js containers and works with existing volume mounts

**Implementation Details:**
- Uses existing `node` user from `node:22-slim` base image
- Sets proper ownership on all required directories before switching to non-root user
- No application code changes required
- Follows Docker security best practices and industry standards

This change significantly reduces the container's attack surface while maintaining full backward compatibility with existing deployments.

