### PR TITLE
chore: fix typo in swagger spec

### DIFF
--- a/packages/nocodb/src/schema/swagger-v3.json
+++ b/packages/nocodb/src/schema/swagger-v3.json
@@ -7560,7 +7560,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7592,7 +7592,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7624,7 +7624,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 },
                 "required": [
@@ -7659,7 +7659,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 },
                 "required": [
@@ -7703,7 +7703,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7729,7 +7729,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7755,7 +7755,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7781,7 +7781,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               }
@@ -7865,7 +7865,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7897,7 +7897,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 }
               },
@@ -7929,7 +7929,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 },
                 "required": [
@@ -7964,7 +7964,7 @@
                   },
                   "row_coloring": {
                     "$ref": "#/components/schemas/ViewRowColour",
-                    "description": "Row colour configuration for the the view."
+                    "description": "Row colour configuration for the view."
                   }
                 },
                 "required": [


### PR DESCRIPTION
## Summary

Fix typo in swagger-v3.json API documentation:

- `the the view` → `the view` (12 occurrences)

This corrects the row colour configuration description for all view types.