### PR TITLE
fix(security): V3 - add SSRF protection to attachment URL upload

### DIFF
--- a/packages/nocodb/src/services/v3/data-attachment-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-attachment-v3.service.ts
@@ -4,6 +4,7 @@ import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import axios from 'axios';
 import { nanoid } from 'nanoid';
 import { AuditV1OperationTypes, EventType, ncIsNull } from 'nocodb-sdk';
+import { useAgent } from 'request-filtering-agent';
 import slash from 'slash';
 import type { DataUpdatePayload, NcContext } from 'nocodb-sdk';
 import type { AttachmentFilePathConstructed } from '~/helpers/attachmentHelpers';
@@ -376,6 +377,17 @@ export class DataAttachmentV3Service {
       responseType: 'stream',
       maxRedirects: NC_ATTACHMENT_URL_MAX_REDIRECT,
       maxContentLength: NC_ATTACHMENT_FIELD_SIZE,
+      ...(process.env.NC_ALLOW_LOCAL_HOOKS !== 'true'
+        ? {
+            httpAgent: useAgent(url, {
+              stopPortScanningByUrlRedirection: true,
+            }),
+            httpsAgent: useAgent(url, {
+              stopPortScanningByUrlRedirection: true,
+            }),
+          }
+        : {}),
+      timeout: 30 * 1000,
     });
 
     // Extract file information from response headers


### PR DESCRIPTION
# Security Disclosure Notice

This PR addresses a security vulnerability identified by **Kolega.dev** as part of our automated security remediation platform validation.

## Disclosure Timeline:
- **December 10, 2025**: Initial responsible disclosure sent to security@nocodb.com with full technical details, reproduction steps, and proposed fixes
- **December 16, 2025**: Follow-up sent noting the approaching 7-day SLA
- **December 19, 2025**: No acknowledgment received; PR submitted publicly per standard responsible disclosure practices

We attempted to coordinate privately through NocoDB's official security reporting channel. After exceeding the published response SLA without acknowledgment, we are proceeding with public disclosure to ensure the community can protect their deployments.


*Vulnerability identified and fix provided by **[Kolega.dev](http://kolega.dev/) (https://kolega.dev/)***

## Change Summary

Add SSRF protection to attachment URL upload functionality by integrating `request-filtering-agent` in the `downloadAndStoreAttachment` function. This blocks requests to private IP ranges and cloud metadata endpoints, preventing Server-Side Request Forgery attacks when users upload attachments via URL.

The implementation follows the existing pattern used in webhook-invoker and respects the `NC_ALLOW_LOCAL_HOOKS` environment variable for development/testing scenarios.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Verify attachment uploads from public URLs continue to work normally
- Confirm requests to private IP ranges (127.0.0.1, 192.168.x.x, 10.x.x.x, etc.) are blocked
- Confirm requests to cloud metadata endpoints (169.254.169.254) are blocked
- Verify `NC_ALLOW_LOCAL_HOOKS=true` allows local URL access for development scenarios
- Test with URL redirects to ensure protection against redirect-based SSRF

## Additional information / screenshots (optional)

Security enhancement that follows the existing security pattern in the codebase. Added 30-second timeout for attachment downloads to prevent hanging requests.
