### PR TITLE
fix: external PostgreSQL row delete blocked by m2m linked records

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -34,11 +34,11 @@ import {
   ncIsNullOrUndefined,
   ncIsObject,
   ncIsUndefined,
+  parseHelper,
   PermissionEntity,
   PermissionKey,
   RelationTypes,
   UITypes,
-  parseHelper,
 } from 'nocodb-sdk';
 import { v4 as uuidv4 } from 'uuid';
 import debug from 'debug';
@@ -2407,6 +2407,22 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       const colOptions = (await column.getColOptions(
         this.context,
       )) as LinkToAnotherRecordColumn;
+      const relationType = isMMOrMMLike(column) ? 'mm' : colOptions.type;
+      const { refContext } = colOptions.getRelContext(this.context);
+
+      // Many-to-many links are cleaned up via junction-row deletes in delByPk,
+      // so they should not block row deletion in the external DB pre-check.
+      if (relationType === 'mm') {
+        continue;
+      }
+
+      if (relationType === RelationTypes.HAS_MANY) {
+        const relatedTable = await colOptions.getRelatedTable(refContext);
+        if (relatedTable?.mm) {
+          continue;
+        }
+      }
+
       const childColumn = await colOptions.getChildColumn(this.context);
       const parentColumn = await colOptions.getParentColumn(this.context);
       const childModel = await childColumn.getModel(this.context);
@@ -2414,7 +2430,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       const parentModel = await parentColumn.getModel(this.context);
       await parentModel.getColumns(this.context);
       let cnt = 0;
-      if (colOptions.type === RelationTypes.HAS_MANY) {
+      if (relationType === RelationTypes.HAS_MANY) {
         cnt = +(
           await this.execAndParse(
             this.dbDriver(this.getTnPath(childModel.table_name))


### PR DESCRIPTION
## Change Summary

Fixes issue where deleting rows in an external PostgreSQL base failed when rows had linked records through many-to-many or junction-backed LTAR relations.

### Root cause
Delete pre-check `hasLTARData` blocked deletion for m2m or junction-backed LTAR cases, even though delete flow already cleans related junction rows.

### Code change
Updated `hasLTARData` in [packages/nocodb/src/db/BaseModelSqlv2.ts](packages/nocodb/src/db/BaseModelSqlv2.ts) to:
- skip blockers for `mm` and mm-like LTAR relations
- skip blockers for `has-many` LTAR when related table is an m2m junction via `relatedTable.mm`
- keep existing blocking behavior for normal non-m2m has-many relations

closes: #13238

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

### External PostgreSQL E2E (bug path)
- Created external PostgreSQL base
- Created two tables and m2m LTAR
- Inserted linked rows
- Deleted linked parent row
- Verified:
  - delete succeeded
  - deleted row is absent
  - unrelated linked-table row remains

### Non-regression check
- Created parent and child has-many relation
- Attempted parent delete with existing child link
- Verified delete is still blocked with HTTP 400 LTAR blocker message

## Additional information / screenshots (optional)

- PR contains only one source file change:
  - [packages/nocodb/src/db/BaseModelSqlv2.ts](packages/nocodb/src/db/BaseModelSqlv2.ts)
- No API contract or schema changes.