### PR TITLE
fix: respect requested fields in shared form linked record list

### DIFF
--- a/packages/nocodb/src/services/public-datas.service.ts
+++ b/packages/nocodb/src/services/public-datas.service.ts
@@ -654,7 +654,7 @@ export class PublicDatasService {
     const { ast, dependencyFields } = await getAst(context, {
       query: param.query,
       model,
-      extractOnlyPrimaries: true,
+      extractOnlyPrimaries: !(param.query?.f || param.query?.fields),
     });
 
     const listArgs: DependantFields & {
@@ -666,16 +666,6 @@ export class PublicDatasService {
       if (listArgs.filterArrJson)
         listArgs.filterArr = JSON.parse(listArgs.filterArrJson) as Filter[];
     } catch (e) {}
-
-    if (view.type === ViewTypes.FORM && ncIsArray(param.query?.fields)) {
-      param.query.fields.forEach(listArgs.fieldsSet.add, listArgs.fieldsSet);
-
-      param.query.fields.forEach((f) => {
-        if (ast[f] === undefined) {
-          ast[f] = 1;
-        }
-      });
-    }
 
     let data = [];
 


### PR DESCRIPTION
## Change Summary

Fix linked record fields showing "-" and missing attachment images in shared form views.

In the public `relDataList` endpoint, `extractOnlyPrimaries` was hardcoded to `true`, causing `getAst` to return only primary key and display value columns — ignoring the fields requested by the frontend. This made shared forms show "-" for extra fields (number, date, currency) and no attachment images in the linked record picker, while the form builder preview worked correctly.

The fix aligns with the existing authenticated API pattern in `data-table.service.ts` by conditionally setting `extractOnlyPrimaries` based on whether fields are explicitly requested. Also removes an unreachable dead code block that attempted to patch the AST after early return.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

1. Create Table A with Text, Number, Date, Currency, and Attachment fields. Add records with data and images.
2. Create Table B with a Links field pointing to Table A.
3. Create a Form view on Table B.
4. Click the Links field in the form builder, enable **"Show Extra Fields"** in the right sidebar.
5. Verify extra fields and attachment images display correctly in the form builder preview.
6. Share the form, open the link in an incognito browser.
7. Click the Links field — extra fields now show actual values and attachment images display correctly.

## Additional information / screenshots (optional)

**File changed:** `packages/nocodb/src/services/public-datas.service.ts`

**Before:** `extractOnlyPrimaries: true` (hardcoded)
**After:** `extractOnlyPrimaries: !(param.query?.f || param.query?.fields)` (matches `data-table.service.ts:473` pattern)

## Issue: #13030
