### PR TITLE
feat(nc-gui,nocodb): allow configurable file size limit for imports

### DIFF
--- a/packages/nc-gui/components/dlg/QuickImport.vue
+++ b/packages/nc-gui/components/dlg/QuickImport.vue
@@ -460,9 +460,10 @@ const beforeUpload = (file: UploadFile, fileList: UploadFile[]) => {
     showMaxFileLimitError.value = true
   }
 
-  const exceedLimit = file.size! / 1024 / 1024 > 25
+  const importFileSizeLimitMB = Math.max(1, appInfo.value.ncImportFileSize || 25)
+  const exceedLimit = file.size! / 1024 / 1024 > importFileSizeLimitMB
   if (exceedLimit) {
-    message.error(`File ${file.name} is too big. The accepted file size is less than 25MB.`)
+    message.error(`File ${file.name} is too big. The accepted file size is less than ${importFileSizeLimitMB}MB.`)
   }
   return !exceedLimit || Upload.LIST_IGNORE
 }

--- a/packages/nc-gui/composables/useGlobal/state.ts
+++ b/packages/nc-gui/composables/useGlobal/state.ts
@@ -140,6 +140,7 @@ export function useGlobalState(storageKey = 'nocodb-gui-v2'): State {
     type: 'nocodb',
     version: '0.0.0',
     ncAttachmentFieldSize: 20,
+    ncImportFileSize: 25,
     ncMaxAttachmentsAllowed: 10,
     isCloud: false,
     automationLogLevel: 'OFF',

--- a/packages/nc-gui/composables/useGlobal/types.ts
+++ b/packages/nc-gui/composables/useGlobal/types.ts
@@ -31,6 +31,7 @@ export interface AppInfo {
   version: string
   ee?: boolean
   ncAttachmentFieldSize: number
+  ncImportFileSize: number
   ncMaxAttachmentsAllowed: number
   isCloud: boolean
   automationLogLevel: 'OFF' | 'ERROR' | 'ALL'

--- a/packages/nocodb/src/constants/index.ts
+++ b/packages/nocodb/src/constants/index.ts
@@ -10,6 +10,10 @@ export const NC_ATTACHMENT_FIELD_SIZE =
   +process.env['NC_ATTACHMENT_FIELD_SIZE'] || 20 * 1024 * 1024; // 20 MB
 export const NC_MAX_ATTACHMENTS_ALLOWED =
   +process.env['NC_MAX_ATTACHMENTS_ALLOWED'] || 10;
+export const NC_IMPORT_FILE_SIZE = Math.max(
+  1,
+  +process.env['NC_IMPORT_FILE_SIZE'] || 25,
+); // in MB
 export const NC_REFRESH_TOKEN_EXP_IN_DAYS =
   parseInt(process.env.NC_REFRESH_TOKEN_EXP_IN_DAYS, 10) || 30;
 

--- a/packages/nocodb/src/services/utils.service.ts
+++ b/packages/nocodb/src/services/utils.service.ts
@@ -10,6 +10,7 @@ import type { ErrorReportReqType } from 'nocodb-sdk';
 import type { AppConfig, NcRequest } from '~/interface/config';
 import {
   NC_ATTACHMENT_FIELD_SIZE,
+  NC_IMPORT_FILE_SIZE,
   NC_MAX_ATTACHMENTS_ALLOWED,
 } from '~/constants';
 import SqlMgrv2 from '~/db/sql-mgr/v2/SqlMgrv2';
@@ -467,6 +468,7 @@ export class UtilsService {
       ncSiteUrl: (param.req as any).ncSiteUrl,
       ee: Noco.isEE(),
       ncAttachmentFieldSize: NC_ATTACHMENT_FIELD_SIZE,
+      ncImportFileSize: NC_IMPORT_FILE_SIZE,
       ncMaxAttachmentsAllowed: NC_MAX_ATTACHMENTS_ALLOWED,
       isCloud: isCloud,
       automationLogLevel: process.env.NC_AUTOMATION_LOG_LEVEL || 'OFF',


### PR DESCRIPTION
## Summary

- Add `NC_IMPORT_FILE_SIZE` environment variable (in MB, default: 25) to configure the maximum file size allowed for CSV/JSON/Excel imports
- Replace the hardcoded 25MB limit in `QuickImport.vue` with the configurable value from the backend via the existing `appInfo` pipeline
- Error message now dynamically reflects the configured limit

## Details

The value flows through the existing env-var-to-frontend pattern used by `NC_ATTACHMENT_FIELD_SIZE`:

1. Backend constant in `constants/index.ts` with `Math.max(1, ...)` guard
2. Exposed via `appInfo` in `utils.service.ts`
3. Typed in `useGlobal/types.ts`, defaulted in `useGlobal/state.ts`
4. Consumed in `QuickImport.vue` with fallback to 25MB

**Note:** The unit for `NC_IMPORT_FILE_SIZE` is MB (e.g., `NC_IMPORT_FILE_SIZE=50` means 50 MB). This differs from `NC_ATTACHMENT_FIELD_SIZE` which uses bytes. MB was chosen because the import dialog comparison already operates in MB and it's more intuitive for operators. Happy to change to bytes if the team prefers consistency.

**Note:** Server-side enforcement of this limit is not yet implemented (the existing hardcoded check was also frontend-only). This could be a follow-up.

closes: #12572

## Test plan

- [x] Set `NC_IMPORT_FILE_SIZE=5`, upload a 6MB CSV → error: "less than 5MB"
- [x] Unset the env var (default 25MB), upload the same 6MB CSV → imports successfully
- [x] Set `NC_IMPORT_FILE_SIZE=0` or negative → clamps to 1MB minimum
- [x] Verify backward compatibility: no env var set behaves exactly like before (25MB limit)