### PR TITLE
fix: add webhook signature validation with HMAC-SHA256

### DIFF
--- a/packages/nocodb/src/controllers/hooks.controller.ts
+++ b/packages/nocodb/src/controllers/hooks.controller.ts
@@ -86,6 +86,23 @@ export class HooksController {
   }
 
   @Post([
+    '/api/v1/db/meta/hooks/:hookId/regenerate-secret',
+    '/api/v2/meta/hooks/:hookId/regenerate-secret',
+  ])
+  @HttpCode(200)
+  @Acl('hookUpdate')
+  async hookRegenerateSecret(
+    @TenantContext() context: NcContext,
+    @Param('hookId') hookId: string,
+    @Req() req: NcRequest,
+  ) {
+    return await this.hooksService.hookRegenerateSecret(context, {
+      hookId,
+      req,
+    });
+  }
+
+  @Post([
     '/api/v1/db/meta/tables/:tableId/hooks/test',
     '/api/v2/meta/tables/:tableId/hooks/test',
   ])

--- a/packages/nocodb/src/meta/migrations/XcMigrationSourcev2.ts
+++ b/packages/nocodb/src/meta/migrations/XcMigrationSourcev2.ts
@@ -78,6 +78,8 @@ import * as nc_088_add_sso_client_to_api_tokens from '~/meta/migrations/v2/nc_08
 import * as nc_089_dashboard_sharing from '~/meta/migrations/v2/nc_089_dashboard_sharing';
 import * as nc_090_add_is_new_user_to_users from '~/meta/migrations/v2/nc_090_add_is_new_user_to_users';
 import * as nc_091_unify_model from '~/meta/migrations/v2/nc_091_unify_model';
+import * as nc_092_composite_pk from '~/meta/migrations/v2/nc_092_composite_pk';
+import * as nc_093_webhook_signing_secrets from '~/meta/migrations/v2/nc_093_webhook_signing_secrets';
 
 // Create a custom migration source class
 export default class XcMigrationSourcev2 {
@@ -167,6 +169,8 @@ export default class XcMigrationSourcev2 {
       'nc_089_dashboard_sharing',
       'nc_090_add_is_new_user_to_users',
       'nc_091_unify_model',
+      'nc_092_composite_pk',
+      'nc_093_webhook_signing_secrets',
     ]);
   }
 
@@ -336,6 +340,10 @@ export default class XcMigrationSourcev2 {
         return nc_090_add_is_new_user_to_users;
       case 'nc_091_unify_model':
         return nc_091_unify_model;
+      case 'nc_092_composite_pk':
+        return nc_092_composite_pk;
+      case 'nc_093_webhook_signing_secrets':
+        return nc_093_webhook_signing_secrets;
     }
   }
 }

--- a/packages/nocodb/src/meta/migrations/v2/nc_093_webhook_signing_secrets.ts
+++ b/packages/nocodb/src/meta/migrations/v2/nc_093_webhook_signing_secrets.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+import { MetaTable } from '~/utils/globals';
+
+const up = async (knex: Knex) => {
+  await knex.schema.alterTable(MetaTable.HOOKS, (table) => {
+    table.text('signing_secret');
+    table.timestamp('signing_secret_updated_at');
+  });
+};
+
+const down = async (knex: Knex) => {
+  await knex.schema.alterTable(MetaTable.HOOKS, (table) => {
+    table.dropColumn('signing_secret');
+    table.dropColumn('signing_secret_updated_at');
+  });
+};
+
+export { up, down };

