### PR TITLE
fix: comment count badges missing in grouped view and after refresh

### DIFF
--- a/packages/nc-gui/composables/useInfiniteData.ts
+++ b/packages/nc-gui/composables/useInfiniteData.ts
@@ -587,18 +587,34 @@ export function useInfiniteData(args: {
         ids,
       })
 
+      const idToRowMap = new Map<string, Row>()
       formattedData.forEach((row) => {
-        const cachedRow = Array.from(dataCache.cachedRows.value.values()).find(
-          (cachedRow) => cachedRow.rowMeta.rowIndex === row.rowMeta.rowIndex,
-        )
-        if (!cachedRow) return
-
         const id = extractPkFromRow(row.row, meta.value?.columns as ColumnType[])
-        const count = aggCommentCount?.find((c: Record<string, any>) => c.row_id === id)?.count || 0
-        cachedRow.rowMeta.commentCount = +count
+        if (id) {
+          idToRowMap.set(String(id), row)
+        }
       })
 
-      // Trigger re-render canvas to update the comment count
+      aggCommentCount?.forEach((commentData: Record<string, any>) => {
+        const rowId = String(commentData.row_id)
+        const count = +commentData.count || 0
+
+        const formattedRow = idToRowMap.get(rowId)
+        if (formattedRow) {
+          formattedRow.rowMeta.commentCount = count
+        }
+
+        const cachedRow = Array.from(dataCache.cachedRows.value.values()).find(
+          (cachedRow) => {
+            const cachedId = extractPkFromRow(cachedRow.row, meta.value?.columns as ColumnType[])
+            return cachedId && String(cachedId) === rowId
+          },
+        )
+        if (cachedRow) {
+          cachedRow.rowMeta.commentCount = count
+        }
+      })
+
       eventBus.emit(SmartsheetStoreEvents.TRIGGER_RE_RENDER)
     } catch (e) {
       console.error('Failed to load aggregate comment count:', e)
@@ -675,7 +691,7 @@ export function useInfiniteData(args: {
       const data = formatData(response.list, response.pageInfo, params, path, getEvaluatedRowMetaRowColorInfo)
 
       if (!disableSmartsheet) {
-        loadAggCommentsCount(data, path)
+        await loadAggCommentsCount(data, path)
       }
 
       return data


### PR DESCRIPTION
## Description

Fix comment count badges not appearing in grouped views and disappearing after page refresh.

## Change Summary

- Fix badge not appearing in grouped views by matching rows by ID instead of rowIndex
- Fix badge disappearing after page refresh by awaiting loadAggCommentsCount
- Update both formattedData and cachedRows to ensure badges persist correctly

Fixes comment count badge visibility issues in both grouped and ungrouped grid views.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

**Case 1: Grouped View - Badge Not Appearing**
1. Open a table with Grid view
2. Enable "Group By" on any column
3. Expand a group and open a row (expanded form)
4. Add a comment to the row
5. Close the expanded form
6. ✅ **Verified**: Badge now appears correctly on the row

**Case 2: Ungrouped View - Badge Disappearing on Refresh**
1. Open the same table with Grid view (no Group By)
2. Open a row (expanded form)
3. Add a comment to the row
4. Close the expanded form
5. Badge appears correctly
6. Refresh the page (F5)
7. ✅ **Verified**: Badge persists after refresh

**Root Cause:**
- `loadAggCommentsCount` was matching rows by `rowMeta.rowIndex`, which fails when groups load asynchronously
- `loadAggCommentsCount` was called but not awaited, causing race conditions where comment counts weren't loaded before rendering

**Solution:**
- Changed row matching from `rowIndex` to row ID (primary key) for reliable matching across async operations
- Added `await` to ensure comment counts load before data is returned
- Update both `formattedData` and `cachedRows` to ensure badges appear correctly in all scenarios

## Additional information / screenshots (optional)

**Files Changed:**
- `packages/nc-gui/composables/useInfiniteData.ts`

**Technical Details:**
- Modified `loadAggCommentsCount` function to use ID-based matching instead of rowIndex
- Added `await` keyword before `loadAggCommentsCount` call in `loadData` function
- Ensures comment count badges work correctly in both canvas (infinite scroll) and grouped views

**Backward Compatibility:**
- Changes are backward compatible
- No breaking changes to existing functionality
- Only improves reliability of comment count badge display