### PR TITLE
fix tsconfig for eslint

### DIFF
--- a/packages/nocodb/tsconfig.json
+++ b/packages/nocodb/tsconfig.json
@@ -31,5 +31,5 @@
     "typeRoots": ["src/types", "node_modules/@types"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/ee", "src/ee-on-prem", "src/ee-cloud", "**/*.spec.ts"]
+  "exclude": ["src/ee", "src/ee-on-prem", "src/ee-cloud"]
 }


### PR DESCRIPTION
## Change Summary

I'm trying to run `eslint "src/**/*.ts"`, but I received such an error:

```
0:0 error Parsing error: ESLint was configured to run on <tsconfigRootDir>/src/controllers/api-docs/api-docs.controller.spec.ts using `parserOptions.project`: /users/aoriekhov/git/personal/nocodb/packages/nocodb/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```



## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
