### PR TITLE
fix(security): auto-generate HTTP Basic Auth credentials to prevent h…

### DIFF
--- a/packages/nocodb/src/app.config.ts
+++ b/packages/nocodb/src/app.config.ts
@@ -6,8 +6,10 @@ const config: AppConfig = {
     calc_execution_time: false,
   },
   basicAuth: {
-    username: process.env.NC_HTTP_BASIC_USER ?? 'defaultusername',
-    password: process.env.NC_HTTP_BASIC_PASS ?? 'defaultpassword',
+    // Initialized by initBasicAuth() during startup
+    // Sentinel values prevent use before initialization
+    username: process.env.NC_HTTP_BASIC_USER ?? '__UNINITIALIZED__',
+    password: process.env.NC_HTTP_BASIC_PASS ?? '__UNINITIALIZED__',
   },
   auth: {
     emailPattern:

--- a/packages/nocodb/src/helpers/initBasicAuth.ts
+++ b/packages/nocodb/src/helpers/initBasicAuth.ts
@@ -1,0 +1,211 @@
+import { Logger } from '@nestjs/common';
+import { validatePassword } from 'nocodb-sdk';
+import boxen from 'boxen';
+import { NcDebug } from 'nc-gui/utils/debug';
+import Noco from '~/Noco';
+import { MetaTable, RootScopes } from '~/utils/globals';
+import { randomTokenString } from '~/services/users/helpers';
+
+const logger = new Logger('initBasicAuth');
+
+/**
+ * Generates cryptographically secure random credentials
+ */
+function generateSecureCredentials(): { username: string; password: string } {
+  // Use randomTokenString() which generates 80-character hex strings (320 bits entropy)
+  // This provides sufficient security for HTTP Basic Auth credentials
+  const username = randomTokenString();
+  const password = randomTokenString();
+
+  return { username, password };
+}
+
+/**
+ * Validates if credentials are weak or use default values
+ */
+function isWeakCredentials(
+  username: string,
+  password: string,
+): {
+  isWeak: boolean;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  let isWeak = false;
+
+  // Check for hardcoded defaults from old configuration
+  if (username === 'defaultusername') {
+    reasons.push('Username is using default value');
+    isWeak = true;
+  }
+  if (password === 'defaultpassword') {
+    reasons.push('Password is using default value');
+    isWeak = true;
+  }
+
+  // Check password strength using nocodb-sdk validation
+  const { valid, error } = validatePassword(password);
+  if (!valid) {
+    reasons.push(`Weak password: ${error}`);
+    isWeak = true;
+  }
+
+  // Check for common weak usernames
+  const commonWeak = ['admin', 'user', 'test', 'root', 'administrator'];
+  if (commonWeak.includes(username.toLowerCase())) {
+    reasons.push('Username is commonly used and easily guessable');
+    isWeak = true;
+  }
+
+  return { isWeak, reasons };
+}
+
+/**
+ * Initialize BasicAuth credentials with secure defaults
+ * Follows the same pattern as initJwt in Noco.ts
+ *
+ * Priority order:
+ * 1. Environment variables (NC_HTTP_BASIC_USER, NC_HTTP_BASIC_PASS)
+ * 2. Database stored credentials
+ * 3. Auto-generated secure credentials
+ *
+ * @param _ncMeta - MetaService instance for database operations
+ * @returns Object containing username, password, and source
+ */
+export default async function initBasicAuth(_ncMeta = Noco.ncMeta) {
+  try {
+    let username: string;
+    let password: string;
+    let source = 'generated';
+
+    // Priority 1: Check environment variables (backward compatibility)
+    if (process.env.NC_HTTP_BASIC_USER && process.env.NC_HTTP_BASIC_PASS) {
+      username = process.env.NC_HTTP_BASIC_USER;
+      password = process.env.NC_HTTP_BASIC_PASS;
+      source = 'environment';
+
+      // Validate environment-provided credentials
+      const { isWeak, reasons } = isWeakCredentials(username, password);
+      if (isWeak) {
+        console.warn(
+          '\n',
+          boxen(
+            [
+              'SECURITY WARNING: Weak HTTP Basic Auth credentials detected!',
+              '',
+              'Issues found:',
+              ...reasons.map((r) => `  • ${r}`),
+              '',
+              'Recommendation: Use strong, randomly generated credentials or remove',
+              'NC_HTTP_BASIC_USER and NC_HTTP_BASIC_PASS to auto-generate secure credentials.',
+            ].join('\n'),
+            {
+              title: '⚠️  HTTP Basic Auth Security Warning',
+              padding: 1,
+              borderStyle: 'double',
+              titleAlignment: 'center',
+              borderColor: 'yellow',
+            },
+          ),
+          '\n',
+        );
+      }
+
+      NcDebug.log(
+        'HTTP Basic Auth credentials loaded from environment variables',
+      );
+    } else {
+      // Priority 2: Check database for stored credentials
+      const storedUsername = await _ncMeta.metaGet(
+        RootScopes.ROOT,
+        RootScopes.ROOT,
+        MetaTable.STORE,
+        { key: 'nc_http_basic_username' },
+      );
+
+      const storedPassword = await _ncMeta.metaGet(
+        RootScopes.ROOT,
+        RootScopes.ROOT,
+        MetaTable.STORE,
+        { key: 'nc_http_basic_password' },
+      );
+
+      if (storedUsername?.value && storedPassword?.value) {
+        username = storedUsername.value;
+        password = storedPassword.value;
+        source = 'database';
+        NcDebug.log('HTTP Basic Auth credentials loaded from database');
+      } else {
+        // Priority 3: Generate new secure credentials
+        const generated = generateSecureCredentials();
+        username = generated.username;
+        password = generated.password;
+
+        // Store in database for persistence across restarts
+        await _ncMeta.metaInsert2(
+          RootScopes.ROOT,
+          RootScopes.ROOT,
+          MetaTable.STORE,
+          {
+            key: 'nc_http_basic_username',
+            value: username,
+          },
+          true,
+        );
+
+        await _ncMeta.metaInsert2(
+          RootScopes.ROOT,
+          RootScopes.ROOT,
+          MetaTable.STORE,
+          {
+            key: 'nc_http_basic_password',
+            value: password,
+          },
+          true,
+        );
+
+        logger.log(
+          '\n' +
+            boxen(
+              [
+                'HTTP Basic Auth credentials have been auto-generated.',
+                '',
+                `Username: ${username}`,
+                `Password: ${password}`,
+                '',
+                'IMPORTANT: Save these credentials securely!',
+                'These credentials are stored in the database and will persist.',
+                '',
+                'To customize, set environment variables:',
+                '  NC_HTTP_BASIC_USER=your_username',
+                '  NC_HTTP_BASIC_PASS=your_password',
+              ].join('\n'),
+              {
+                title: '🔐 HTTP Basic Auth Credentials Generated',
+                padding: 1,
+                borderStyle: 'round',
+                borderColor: 'green',
+              },
+            ),
+        );
+
+        NcDebug.log(
+          'HTTP Basic Auth credentials auto-generated and stored in database',
+        );
+      }
+    }
+
+    // Update the application config with initialized credentials
+    if (Noco.config) {
+      Noco.config.basicAuth = {
+        username,
+        password,
+      };
+    }
+
+    return { username, password, source };
+  } catch (error) {
+    logger.error('Failed to initialize HTTP Basic Auth credentials', error);
+    throw error;
+  }
+}

--- a/packages/nocodb/src/providers/init-meta-service.provider.ts
+++ b/packages/nocodb/src/providers/init-meta-service.provider.ts
@@ -10,6 +10,7 @@ import NcUpgrader from '~/version-upgrader/NcUpgrader';
 import NocoCache from '~/cache/NocoCache';
 import getInstance from '~/utils/getInstance';
 import initAdminFromEnv from '~/helpers/initAdminFromEnv';
+import initBasicAuth from '~/helpers/initBasicAuth';
 import { User } from '~/models';
 import { NcConfig, prepareEnv } from '~/utils/nc-config';
 import { MetaTable, RootScopes } from '~/utils/globals';
@@ -109,6 +110,10 @@ export const InitMetaServiceProvider: FactoryProvider = {
     // init jwt secret
     await Noco.initJwt();
     NcDebug.log('JWT initialized');
+
+    // init basic auth credentials
+    await initBasicAuth(metaService);
+    NcDebug.log('HTTP Basic Auth initialized');
 
     // load super admin user from env if env is set
     await initAdminFromEnv(metaService);

--- a/packages/nocodb/src/strategies/basic.strategy/basic.strategy.ts
+++ b/packages/nocodb/src/strategies/basic.strategy/basic.strategy.ts
@@ -1,11 +1,14 @@
+import crypto from 'crypto';
 import { BasicStrategy as Strategy } from 'passport-http';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import type { AppConfig } from '~/interface/config';
 
 @Injectable()
 export class BasicStrategy extends PassportStrategy(Strategy) {
+  private readonly logger = new Logger(BasicStrategy.name);
+
   constructor(private readonly configService: ConfigService<AppConfig>) {
     super({
       passReqToCallback: true,
@@ -16,12 +19,58 @@ export class BasicStrategy extends PassportStrategy(Strategy) {
     const credentials = this.configService.get('basicAuth', {
       infer: true,
     });
+
+    // Security check: prevent use of uninitialized credentials
     if (
-      credentials.username === username &&
-      credentials.password === password
+      credentials.username === '__UNINITIALIZED__' ||
+      credentials.password === '__UNINITIALIZED__'
     ) {
+      this.logger.error(
+        'HTTP Basic Auth credentials not initialized. This should never happen.',
+      );
+      throw new UnauthorizedException();
+    }
+
+    // Constant-time comparison to prevent timing attacks
+    const usernameMatch = this.secureCompare(credentials.username, username);
+    const passwordMatch = this.secureCompare(credentials.password, password);
+
+    if (usernameMatch && passwordMatch) {
       return true;
     }
+
+    // Log failed authentication attempts (for security monitoring)
+    this.logger.warn(
+      `HTTP Basic Auth failed for user: ${username} from IP: ${req.ip}`,
+    );
+
     throw new UnauthorizedException();
   };
+
+  /**
+   * Constant-time string comparison to prevent timing attacks
+   * Uses crypto.timingSafeEqual for security-critical comparison
+   */
+  private secureCompare(a: string, b: string): boolean {
+    if (typeof a !== 'string' || typeof b !== 'string') {
+      return false;
+    }
+
+    // Convert to buffers for timing-safe comparison
+    const bufferA = Buffer.from(a, 'utf8');
+    const bufferB = Buffer.from(b, 'utf8');
+
+    // If lengths differ, still perform comparison to prevent timing leak
+    if (bufferA.length !== bufferB.length) {
+      // Compare against self to maintain constant time
+      crypto.timingSafeEqual(bufferA, bufferA);
+      return false;
+    }
+
+    try {
+      return crypto.timingSafeEqual(bufferA, bufferB);
+    } catch {
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
Vulnerability identified and PR provided by [Kolega.dev](http://kolega.dev/) (https://kolega.dev/)

Resolves CWE-798 vulnerability where BasicAuth credentials were hardcoded as 'defaultusername'/'defaultpassword', creating authentication bypass risk for misconfigured deployments.

Changes:
- Remove hardcoded default credentials from app.config.ts
- Add initBasicAuth() helper following JWT initialization pattern
- Auto-generate cryptographically secure credentials (320-bit entropy)
- Store credentials persistently in database (MetaTable.STORE)
- Maintain backward compatibility with NC_HTTP_BASIC_USER/NC_HTTP_BASIC_PASS
- Add timing-attack resistant credential comparison using crypto.timingSafeEqual
- Log failed authentication attempts for security monitoring
- Validate and warn about weak passwords from environment variables

Security improvements:
- Eliminates publicly known default credentials
- Uses crypto.randomBytes() for secure random generation
- Implements constant-time comparison to prevent timing attacks
- Provides defense-in-depth with multiple security layers

Backward compatibility:
- Non-breaking for deployments using environment variables
- Auto-generated credentials displayed in logs on first startup

## Change Summary

  Fixes CWE-798 vulnerability where HTTP Basic Auth credentials were hardcoded as `defaultusername`/`defaultpassword`. These publicly known defaults created an authentication bypass risk for
  deployments without explicit credential configuration.

  **Solution:** Auto-generate cryptographically secure credentials on first deployment, following the existing JWT initialization pattern.

  ## Change type

  - [ ] feat: (new feature for the user, not a new feature for build script)
  - [x] fix: (bug fix for the user, not a fix to a build script)
  - [ ] docs: (changes to the documentation)
  - [ ] style: (formatting, missing semi colons, etc; no production code change)
  - [ ] refactor: (refactoring production code, eg. renaming a variable)
  - [ ] test: (adding missing tests, refactoring tests; no production code change)
  - [ ] chore: (updating grunt tasks etc; no production code change)

  ## Test/ Verification

  **Fresh deployment:**
  1. Start NocoDB without `NC_HTTP_BASIC_USER`/`NC_HTTP_BASIC_PASS` env vars
  2. Check logs for auto-generated credentials display
  3. Restart - verify same credentials used (stored in database)

  **Existing deployments:**
  - Environment variables continue to work unchanged
  - Weak passwords trigger warning in logs

  **Security validation:**
  - Credentials use `randomTokenString()` (80-char hex, 320-bit entropy)
  - `crypto.timingSafeEqual()` prevents timing attacks
  - Failed auth attempts logged with IP address

  ## Additional information / screenshots (optional)

  **Backward compatibility:**
  - Non-breaking for deployments using environment variables
  - Deployments relying on hardcoded defaults will need to update (intentional security fix)

  **Implementation:**
  - Follows existing `initJwt()` pattern from `Noco.ts`
  - Stores in `MetaTable.STORE` (keys: `nc_http_basic_username`, `nc_http_basic_password`)
  - Defense in depth: env vars → database → auto-generation