### PR TITLE
fix(oauth): add OAuth tables to RootScopeTables allowlist

### DIFF
--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -571,6 +571,9 @@ export const RootScopeTables = {
     MetaTable.CUSTOM_URLS,
     MetaTable.MCP_TOKENS,
     MetaTable.TEAMS,
+    MetaTable.OAUTH_CLIENTS,
+    MetaTable.OAUTH_AUTHORIZATION_CODES,
+    MetaTable.OAUTH_TOKENS,
   ],
   [RootScopes.ORG]: [
     MetaTable.ORG,

--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -557,6 +557,9 @@ export const RootScopeTables = {
     MetaTable.CUSTOM_URLS,
     MetaTable.MCP_TOKENS,
     MetaTable.TEAMS,
+    MetaTable.OAUTH_CLIENTS,
+    MetaTable.OAUTH_AUTHORIZATION_CODES,
+    MetaTable.OAUTH_TOKENS,
   ],
   [RootScopes.ORG]: [
     MetaTable.ORG,


### PR DESCRIPTION
## Summary
- Adds `OAUTH_CLIENTS`, `OAUTH_AUTHORIZATION_CODES`, and `OAUTH_TOKENS` to the `RootScopeTables` allowlist
- These tables were introduced in the OAuth migration but not added to the root scope, causing model operations (insert/update/delete) to fail with *"Table not accessible from this scope"* when called outside the internal OAuth UI context (e.g. from API endpoints)

## Root Cause
The OAuth tables were added to `MetaTable` in `1860a4804d` (`feat(wip): oauth models`) but were never registered in `RootScopeTables`. The internal OAuth UI didn't surface this bug because it uses a code path that bypasses scope checks. Any external API access to these tables (e.g. Dynamic Client Registration) fails.

Ref: #13363

## Test plan
- [x] Existing OAuth controller tests pass (19/19)
- [x] Manual: verified on fresh local instance — `POST /api/v2/oauth/register` returns `"Error: Table not accessible from this scope"` **before** fix, returns valid `client_id` **after** fix