### PR TITLE
fix: parallelize row resolution in nocoExecute to enable DataLoader batching

### DIFF
--- a/packages/nocodb/src/utils/nocoExecute.ts
+++ b/packages/nocodb/src/utils/nocoExecute.ts
@@ -33,17 +33,15 @@ const nocoExecute = async (
   dataTree = {},
   rootArgs = null,
 ): Promise<any> => {
-  // Handle array of resolvers by executing nocoExecute on each sequentially
+  // Handle array of resolvers in parallel so DataLoader can batch all IDs
+  // in a single event-loop tick instead of firing one query per row
   if (Array.isArray(resolverObj)) {
-    const res = [];
-    for (let i = 0; i < resolverObj.length; i++) {
-      const resolver = resolverObj[i];
-      dataTree[i] = dataTree[i] || {};
-      res.push(
-        await nocoExecuteSingle(requestObj, resolver, dataTree[i], rootArgs),
-      );
-    }
-    return res;
+    return Promise.all(
+      resolverObj.map((resolver, i) => {
+        dataTree[i] = dataTree[i] || {};
+        return nocoExecuteSingle(requestObj, resolver, dataTree[i], rootArgs);
+      }),
+    );
   } else {
     return nocoExecuteSingle(requestObj, resolverObj, dataTree, rootArgs);
   }
@@ -106,11 +104,9 @@ const nocoExecuteSingle = async (
         : Promise.resolve(dataTreeObj[path[0]]));
 
       if (Array.isArray(res1)) {
-        const res = [];
-        for (let i = 0; i < res1.length; i++) {
-          res.push(await extractNested(path.slice(1), res1[i], {}, args));
-        }
-        return res;
+        return Promise.all(
+          res1.map((item) => extractNested(path.slice(1), item, {}, args)),
+        );
       } else {
         return res1 !== null && res1 !== undefined
           ? await extractNested(path.slice(1), res1, {}, args)
@@ -177,28 +173,25 @@ const nocoExecuteSingle = async (
       if (res[key]) {
         const res1 = await res[key];
         if (Array.isArray(res1)) {
-          // Handle arrays of results by executing nocoExecute on each element sequentially
           dataTree[key] = dataTree[key] || [];
-          res[key] = [];
-          for (let i = 0; i < res1.length; i++) {
-            const r = res1[i];
-            dataTree[key][i] = dataTree[key][i] || {};
-
-            res[key].push(
-              (dataTree[key][i] = await nocoExecute(
+          const nestedArgs = Object.assign(
+            {
+              nestedPage: rootArgs?.nestedPage,
+              limit: rootArgs?.nestedLimit,
+            },
+            rootArgs?.nested?.[key] || {},
+          );
+          res[key] = Promise.all(
+            res1.map((r, i) => {
+              dataTree[key][i] = dataTree[key][i] || {};
+              return nocoExecute(
                 requestObj[key] as XcRequest,
                 r,
                 dataTree[key][i],
-                Object.assign(
-                  {
-                    nestedPage: rootArgs?.nestedPage,
-                    limit: rootArgs?.nestedLimit,
-                  },
-                  rootArgs?.nested?.[key] || {},
-                ),
-              )),
-            );
-          }
+                nestedArgs,
+              ).then((v) => (dataTree[key][i] = v));
+            }),
+          );
         } else if (res1) {
           // Handle single objects
           res[key] = await nocoExecute(


### PR DESCRIPTION
## Change Summary

Fixes #13231

Grid views with Links/Lookup columns suffer from a performance bottleneck caused by sequential `await` in for-loops inside `nocoExecute`. This yields the event loop between each row, preventing DataLoader from accumulating more than 1 ID per batch — resulting in one SQL query per row per linked column.

This PR replaces three sequential for/await loops with `Promise.all` so all promises fire in the same event-loop tick, enabling the existing DataLoader + `UNION ALL` batch infrastructure (`multipleHmList`/`multipleMmList`) to work as designed.

## Change Type
- [ ] feat
- [x] fix
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [ ] chore

## Test/Verification

Tested locally against a real dataset (Speakers table, ~700 rows, multiple Links/Lookup columns) on NocoDB 0.301.3 with SQLite:

| Version       | Cold  | Warm (avg of 3) |
|---------------|-------|-----------------|
| Stock 0.301.3 | 13.3s | ~13s            |
| With fix      | 2.3s  | 0.45–0.8s       |

API endpoint: `GET /api/v1/db/data/noco/:baseId/:tableId/views/:viewId?offset=0&limit=100`

UI confirmed working — grid view loads correctly with all linked record data intact.

### Why this applies equally (or better) to Postgres

The fix is in `nocoExecute.ts` which is database-agnostic — it controls how promises are scheduled, not how queries are executed. The DataLoader batching and `UNION ALL` queries in `relation-data-fetcher.ts` work identically regardless of DB engine.

The improvement on Postgres is likely larger because each sequential query pays real network round-trip latency. With SQLite (in-process), the per-query overhead is just function call + disk I/O. With Postgres, each of the N×M queries (N rows × M linked columns) pays TCP round-trip time on top of query execution. Batching collapses those into M queries total, eliminating hundreds of network round-trips.

## Additional Information

The fix is low-risk: `multipleHmList`/`multipleMmList` batch functions already handle multiple IDs correctly. The only change is allowing DataLoader to collect those IDs by not yielding the event loop between rows. Memory pressure from concurrent resolution is mitigated by the existing per-column `limit` (default 25) in the UNION ALL queries.