### PR TITLE
fix: mcp queryRecords tools schema error & data-v3 validateDataListQueryParams support mcp sort (array type)

### DIFF
--- a/packages/nocodb/src/mcp/mcp.service.ts
+++ b/packages/nocodb/src/mcp/mcp.service.ts
@@ -206,7 +206,7 @@ export class McpService {
             .array(
               z.object({
                 field: z.string().describe('Field Name'),
-                description: z.enum(['asc', 'desc']).describe('Sort Direction'),
+                direction: z.enum(['asc', 'desc']).describe('Sort Direction'),
               }),
             )
             .optional(),

--- a/packages/nocodb/src/services/v3/data-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-v3.service.ts
@@ -320,22 +320,29 @@ export class DataV3Service {
   ) {
     const columns = param.modelInfo.columns;
     if (param.query.sort) {
+      
       let fieldsArr: string[] = [];
-      if (typeof param.query.sort !== 'string') {
-        NcError.get(context).invalidRequestBody(
-          `Query parameter 'sort' needs to be a single string`,
-        );
-      }
-      let parsedSort: any | any[];
+      let parsedSort: any[] = [];
+
       try {
-        const parsedSortJSON = JSON.parse(param.query.sort);
-        parsedSort = Array.isArray(parsedSortJSON)
-          ? parsedSortJSON
-          : [parsedSortJSON];
+        if (typeof param.query.sort === 'string') {
+          const parsed = JSON.parse(param.query.sort);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            parsedSort = [parsed];
+          } else if (Array.isArray(parsed)) {
+            parsedSort = parsed;
+          } else {
+            throw new Error('Invalid sort format');
+          }
+        } else if (Array.isArray(param.query.sort)) {
+          parsedSort = param.query.sort;
+        } else if (param.query.sort && typeof param.query.sort === 'object') {
+          parsedSort = [param.query.sort];
+        }
         fieldsArr = parsedSort.map((s) => s.field);
       } catch {
         NcError.get(context).invalidRequestBody(
-          `Query parameter 'sort' needs to a JSON string in format of [{"field": "fieldId", "direction": "asc"}]`,
+          `Query parameter 'sort' needs to be a JSON string, object, or array in format [{"field": "fieldId", "direction": "asc"}]`,
         );
       }
       if (

--- a/packages/nocodb/src/services/v3/data-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-v3.service.ts
@@ -320,7 +320,6 @@ export class DataV3Service {
   ) {
     const columns = param.modelInfo.columns;
     if (param.query.sort) {
-      
       let fieldsArr: string[] = [];
       let parsedSort: any[] = [];
 


### PR DESCRIPTION
mcp queryRecords tools schema error & data-v3 validateDataListQ
## Change Summary

mcp queryRecords tools schema error & data-v3 validateDataListQueryParams support mcp sort (array type)

## Change type

- [x] fix: (bug fix  for mcp queryRecords tools schema error & data-v3 validateDataListQueryParams support mcp sort (array type))
