### PR TITLE
fix(nocodb): handle missing FileReference in delete to prevent TypeError

### DIFF
--- a/packages/nocodb/src/models/FileReference.ts
+++ b/packages/nocodb/src/models/FileReference.ts
@@ -136,6 +136,13 @@ export default class FileReference {
         fileReferences[0],
       );
 
+      if (!fileReferenceObj) {
+        logger.warn(
+          `FileReference not found for id ${fileReferences[0]}, skipping delete`,
+        );
+        return;
+      }
+
       await ncMeta.metaUpdate(
         context.workspace_id,
         context.base_id,


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Cannot read properties of undefined (reading 'id')` crash when deleting an attachment from the UI.

**Root cause**: `FileReference.delete()` calls `metaGet2()` to look up a file reference record but doesn't handle the case where the record is not found (returns `null`/`undefined`). When `fileReferenceObj` is `undefined`, accessing `.id` on it crashes the request.

**Fix**: Added a null check after `metaGet2()`. If the file reference is not found, it logs a warning and returns early instead of crashing. This is a graceful degradation — the attachment cell update still succeeds; we just skip the soft-delete of a record that doesn't exist anyway.

## How to reproduce

1. Create a table with an Attachment field
2. Upload a file to the Attachment field in any row
3. Open the cell and try to delete/remove the attachment via the UI
4. Server crashes with:
```
TypeError: Cannot read properties of undefined (reading 'id')
    at FileReference.delete (...)
    at async BaseModelSqlv2.prepareNocoData (...)
    at async BaseModelSqlv2.updateByPk (...)
```

## Changes

- `packages/nocodb/src/models/FileReference.ts`: Added null guard for `fileReferenceObj` in `delete()` method. When a file reference record is not found via `metaGet2()`, the method now logs a warning and returns early instead of throwing.

closes: #13096