### PR TITLE
fix(security): add origin validation to postMessage in useUserSync

### DIFF
--- a/packages/nc-gui/composables/useUserSync.ts
+++ b/packages/nc-gui/composables/useUserSync.ts
@@ -6,11 +6,55 @@ export interface UserObject {
   display_name?: string
 }
 
+// Security: Trusted origins for postMessage communication
+const TRUSTED_EXTERNAL_ORIGINS = [
+  'https://docs.google.com', // Google Docs viewer for Office document preview
+] as const
+
+const MESSAGE_TYPE = '___NC_USER_SYNC' as const
+
 export const useUserSync = createSharedComposable(() => {
   const isIFrame = ncIsIframe()
   const { user } = useGlobal()
   const currentUser = ref<UserObject | null>(null)
   let syncInterval: NodeJS.Timeout | null = null
+
+  /**
+   * Determines the appropriate target origin for an iframe
+   * @param iframe - The iframe element to check
+   * @returns The target origin URL, or null if iframe should be skipped
+   */
+  const getIframeTargetOrigin = (iframe: HTMLIFrameElement): string | null => {
+    try {
+      // Get iframe src attribute
+      const src = iframe.getAttribute('src')
+
+      // Skip iframes without src or with special protocols
+      if (!src || src === 'about:blank' || src.startsWith('data:') || src.startsWith('blob:')) {
+        return null
+      }
+
+      // Parse the URL
+      const url = new URL(src, window.location.origin)
+
+      // Check if same origin
+      if (url.origin === window.location.origin) {
+        return window.location.origin
+      }
+
+      // Check if trusted external origin
+      if (TRUSTED_EXTERNAL_ORIGINS.includes(url.origin as any)) {
+        return url.origin
+      }
+
+      // Unknown origin - skip this iframe
+      console.warn('Skipping iframe with untrusted origin:', url.origin)
+      return null
+    } catch (error) {
+      console.warn('Failed to determine iframe origin:', error)
+      return null
+    }
+  }
 
   const sendToAllIframes = () => {
     const userObj = {
@@ -21,12 +65,19 @@ export const useUserSync = createSharedComposable(() => {
 
     document.querySelectorAll('iframe').forEach((iframe) => {
       try {
+        const targetOrigin = getIframeTargetOrigin(iframe)
+
+        // Skip iframes with untrusted or indeterminate origins
+        if (!targetOrigin) {
+          return
+        }
+
         iframe.contentWindow?.postMessage(
           {
-            type: '___NC_USER_SYNC',
+            type: MESSAGE_TYPE,
             user: userObj,
           },
-          '*',
+          targetOrigin, // FIXED: Use specific origin instead of '*'
         )
       } catch (error) {
         console.warn('Failed to send user data to iframe:', error)
@@ -37,7 +88,17 @@ export const useUserSync = createSharedComposable(() => {
   // IFRAME MODE: Listen for user data
   if (isIFrame) {
     window.addEventListener('message', (event) => {
-      if (event.data.type === '___NC_USER_SYNC') {
+      // Security: Validate origin before processing message
+      const isValidOrigin =
+        event.origin === window.location.origin ||
+        TRUSTED_EXTERNAL_ORIGINS.includes(event.origin as any)
+
+      if (!isValidOrigin) {
+        console.warn('Rejected user sync message from untrusted origin:', event.origin)
+        return
+      }
+
+      if (event.data.type === MESSAGE_TYPE) {
         currentUser.value = event.data.user
       }
     })


### PR DESCRIPTION
Vulnerability identified and PR provided by [Kolega.dev](http://kolega.dev/) (https://kolega.dev/)

Add origin validation to postMessage in useUserSync to prevent data leakage to untrusted iframes and block malicious parent windows from injecting fake user data. Resolves **CWE-345** (Insufficient Verification of Data Authenticity) and **OWASP A08:2021** vulnerabilities.

## Change Summary

Added origin validation to both sender and receiver in `useUserSync.ts` postMessage communication:

**Sender side**: Replaced wildcard `*` origin with specific origin validation - only sends user data to same-origin iframes or explicitly trusted domains (docs.google.com for Google Docs viewer)

**Receiver side**: Added `event.origin` validation before processing messages - rejects messages from untrusted origins with console warnings

**Fixes security findings:**
- **Rule #19**: wildcard-postmessage-configuration - postMessage sender now uses specific origins instead of wildcard `*`
- **Rule #20**: insufficient-postmessage-origin-validation - postMessage receiver now validates event.origin before processing

**Files modified:**
- `packages/nc-gui/composables/useUserSync.ts`

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

**Manual testing:**
```bash
cd packages/nc-gui
npm run dev
```

**Verify same-origin iframes work:**
1. Create/open a shared view (Grid, Kanban, Form)
2. Test embed functionality
3. Check browser console - no postMessage errors
4. Verify user data syncs correctly

**Verify Google Docs viewer works:**
1. Upload an Office file (PDF, DOCX, XLSX) to an attachment field
2. Click to preview the file
3. Verify preview opens correctly in Google Docs viewer
4. Check console - no errors

**Verify security working:**
1. Open browser DevTools → Console
2. Check for warnings about untrusted iframe origins (expected behavior)
3. Verify no user data leaks to untrusted domains

## Additional information / screenshots (optional)

**Security Context:**
- **Severity:** Medium
- **CWE:** CWE-345 (Insufficient Verification of Data Authenticity)
- **OWASP:** A08:2021 - Software and Data Integrity Failures
- **Impact Before Fix:** Any iframe could receive user data (id, email, display_name); any parent window could inject fake user data
- **Impact After Fix:** Only same-origin and explicitly trusted iframes receive data; untrusted origins are rejected

**Backward Compatibility:** ✅ Fully compatible - no breaking changes to existing functionality
- Same-origin shared views/forms continue to work
- Google Docs viewer continues to work
- Only blocks previously insecure behavior (untrusted iframes)

**Implementation Details:**
- Adds `getIframeTargetOrigin()` helper to validate iframe sources
- Extracts trusted origins list to constant for maintainability
- Handles edge cases (about:blank, data:, blob: URLs)
- Follows existing NocoDB coding patterns

This change is a defence-in-depth security improvement that prevents potential data leakage while maintaining full backward compatibility.
