### PR TITLE
Add NC_SMTP_FROM_DOMAIN env variable for SMTP plugin

### DIFF
--- a/packages/nocodb/src/helpers/NcPluginMgrv2.ts
+++ b/packages/nocodb/src/helpers/NcPluginMgrv2.ts
@@ -174,6 +174,7 @@ class NcPluginMgrv2 {
           from: process.env.NC_SMTP_FROM,
           host: process.env.NC_SMTP_HOST,
           port: process.env.NC_SMTP_PORT,
+          name: process.env.NC_SMTP_FROM_DOMAIN,
           username: process.env.NC_SMTP_USERNAME,
           password: process.env.NC_SMTP_PASSWORD,
           secure: process.env.NC_SMTP_SECURE === 'true',


### PR DESCRIPTION
Description:

## Change Summary

The SMTP plugin UI exposes a "From domain" field (`name`), used by nodemailer for the EHLO/HELO greeting. However, this field was missing from the env-based SMTP configuration, meaning it could only be set through the UI.

This adds `NC_SMTP_FROM_DOMAIN` to the env-based SMTP setup in `NcPluginMgrv2.initPluginsFromEnv()`. When not set, nodemailer falls back to `os.hostname()` as before.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

1. Set `NC_SMTP_FROM`, `NC_SMTP_HOST`, `NC_SMTP_PORT`, and `NC_SMTP_FROM_DOMAIN` env variables
2. Start NocoDB — verify the SMTP plugin is active with the "From domain" field populated
3. Send a test email and confirm the EHLO/HELO uses the configured domain

## Additional information / screenshots (optional)

Optional env variable — no breaking changes. Existing deployments without `NC_SMTP_FROM_DOMAIN` will continue to work with nodemailer's default (`os.hostname()`).