### PR TITLE
fix(security): add configurable CORS origins via NC_ALLOWED_ORIGINS

### DIFF
--- a/packages/nocodb/src/main.ts
+++ b/packages/nocodb/src/main.ts
@@ -1,16 +1,13 @@
 import cors from 'cors';
 import express from 'express';
 import Noco from '~/Noco';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 
 const server = express();
 server.enable('trust proxy');
 server.disable('etag');
 server.disable('x-powered-by');
-server.use(
-  cors({
-    exposedHeaders: 'xc-db-response',
-  }),
-);
+server.use(cors(getCorsOptions()));
 
 server.set('view engine', 'ejs');
 

--- a/packages/nocodb/src/run/cloud.ts
+++ b/packages/nocodb/src/run/cloud.ts
@@ -11,6 +11,7 @@ import express from 'express';
 import cors from 'cors';
 import Noco from '~/Noco';
 import { handleUncaughtErrors } from '~/utils';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 
 handleUncaughtErrors(process);
 
@@ -36,7 +37,7 @@ let httpServer: http.Server | null = null;
 async function createServer(isMaster: boolean): Promise<http.Server> {
   const server = express();
   server.enable('trust proxy');
-  server.use(cors());
+  server.use(cors(getCorsOptions()));
 
   // Add static file serving for the dashboard
   server.use(

--- a/packages/nocodb/src/run/docker.ts
+++ b/packages/nocodb/src/run/docker.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import express from 'express';
 import Noco from '~/Noco';
 import { handleUncaughtErrors } from '~/utils';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 handleUncaughtErrors(process);
 
 // ref: https://github.com/nodejs/node/issues/40702#issuecomment-1103623246
@@ -12,11 +13,7 @@ const server = express();
 server.enable('trust proxy');
 server.disable('etag');
 server.disable('x-powered-by');
-server.use(
-  cors({
-    exposedHeaders: 'xc-db-response',
-  }),
-);
+server.use(cors(getCorsOptions()));
 
 server.set('view engine', 'ejs');
 

--- a/packages/nocodb/src/run/dockerEntry.ts
+++ b/packages/nocodb/src/run/dockerEntry.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import cors from 'cors';
 import Noco from '~/Noco';
 import { handleUncaughtErrors } from '~/utils';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 handleUncaughtErrors(process);
 
 // ref: https://github.com/nodejs/node/issues/40702#issuecomment-1103623246
@@ -10,7 +11,7 @@ dns.setDefaultResultOrder('ipv4first');
 
 const server = express();
 server.enable('trust proxy');
-server.use(cors());
+server.use(cors(getCorsOptions()));
 
 server.set('view engine', 'ejs');
 

--- a/packages/nocodb/src/run/local.ts
+++ b/packages/nocodb/src/run/local.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import express from 'express';
 import Noco from '~/Noco';
 import { handleUncaughtErrors } from '~/utils';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 handleUncaughtErrors(process);
 
 // ref: https://github.com/nodejs/node/issues/40702#issuecomment-1103623246
@@ -11,7 +12,7 @@ dns.setDefaultResultOrder('ipv4first');
 
 const server = express();
 server.enable('trust proxy');
-server.use(cors());
+server.use(cors(getCorsOptions()));
 server.use(
   process.env.NC_DASHBOARD_URL ?? '/dashboard',
   express.static(path.join(__dirname, 'nc-gui')),

--- a/packages/nocodb/src/run/testDocker.ts
+++ b/packages/nocodb/src/run/testDocker.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import Noco from '~/Noco';
 import { User } from '~/models';
 import { handleUncaughtErrors } from '~/utils';
+import { getCorsOptions } from '~/utils/nc-config/cors';
 handleUncaughtErrors(process);
 
 process.env.NC_VERSION = '0009044';
@@ -16,11 +17,7 @@ const server = express();
 server.enable('trust proxy');
 server.disable('etag');
 server.disable('x-powered-by');
-server.use(
-  cors({
-    exposedHeaders: 'xc-db-response',
-  }),
-);
+server.use(cors(getCorsOptions()));
 
 server.set('view engine', 'ejs');
 

--- a/packages/nocodb/src/utils/nc-config/constants.ts
+++ b/packages/nocodb/src/utils/nc-config/constants.ts
@@ -89,3 +89,5 @@ export const NC_DISABLE_SUPPORT_CHAT =
 
 export const NC_IFRAME_WHITELIST_DOMAINS =
   process.env.NC_IFRAME_WHITELIST_DOMAINS || '';
+
+export const NC_ALLOWED_ORIGINS = process.env.NC_ALLOWED_ORIGINS || '';

--- a/packages/nocodb/src/utils/nc-config/cors.ts
+++ b/packages/nocodb/src/utils/nc-config/cors.ts
@@ -1,0 +1,47 @@
+import type { CorsOptions } from 'cors';
+
+/**
+ * Get CORS configuration based on NC_ALLOWED_ORIGINS environment variable
+ *
+ * Environment Variable:
+ *   NC_ALLOWED_ORIGINS - Comma-separated list of allowed origins
+ *
+ * Examples:
+ *   NC_ALLOWED_ORIGINS=https://app.example.com
+ *   NC_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+ *   NC_ALLOWED_ORIGINS=* (explicitly allow all origins)
+ *
+ * Security Notes:
+ *   - If NC_ALLOWED_ORIGINS is not set, defaults to permissive CORS (backwards compatible)
+ *   - When specific origins are configured, credentials are enabled
+ *   - For self-hosted deployments, users can intentionally set "*" for permissive CORS
+ *   - For production/cloud deployments, configure specific allowed origins
+ *
+ * @returns CorsOptions for cors middleware
+ */
+export function getCorsOptions(): CorsOptions {
+  const allowedOrigins = process.env.NC_ALLOWED_ORIGINS;
+
+  const corsOptions: CorsOptions = {
+    exposedHeaders: 'xc-db-response',
+  };
+
+  if (allowedOrigins) {
+    // Parse comma-separated origins
+    const origins = allowedOrigins.split(',').map((origin) => origin.trim());
+
+    if (origins.length === 1 && origins[0] === '*') {
+      // Explicit wildcard - allow all origins
+      corsOptions.origin = true;
+    } else {
+      // Whitelist specific origins
+      corsOptions.origin = origins;
+      // Enable credentials for whitelisted origins
+      corsOptions.credentials = true;
+    }
+  }
+  // If NC_ALLOWED_ORIGINS is not set, default to permissive CORS (backwards compatible)
+  // This allows all origins (origin is undefined, which cors middleware treats as *)
+
+  return corsOptions;
+}


### PR DESCRIPTION
Vulnerability identified and PR provided by [Kolega.dev](http://kolega.dev/) (https://kolega.dev/)

- Introduces NC_ALLOWED_ORIGINS environment variable for CORS origin whitelisting
- Maintains backwards compatibility (defaults to permissive CORS)
- Enables credentials when specific origins are configured
- Updates all entry points to use centralized CORS configuration
- Addresses CWE-346 (Origin Validation Error)

## Change Summary

Provide summary of changes with issue number if any.

## Change Summary

Adds configurable CORS origin whitelisting via the `NC_ALLOWED_ORIGINS` environment variable to address unrestricted CORS configuration (CWE-346).

**Current behavior:** CORS allows all origins (`*`) by default across all entry points.

**New behavior:**
- If `NC_ALLOWED_ORIGINS` is not set: maintains current permissive behavior (backwards compatible)
- If set with specific origins: enables CORS whitelist with credentials support
- If set to `*`: explicitly allows all origins

This allows production/cloud deployments to restrict origins while maintaining flexibility for self-hosted users.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

**Test 1: Default behavior (no env var)**
```bash
# Start NocoDB without NC_ALLOWED_ORIGINS
npm start
# Verify CORS allows all origins
curl -H "Origin: https://example.com" http://localhost:8080/api/v1/health -v
# Should return Access-Control-Allow-Origin header
```

**Test 2: Single origin whitelist**
```bash
NC_ALLOWED_ORIGINS=https://app.example.com npm start
# Verify only whitelisted origin is allowed
curl -H "Origin: https://app.example.com" http://localhost:8080/api/v1/health -v
# Should return Access-Control-Allow-Origin: https://app.example.com
# Should also return Access-Control-Allow-Credentials: true
```

**Test 3: Multiple origins**
```bash
NC_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com npm start
# Both origins should be allowed
```

**Test 4: Exposed headers maintained**
All configurations should continue to expose `xc-db-response` header.

## Additional information / screenshots (optional)

**Files modified:**
- New utility: `packages/nocodb/src/utils/nc-config/cors.ts` - Centralizes CORS configuration logic
- Updated all entry points: `main.ts`, `docker.ts`, `dockerEntry.ts`, `cloud.ts`, `local.ts`, `testDocker.ts`
- Added constant: `NC_ALLOWED_ORIGINS` in `constants.ts`

**Security considerations:**
- Backwards compatible: no breaking changes for existing deployments
- Credentials enabled only when specific origins are configured (prevents wildcard + credentials)
- Follows existing NocoDB patterns for environment variable configuration

**Usage examples:**
```bash
# Single origin
NC_ALLOWED_ORIGINS=https://app.example.com

# Multiple origins (comma-separated)
NC_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com

# Explicit wildcard
NC_ALLOWED_ORIGINS=*

# Not set (default - permissive)
# [no configuration needed]
```