--- a/packages/nocodb/src/utils/webhook-signature.ts
+++ b/packages/nocodb/src/utils/webhook-signature.ts
@@ -1,0 +1,93 @@
+import crypto from 'crypto';
+
+/**
+ * Generate HMAC-SHA256 signature for webhook payload
+ * Follows industry standard similar to GitHub, Stripe webhooks
+ *
+ * @param payload - The webhook payload (object or string)
+ * @param secret - The signing secret
+ * @param timestamp - Unix timestamp in seconds
+ * @returns Hex string signature, or null if secret is missing
+ */
+export function generateWebhookSignature(
+  payload: string | object,
+  secret: string,
+  timestamp: number,
+): string | null {
+  if (!secret) {
+    return null;
+  }
+
+  try {
+    // Convert payload to string if it's an object
+    const payloadString =
+      typeof payload === 'string' ? payload : JSON.stringify(payload);
+
+    // Create signed payload: timestamp.payload
+    const signedPayload = `${timestamp}.${payloadString}`;
+
+    // Generate HMAC-SHA256 signature
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(signedPayload, 'utf8')
+      .digest('hex');
+
+    return signature;
+  } catch (e) {
+    // If signature generation fails, return null to allow webhook delivery
+    return null;
+  }
+}
+
+/**
+ * Verify webhook signature (for testing/validation)
+ *
+ * @param payload - The webhook payload (object or string)
+ * @param signature - The signature to verify
+ * @param secret - The signing secret
+ * @param timestamp - Unix timestamp in seconds
+ * @param toleranceSeconds - Time tolerance for replay attack prevention (default: 5 minutes)
+ * @returns True if signature is valid and timestamp is fresh
+ */
+export function verifyWebhookSignature(
+  payload: string | object,
+  signature: string,
+  secret: string,
+  timestamp: number,
+  toleranceSeconds: number = 300, // 5 minutes
+): boolean {
+  if (!secret || !signature) {
+    return false;
+  }
+
+  try {
+    // Check timestamp freshness to prevent replay attacks
+    const currentTime = Math.floor(Date.now() / 1000);
+    if (Math.abs(currentTime - timestamp) > toleranceSeconds) {
+      return false;
+    }
+
+    // Compute expected signature
+    const expectedSignature = generateWebhookSignature(
+      payload,
+      secret,
+      timestamp,
+    );
+
+    // Constant-time comparison to prevent timing attacks
+    if (
+      !expectedSignature ||
+      signature.length !== expectedSignature.length ||
+      signature.length === 0
+    ) {
+      return false;
+    }
+
+    return crypto.timingSafeEqual(
+      Buffer.from(signature, 'hex'),
+      Buffer.from(expectedSignature, 'hex'),
+    );
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Vulnerability identified and PR provided by [Kolega.dev](http://kolega.dev/) (https://kolega.dev/)

- Add signing_secret and signing_secret_updated_at columns to hooks table
- Implement HMAC-SHA256 signature generation for webhook payloads
- Add signature headers (x-nc-webhook-id, x-nc-webhook-signature, x-nc-webhook-timestamp)
- Auto-generate signing secrets for new webhooks with encryption support
- Add API endpoint to regenerate webhook secrets
- Maintain backward compatibility for existing webhooks without secrets
- Sanitize hook list responses to prevent secret exposure

## Change Summary

Implements webhook signature validation to resolve CWE-345 (Insufficient Verification of Data Authenticity). This enhancement allows webhook receivers to verify that requests genuinely originate from their NocoDB instance and prevents replay attacks.

**Key Changes:**
- Added HMAC-SHA256 signature generation for all webhook payloads
- Auto-generate and encrypt signing secrets for new webhooks
- Added three signature headers: `x-nc-webhook-id`, `x-nc-webhook-signature`, `x-nc-webhook-timestamp`
- Added API endpoint to regenerate webhook secrets: `POST /api/v2/meta/hooks/:hookId/regenerate-secret`
- Maintained full backward compatibility - existing webhooks continue working without modification

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

### Verification Steps:

1. **New Webhooks:**
   - Create a new webhook via API or UI
   - Verify `signing_secret` is returned in the response
   - Trigger the webhook and verify headers are present:
     - `x-nc-webhook-id`
     - `x-nc-webhook-signature`
     - `x-nc-webhook-timestamp`

2. **Secret Regeneration:**
   - Call `POST /api/v2/meta/hooks/:hookId/regenerate-secret`
   - Verify new secret is returned
   - Verify subsequent webhook requests use the new secret

3. **Backward Compatibility:**
   - Verify existing webhooks without secrets continue working
   - Verify no signature headers are added for webhooks without secrets

4. **Signature Validation (Receiver Side):**
   ```javascript
   const crypto = require('crypto');

   function verifyWebhook(payload, signature, secret, timestamp) {
     const signedPayload = `${timestamp}.${JSON.stringify(payload)}`;
     const expectedSig = crypto.createHmac('sha256', secret)
       .update(signedPayload, 'utf8')
       .digest('hex');

     return crypto.timingSafeEqual(
       Buffer.from(signature, 'hex'),
       Buffer.from(expectedSig, 'hex')
     );
   }
   ```

## Additional information / screenshots (optional)

**Security Features:**
- Secrets are encrypted using existing `NC_CONNECTION_ENCRYPT_KEY` infrastructure
- HMAC-SHA256 prevents tampering with webhook payloads
- Timestamp in signature prevents replay attacks (5-minute tolerance)
- Constant-time comparison prevents timing attacks
- Secrets are sanitized from list responses (only `has_signing_secret` flag exposed)

**Migration:**
- Database migration `nc_093_webhook_signing_secrets` adds two columns to `nc_hooks_v2` table
- Migration runs automatically on startup

**Follows Industry Standards:**
- Signature algorithm matches GitHub, Stripe, and other major webhook providers
- Secret only returned on webhook creation or regeneration (not in list/get endpoints)

