### PR TITLE
fix: V2 - properly validate WebSocket authentication in gateway middleware

### DIFF
--- a/packages/nocodb/src/gateways/socket.gateway.ts
+++ b/packages/nocodb/src/gateways/socket.gateway.ts
@@ -53,10 +53,16 @@ export class SocketGateway implements OnModuleInit {
         try {
           const context = new ExecutionContextHost([socket.handshake as any]);
           const guard = new (AuthGuard('jwt'))(context);
-          await guard.canActivate(context);
-        } catch {}
+          const canActivate = await guard.canActivate(context);
 
-        next();
+          if (canActivate) {
+            next();
+          } else {
+            next(new Error('Unauthorized'));
+          }
+        } catch (error) {
+          next(new Error('Unauthorized'));
+        }
       })
       .on('connection', (socket) => {
         this.clients[socket.id] = socket;


### PR DESCRIPTION
Previously, the WebSocket authentication middleware had an empty catch block that allowed all connections to proceed regardless of authentication status. This created a critical security vulnerability (CWE-287) where unauthenticated users could establish WebSocket connections and access real-time data.

Changes:
- Capture and check the return value of guard.canActivate()
- Only call next() if authentication succeeds
- Reject connections with 'Unauthorized' error on auth failure
- Properly handle exceptions by rejecting the connection

This ensures that only authenticated clients can establish WebSocket connections.

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
