### PR TITLE
fix(api-v3): return full linked records instead of counts for UITypes.Links

### DIFF
--- a/packages/nocodb/src/helpers/getAst.ts
+++ b/packages/nocodb/src/helpers/getAst.ts
@@ -235,7 +235,7 @@ const getAst = async (
     const nestedFields =
       query?.nested?.[col.title]?.fields || query?.nested?.[col.title]?.f;
     if (nestedFields && nestedFields !== '*') {
-      if (col.uidt === UITypes.LinkToAnotherRecord) {
+      if (isLinksOrLTAR(col)) {
         const colOpt = await col.getColOptions<LinkToAnotherRecordColumn>(
           context,
         );
@@ -257,14 +257,12 @@ const getAst = async (
         value = ast;
 
         // todo: include field relative to the relation => pk / fk
-      } else if (col.uidt === UITypes.Links) {
-        value = 1;
       } else {
         value = (
           Array.isArray(nestedFields) ? nestedFields : nestedFields.split(',')
         ).reduce((o, f) => ({ ...o, [f]: 1 }), {});
       }
-    } else if (col.uidt === UITypes.LinkToAnotherRecord) {
+    } else if (isLinksOrLTAR(col)) {
       const colOpt = await col.getColOptions<LinkToAnotherRecordColumn>(
         context,
       );


### PR DESCRIPTION
## Summary
- Updates `getAst.ts` to treat `UITypes.Links` the same as `LinkToAnotherRecord` when generating the AST for nested field queries
- Updates `data-v3.service.ts` to handle `UITypes.Links` columns by looking for linked data with the `_nc_lk_` prefix used by `getProto()`
- Transforms the linked records to v3 format and filters out count values that shouldn't be in the response

## Root Cause
Previously, API v3 endpoints returned numeric counts for `UITypes.Links` columns instead of the actual paginated linked records as documented. This was because:
1. `getAst.ts` had special handling to return `value = 1` (count) for `UITypes.Links` instead of building the AST for nested fields
2. `data-v3.service.ts` only handled `UITypes.LinkToAnotherRecord` in the transformation, not `UITypes.Links`

## Test plan
- [x] Create two tables with a Link column between them
- [x] Add records with linked relationships
- [x] Test API v3 endpoint `/v3/{baseId}/tables/{tableId}/records`
- [x] Verify linked records are returned as arrays of objects, not counts
- [x] Test with HAS_MANY, MANY_TO_MANY, BELONGS_TO, and ONE_TO_ONE relationships

## Files Changed
- `packages/nocodb/src/helpers/getAst.ts` - Use `isLinksOrLTAR()` instead of checking only for `UITypes.LinkToAnotherRecord`
- `packages/nocodb/src/services/v3/data-v3.service.ts` - Handle `UITypes.Links` columns in transformation and LTAR column filtering

Fixes #12717