### PR TITLE
fix: render search bar inline to prevent overlapping table headers

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/SearchData.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/SearchData.vue
@@ -201,9 +201,9 @@ watch(
     </NcButton>
     <LazySmartsheetToolbarSearchDataWrapperDropdown v-else :visible="true">
       <div
+        class="border-1 rounded-lg border-gray-200 overflow-hidden focus-within:(border-primary shadow-selected)"
         :class="{
-          'border-1 rounded-lg border-gray-200 overflow-hidden focus-within:(border-primary shadow-selected)': isMobileMode,
-          'border-primary shadow-selected': isMobileMode && search.query.length !== 0,
+          'border-primary shadow-selected': search.query.length !== 0,
         }"
       >
         <div class="flex flex-row h-8 relative">

--- a/packages/nc-gui/components/smartsheet/toolbar/SearchData/WrapperDropdown.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/SearchData/WrapperDropdown.vue
@@ -2,23 +2,8 @@
 defineProps<{
   visible: boolean
 }>()
-
-const { isMobileMode } = useGlobal()
 </script>
 
 <template>
-  <slot v-if="isMobileMode" />
-  <NcDropdown
-    v-else
-    :visible="visible"
-    :trigger="['click']"
-    placement="bottomRight"
-    overlay-class-name="nc-dropdown-toolbar-search !border-primary !shadow-selected overflow-hidden !z-1000"
-    non-nc-dropdown
-  >
-    <div class="absolute -right-1 -top-5"></div>
-    <template #overlay>
-      <slot />
-    </template>
-  </NcDropdown>
+  <slot />
 </template>


### PR DESCRIPTION
## Summary
- Fixes #12669
- Search bar was using NcDropdown with bottomRight placement and high z-index (1000) causing it to overlay on table header columns when expanded
- Simplified WrapperDropdown.vue to render content inline instead of as dropdown overlay
- Updated SearchData.vue to apply border styling consistently for both mobile and desktop views

## Root Cause
The WrapperDropdown.vue component was using NcDropdown with:
- placement="bottomRight" - positioning the dropdown content below and to the right
- z-index: 1000 - which positioned it above the table headers (z-index: 3-5)

This caused the expanded search input to appear as a dropdown overlay that covered the table column headers.

## Solution
Removed the dropdown wrapper and rendered the search input inline within the toolbar flow. This ensures:
1. Search input stays within the toolbar's natural flow
2. Table headers remain visible and are not obscured
3. Responsive behavior for mobile is maintained

## Test plan
- [x] Open any NocoDB project with a Grid View
- [x] Click the search icon (magnifying glass) in the toolbar
- [x] Verify the search input expands inline within the toolbar
- [x] Verify table column headers remain visible and are NOT obscured
- [x] Test searching with results visible
- [x] Test the column selector dropdown works correctly
- [x] Test clicking outside closes the search (when empty)
- [x] Test keyboard shortcuts (Ctrl/Cmd+F, Escape)
- [x] Verify mobile behavior still works correctly

## Files Changed
- packages/nc-gui/components/smartsheet/toolbar/SearchData/WrapperDropdown.vue - Simplified to inline rendering
- packages/nc-gui/components/smartsheet/toolbar/SearchData.vue - Updated border styling for desktop