### PR TITLE
feat(nc-gui): Rollup formatting

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
@@ -556,6 +556,18 @@ const handleScrollIntoView = () => {
               v-else-if="vModel.meta.display_type === UITypes.Rating"
               :value="vModel.meta.display_column_meta"
             />
+            <SmartsheetColumnTimeOptions
+              v-else-if="vModel.meta.display_type === UITypes.Time"
+              :value="vModel.meta.display_column_meta"
+            />
+            <SmartsheetColumnDateTimeOptions
+              v-else-if="vModel.meta.display_type === UITypes.DateTime"
+              :value="vModel.meta.display_column_meta"
+            />
+            <SmartsheetColumnDateOptions
+              v-else-if="vModel.meta.display_type === UITypes.Date"
+              :value="vModel.meta.display_column_meta"
+            />
             <SmartsheetColumnDecimalOptions
               v-else-if="rollupResultType === FormulaDataTypes.NUMERIC"
               :value="vModel"

--- a/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
+++ b/packages/nc-gui/components/smartsheet/column/RollupOptions.vue
@@ -225,17 +225,11 @@ watch(
   },
 )
 
-
-
 // set default value
 vModel.value.meta = {
   ...ColumnHelper.getColumnDefaultMeta(UITypes.Rollup),
   ...(vModel.value.meta || {}),
 }
-
-const { isMetaReadOnly } = useRoles()
-
-
 
 const activeKey = ref('rollup')
 
@@ -257,13 +251,9 @@ const rollupResultType = computed(() => {
   if (!childCol) return FormulaDataTypes.UNKNOWN
 
   if (
-    [
-      UITypes.Date,
-      UITypes.DateTime,
-      UITypes.Time,
-      UITypes.CreatedTime,
-      UITypes.LastModifiedTime,
-    ].includes(childCol.uidt as UITypes)
+    [UITypes.Date, UITypes.DateTime, UITypes.Time, UITypes.CreatedTime, UITypes.LastModifiedTime].includes(
+      childCol.uidt as UITypes,
+    )
   ) {
     return FormulaDataTypes.DATE
   }
@@ -568,10 +558,9 @@ const handleScrollIntoView = () => {
               v-else-if="vModel.meta.display_type === UITypes.Date"
               :value="vModel.meta.display_column_meta"
             />
-            <SmartsheetColumnDecimalOptions
-              v-else-if="rollupResultType === FormulaDataTypes.NUMERIC"
-              :value="vModel"
-            />
+            <!-- Default options based on rollup result type when no specific display_type is selected -->
+            <SmartsheetColumnDateOptions v-else-if="rollupResultType === FormulaDataTypes.DATE" :value="vModel" />
+            <SmartsheetColumnDecimalOptions v-else-if="rollupResultType === FormulaDataTypes.NUMERIC" :value="vModel" />
           </template>
         </div>
       </a-tab-pane>

--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/Rollup.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/Rollup.ts
@@ -20,6 +20,29 @@ export const RollupCellRenderer: CellRenderer = {
 
     const colOptions = column.colOptions as RollupType
 
+    // Check if the rollup column itself has a display_type set
+    const rollupColMeta = parseProp(column?.meta)
+    if (rollupColMeta?.display_type) {
+      // display_column_meta contains the format-specific settings (e.g., {meta: {currency_code, currency_locale}})
+      const displayColumnMeta = rollupColMeta.display_column_meta || {}
+      const renderProps: CellRendererOptions = {
+        ...props,
+        column: {
+          ...column,
+          uidt: rollupColMeta.display_type,
+          // Extract the nested meta from display_column_meta for cell renderers to read
+          meta: {
+            ...parseProp(displayColumnMeta.meta),
+            ...parseProp(displayColumnMeta.custom),
+          },
+        },
+        readonly: true,
+        formula: true,
+      }
+      renderCell(ctx, renderProps.column, renderProps)
+      return
+    }
+
     const relatedColObj = getMetaWithCompositeKey(metas, meta?.base_id, column.fk_model_id)?.columns?.find(
       (c: any) => c.id === colOptions?.fk_relation_column_id,
     ) as ColumnType

--- a/packages/nc-gui/components/virtual-cell/Rollup.vue
+++ b/packages/nc-gui/components/virtual-cell/Rollup.vue
@@ -47,11 +47,37 @@ const childColumn = computed(() => {
 const renderAsTextFun = computed(() => {
   return getRenderAsTextFunForUiType(childColumn.value?.uidt || UITypes.SingleLineText)
 })
+
+// Computed to create updated column with display_type for custom formatting
+const updatedColumn = computed(() => {
+  const colMeta = parseProp(column.value?.meta)
+  if (colMeta?.display_type) {
+    // display_column_meta contains the format-specific settings (e.g., {meta: {currency_code, currency_locale}})
+    const displayColumnMeta = colMeta.display_column_meta || {}
+    return {
+      ...column.value,
+      uidt: colMeta.display_type,
+      // Extract the nested meta from display_column_meta for cell components to read
+      meta: {
+        ...parseProp(displayColumnMeta.meta),
+        ...parseProp(displayColumnMeta.custom),
+      },
+    }
+  }
+  return undefined
+})
+
+// Determine if we should render using FormulaWrapperCell with custom formatting
+const renderAsCell = computed(() => {
+  const colMeta = parseProp(column.value?.meta)
+  return !!colMeta?.display_type
+})
 </script>
 
 <template>
   <div @dblclick="activateShowEditNonEditableFieldWarning">
-    <CellDecimal v-if="renderAsTextFun.includes((colOptions as RollupType).rollup_function!)" :model-value="value" />
+    <LazySmartsheetFormulaWrapperCell v-if="renderAsCell" :column="updatedColumn" />
+    <CellDecimal v-else-if="renderAsTextFun.includes((colOptions as RollupType).rollup_function!)" :model-value="value" />
     <LazySmartsheetCell v-else v-model="value" :column="childColumn" :edit-enabled="false" :read-only="true" />
     <div v-if="showEditNonEditableFieldWarning" class="text-left text-wrap mt-2 text-[#e65100] text-xs">
       {{ $t('msg.info.computedFieldEditWarning') }}


### PR DESCRIPTION
## Change Summary

Add custom formatting options to Rollup columns. Users can now choose how to display Rollup results by selecting from different display types. Instead of having only `$` currency output, now user can choose his own currency, is own date format

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

1. Go to edit fields that is Rollup and choose one formating

## Additional information / screenshots (optional)

I created this PR to resolve my own issue #12887

### Currency example
<img width="826" height="606" alt="image" src="https://github.com/user-attachments/assets/5469091e-58b4-4426-84f1-b0d427c37905" />
<img width="830" height="730" alt="image" src="https://github.com/user-attachments/assets/b21a3f2b-fbce-4d7f-8ea0-786fcf2a12be" />

### Date time example
<img width="832" height="643" alt="image" src="https://github.com/user-attachments/assets/01422995-9257-4ecb-bd8a-13d774442162" />