### PR TITLE
fix(security): V4 - apply SSRF protection to axios.head() in uploadViaURL

### DIFF
--- a/packages/nocodb/src/services/attachments.service.ts
+++ b/packages/nocodb/src/services/attachments.service.ts
@@ -8,6 +8,7 @@ import mime from 'mime/lite';
 import slash from 'slash';
 import PQueue from 'p-queue';
 import axios from 'axios';
+import { useAgent } from 'request-filtering-agent';
 import hash from 'object-hash';
 import moment from 'moment';
 import type { AttachmentReqType, FileType } from 'nocodb-sdk';
@@ -284,7 +285,15 @@ export class AttachmentsService {
           let base64Buffer: Buffer;
 
           if (!url.startsWith('data:')) {
-            response = await axios.head(url, { maxRedirects: 5 });
+            response = await axios.head(url, {
+              maxRedirects: 5,
+              httpAgent: useAgent(url, {
+                stopPortScanningByUrlRedirection: true,
+              }),
+              httpsAgent: useAgent(url, {
+                stopPortScanningByUrlRedirection: true,
+              }),
+            });
             mimeType = response.headers['content-type']?.split(';')[0];
             size = response.headers['content-length'];
             finalUrl = response.request.res.responseUrl;


### PR DESCRIPTION
# Security Disclosure Notice

This PR addresses a security vulnerability identified by **Kolega.dev** as part of our automated security remediation platform validation.

## Disclosure Timeline:
- **December 10, 2025**: Initial responsible disclosure sent to security@nocodb.com with full technical details, reproduction steps, and proposed fixes
- **December 16, 2025**: Follow-up sent noting the approaching 7-day SLA
- **December 19, 2025**: No acknowledgment received; PR submitted publicly per standard responsible disclosure practices

We attempted to coordinate privately through NocoDB's official security reporting channel. After exceeding the published response SLA without acknowledgment, we are proceeding with public disclosure to ensure the community can protect their deployments.


*Vulnerability identified and fix provided by **[Kolega.dev](http://kolega.dev/) (https://kolega.dev/)***

## Change Summary

Applied SSRF protection to `axios.head()` request in `uploadViaURL()` method. Added `useAgent` with `stopPortScanningByUrlRedirection` to prevent Server-Side Request Forgery attacks via redirect chains to internal hosts.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Verify file upload via URL continues to work normally with valid external URLs
- Confirm that attempts to access internal/private IP addresses via URL redirects are blocked
- Test with various redirect scenarios (301, 302, etc.) to ensure SSRF protection is active

## Additional information / screenshots (optional)

This change aligns the `axios.head()` call with other axios requests in the codebase that already use `useAgent` for SSRF protection. The protection specifically guards against port scanning and internal network access via URL redirect chains.

