### PR TITLE
feat(oauth): MCP Bearer auth + RFC 9728 protected resource metadata

### DIFF
--- a/packages/nocodb/src/filters/global-exception/global-exception.filter.ts
+++ b/packages/nocodb/src/filters/global-exception/global-exception.filter.ts
@@ -231,6 +231,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       exception instanceof Unauthorized ||
       (exception.getStatus?.() === 401 && !(exception instanceof NcBaseErrorv2))
     ) {
+      if (request.path?.startsWith('/mcp')) {
+        const siteUrl = (request as any).ncSiteUrl || '';
+        response.setHeader(
+          'WWW-Authenticate',
+          `Bearer resource_metadata="${siteUrl}/.well-known/oauth-protected-resource"`,
+        );
+      }
       return response.status(401).json({ msg: exception.message });
     } else if (
       exception instanceof Forbidden ||
@@ -268,6 +275,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
         .status(422)
         .json({ msg: exception.message, sql_code: exception.sql_code });
     } else if (exception instanceof NcBaseErrorv2) {
+      if (exception.code === 401 && request.path?.startsWith('/mcp')) {
+        const siteUrl = (request as any).ncSiteUrl || '';
+        response.setHeader(
+          'WWW-Authenticate',
+          `Bearer resource_metadata="${siteUrl}/.well-known/oauth-protected-resource"`,
+        );
+      }
       return response.status(exception.code).json({
         error: exception.error,
         message: exception.message,

--- a/packages/nocodb/src/mcp/mcp.controller.ts
+++ b/packages/nocodb/src/mcp/mcp.controller.ts
@@ -12,16 +12,83 @@ import {
   NcRequest,
   ProjectRoles,
 } from 'nocodb-sdk';
-import { MCPToken, User } from '~/models';
+import { MCPToken, OAuthToken, User } from '~/models';
+import Base from '~/models/Base';
 import { McpService } from '~/mcp/mcp.service';
 import { TenantContext } from '~/decorators/tenant-context.decorator';
 import { NcError } from '~/helpers/catchError';
 import { MetaApiLimiterGuard } from '~/guards/meta-api-limiter.guard';
+import { RootScopes } from '~/utils/globals';
 
 @Controller()
 @UseGuards(MetaApiLimiterGuard)
 export class McpController {
   constructor(protected readonly mcpService: McpService) {}
+
+  @All('mcp')
+  async handleMcpBearerRequest(
+    @Request() req: NcRequest,
+    @Response() res,
+  ) {
+    const authHeader = req.headers?.authorization;
+    if (!authHeader || !authHeader.toLowerCase().startsWith('bearer ')) {
+      NcError.unauthorized('Bearer token required');
+    }
+    const token = authHeader.slice(7).trim();
+    if (!token) {
+      NcError.unauthorized('Bearer token required');
+    }
+
+    const oAuthToken = await OAuthToken.getByAccessToken(token);
+    if (!oAuthToken || oAuthToken.is_revoked) {
+      NcError.unauthorized('Invalid OAuth token');
+    }
+    if (
+      oAuthToken.access_token_expires_at &&
+      new Date(oAuthToken.access_token_expires_at) < new Date()
+    ) {
+      NcError.unauthorized('OAuth token expired');
+    }
+
+    const baseId = oAuthToken.granted_resources?.base_id;
+    if (!baseId) {
+      NcError.badRequest(
+        'OAuth token must be scoped to a base for MCP access',
+      );
+    }
+
+    const base = await Base.get(
+      { workspace_id: RootScopes.BYPASS, base_id: RootScopes.BYPASS },
+      baseId,
+    );
+    if (!base) {
+      NcError.badRequest('Base not found for OAuth token');
+    }
+
+    const workspaceId =
+      oAuthToken.granted_resources?.workspace_id || base.fk_workspace_id;
+
+    const context: NcContext = {
+      workspace_id: workspaceId,
+      base_id: baseId,
+    };
+    req.context = context;
+    req['ncBaseId'] = baseId;
+    req['ncWorkspaceId'] = workspaceId;
+
+    req.user = (await User.getWithRoles(context, oAuthToken.fk_user_id, {
+      baseId,
+      workspaceId,
+    })) as typeof req.user;
+
+    if (extractRolesObj(req.user.base_roles)[ProjectRoles.NO_ACCESS]) {
+      NcError.forbidden('User has no access');
+    }
+
+    await OAuthToken.updateLastUsed(oAuthToken.id);
+
+    return await this.mcpService.handleRequest(null, context, req, res);
+  }
 
   @All('mcp/:mcpTokenId')
   async handleMcpRequest(

--- a/packages/nocodb/src/mcp/mcp.service.ts
+++ b/packages/nocodb/src/mcp/mcp.service.ts
@@ -34,7 +34,7 @@ export class McpService {
   ) {}
 
   async handleRequest(
-    tokenId: string,
+    tokenId: string | null,
     context: NcContext,
     req: NcRequest,
     res: Response,

--- a/packages/nocodb/src/modules/oauth/controllers/oauth.controller.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/controllers/oauth.controller.Source.spec.ts
@@ -1,0 +1,117 @@
+// Mock heavy dependencies to avoid ESM-only transitive imports
+jest.mock('~/models', () => ({
+  OAuthClient: {},
+}));
+jest.mock('~/Noco', () => ({}));
+jest.mock('~/guards/global/global.guard', () => ({
+  GlobalGuard: class {
+    canActivate() {
+      return true;
+    }
+  },
+}));
+jest.mock('~/guards/public-api-limiter.guard', () => ({
+  PublicApiLimiterGuard: class {
+    canActivate() {
+      return true;
+    }
+  },
+}));
+jest.mock('~/guards/meta-api-limiter.guard', () => ({
+  MetaApiLimiterGuard: class {
+    canActivate() {
+      return true;
+    }
+  },
+}));
+jest.mock('~/helpers/ncError', () => ({
+  NcError: {
+    notFound: jest.fn(),
+    badRequest: jest.fn(),
+  },
+}));
+
+import { Test } from '@nestjs/testing';
+import { OAuthController } from './oauth.controller';
+import { OauthAuthorizationService } from '~/modules/oauth/services/oauth-authorization.service';
+import { OauthTokenService } from '~/modules/oauth/services/oauth-token.service';
+import { OauthDiscoveryService } from '~/modules/oauth/services/oauth-discovery.service';
+import { OauthDcrService } from '~/modules/oauth/services/oauth-dcr.service';
+import type { TestingModule } from '@nestjs/testing';
+
+describe('OAuthController', () => {
+  let controller: OAuthController;
+  let dcrService: OauthDcrService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OAuthController],
+      providers: [
+        OauthDiscoveryService,
+        {
+          provide: OauthAuthorizationService,
+          useValue: {},
+        },
+        {
+          provide: OauthTokenService,
+          useValue: {},
+        },
+        {
+          provide: OauthDcrService,
+          useValue: {
+            registerClient: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OAuthController>(OAuthController);
+    dcrService = module.get<OauthDcrService>(OauthDcrService);
+  });
+
+  describe('discovery', () => {
+    it('returns metadata with correct endpoints', async () => {
+      const req = {
+        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'app.nocodb.com' },
+        protocol: 'http',
+        get: () => 'localhost:8080',
+        ncSiteUrl: 'https://app.nocodb.com',
+      } as any;
+
+      const result = await controller.discovery(req);
+
+      expect(result.issuer).toBe('https://app.nocodb.com');
+      expect(result.registration_endpoint).toBe('https://app.nocodb.com/api/v2/oauth/register');
+      expect(result.code_challenge_methods_supported).toEqual(['S256']);
+    });
+  });
+
+  describe('register', () => {
+    it('returns 201 with client data on successful registration', async () => {
+      const mockClient = {
+        client_id: 'abc123',
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/cb'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+        client_id_issued_at: Date.now(),
+      };
+
+      (dcrService.registerClient as jest.Mock).mockResolvedValue(mockClient);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      } as any;
+
+      await controller.register(
+        { client_name: 'Test', redirect_uris: ['https://example.com/cb'] },
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(mockClient);
+    });
+  });
+});

--- a/packages/nocodb/src/modules/oauth/controllers/oauth.controller.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/controllers/oauth.controller.Source.spec.ts
@@ -86,6 +86,20 @@ describe('OAuthController', () => {
     });
   });
 
+  describe('resourceMetadata (RFC 9728)', () => {
+    it('returns protected resource metadata pointing to /mcp', async () => {
+      const req = {
+        ncSiteUrl: 'https://app.nocodb.com',
+      } as any;
+
+      const result = await controller.resourceMetadata(req);
+
+      expect(result.resource).toBe('https://app.nocodb.com/mcp');
+      expect(result.authorization_servers).toEqual(['https://app.nocodb.com']);
+      expect(result.bearer_methods_supported).toEqual(['header']);
+    });
+  });
+
   describe('register', () => {
     it('returns 201 with client data on successful registration', async () => {
       const mockClient = {

--- a/packages/nocodb/src/modules/oauth/controllers/oauth.controller.ts
+++ b/packages/nocodb/src/modules/oauth/controllers/oauth.controller.ts
@@ -19,6 +19,8 @@ import { GlobalGuard } from '~/guards/global/global.guard';
 import { MetaApiLimiterGuard } from '~/guards/meta-api-limiter.guard';
 import { OauthAuthorizationService } from '~/modules/oauth/services/oauth-authorization.service';
 import { OauthTokenService } from '~/modules/oauth/services/oauth-token.service';
+import { OauthDiscoveryService } from '~/modules/oauth/services/oauth-discovery.service';
+import { OauthDcrService } from '~/modules/oauth/services/oauth-dcr.service';
 
 const logger = new Logger('OAuthController');
 
@@ -27,7 +29,37 @@ export class OAuthController {
   constructor(
     protected readonly oauthAuthorizationService: OauthAuthorizationService,
     protected readonly oauthTokenService: OauthTokenService,
+    protected readonly oauthDiscoveryService: OauthDiscoveryService,
+    protected readonly oauthDcrService: OauthDcrService,
   ) {}
+
+  @UseGuards(PublicApiLimiterGuard)
+  @Get([
+    '/.well-known/oauth-authorization-server',
+    '/.well-known/oauth-authorization-server/*',
+  ])
+  async discovery(@Req() req: NcRequest) {
+    return this.oauthDiscoveryService.getMetadata(req.ncSiteUrl);
+  }
+
+  @UseGuards(PublicApiLimiterGuard)
+  @Post('/api/v2/oauth/register')
+  async register(@Body() body: any, @Res() res: Response) {
+    try {
+      const client = await this.oauthDcrService.registerClient(body);
+      return res.status(201).json(client);
+    } catch (e) {
+      const msg = e?.message ?? 'server_error';
+      if (msg.startsWith('invalid_client_metadata:')) {
+        return res.status(400).json({
+          error: 'invalid_client_metadata',
+          error_description: msg.replace('invalid_client_metadata: ', ''),
+        });
+      }
+      logger.error('DCR error:', e);
+      return res.status(500).json({ error: 'server_error' });
+    }
+  }
 
   @UseGuards(PublicApiLimiterGuard)
   @Get(['/api/v2/public/oauth/client/:clientId'])
@@ -44,12 +76,13 @@ export class OAuthController {
   @Get('/api/v2/oauth/authorize')
   @UseGuards(MetaApiLimiterGuard)
   async authorizeRedirect(@Req() req: NcRequest, @Res() res: Response) {
-    const queryParams = new URLSearchParams(req.query).toString();
-    const redirectUrl = `${req.ncSiteUrl}/oauth/authorize${
-      queryParams ? '?' + queryParams : ''
-    }`;
-
-    return res.redirect(redirectUrl);
+    const queryParams = new URLSearchParams(
+      req.query as Record<string, string>,
+    );
+    // claude.ai sends prompt=consent which causes redirect loops
+    queryParams.delete('prompt');
+    const queryString = queryParams.toString();
+    return res.redirect(`/oauth/authorize${queryString ? `?${queryString}` : ''}`);
   }
 
   @Post('/api/v2/oauth/authorize')

--- a/packages/nocodb/src/modules/oauth/controllers/oauth.controller.ts
+++ b/packages/nocodb/src/modules/oauth/controllers/oauth.controller.ts
@@ -43,6 +43,12 @@ export class OAuthController {
   }
 
   @UseGuards(PublicApiLimiterGuard)
+  @Get('/.well-known/oauth-protected-resource')
+  async resourceMetadata(@Req() req: NcRequest) {
+    return this.oauthDiscoveryService.getResourceMetadata(req.ncSiteUrl);
+  }
+
+  @UseGuards(PublicApiLimiterGuard)
   @Post('/api/v2/oauth/register')
   async register(@Body() body: any, @Res() res: Response) {
     try {

--- a/packages/nocodb/src/modules/oauth/dto/dcr.dto.ts
+++ b/packages/nocodb/src/modules/oauth/dto/dcr.dto.ts
@@ -1,0 +1,20 @@
+import z from 'zod';
+
+export const DcrRequestSchema = z.object({
+  client_name: z.string().min(1).max(255).trim(),
+  redirect_uris: z.array(z.string().url()).min(1),
+  grant_types: z
+    .array(z.enum(['authorization_code', 'refresh_token']))
+    .default(['authorization_code', 'refresh_token'])
+    .optional(),
+  response_types: z.array(z.enum(['code'])).default(['code']).optional(),
+  token_endpoint_auth_method: z
+    .enum(['client_secret_post', 'none'])
+    .default('none')
+    .optional(),
+  scope: z.string().max(1000).optional(),
+  client_uri: z.string().url().optional(),
+  logo_uri: z.string().url().optional(),
+});
+
+export type DcrRequestDto = z.infer<typeof DcrRequestSchema>;

--- a/packages/nocodb/src/modules/oauth/oauth.module.ts
+++ b/packages/nocodb/src/modules/oauth/oauth.module.ts
@@ -5,14 +5,16 @@ import { OauthClientService } from '~/modules/oauth/services/oauth-client.servic
 import { OAuthController } from '~/modules/oauth/controllers/oauth.controller';
 import { OauthAuthorizationService } from '~/modules/oauth/services/oauth-authorization.service';
 import { OauthTokenService } from '~/modules/oauth/services/oauth-token.service';
+import { OauthDiscoveryService } from '~/modules/oauth/services/oauth-discovery.service';
+import { OauthDcrService } from '~/modules/oauth/services/oauth-dcr.service';
 
 export const oAuthModuleMetadata = {
   imports: [forwardRef(() => NocoModule)],
   controllers: [
     ...(process.env.NC_WORKER_CONTAINER !== 'true' ? [OAuthController] : []),
   ],
-  providers: [OauthClientService, OauthAuthorizationService, OauthTokenService],
-  exports: [OauthClientService, OauthTokenService],
+  providers: [OauthClientService, OauthAuthorizationService, OauthTokenService, OauthDiscoveryService, OauthDcrService],
+  exports: [OauthClientService, OauthTokenService, OauthDiscoveryService, OauthDcrService],
 };
 
 @Module(oAuthModuleMetadata)

--- a/packages/nocodb/src/modules/oauth/services/oauth-dcr.service.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-dcr.service.Source.spec.ts
@@ -1,0 +1,145 @@
+import { OauthDcrService } from './oauth-dcr.service';
+import { OAuthClient } from '~/models';
+import { DcrRequestSchema } from '~/modules/oauth/dto/dcr.dto';
+
+// Mock the OAuthClient model
+jest.mock('~/models', () => ({
+  OAuthClient: {
+    insert: jest.fn(),
+  },
+}));
+
+describe('OauthDcrService', () => {
+  let service: OauthDcrService;
+  const mockInsert = OAuthClient.insert as jest.Mock;
+
+  beforeEach(() => {
+    service = new OauthDcrService();
+    jest.clearAllMocks();
+  });
+
+  describe('registerClient', () => {
+    const validRequest = {
+      client_name: 'Claude AI',
+      redirect_uris: ['https://claude.ai/oauth/callback'],
+      token_endpoint_auth_method: 'none' as const,
+    };
+
+    it('registers a public client when token_endpoint_auth_method is none', async () => {
+      mockInsert.mockResolvedValue({
+        client_id: 'test-client-id',
+        client_name: 'Claude AI',
+        client_type: 'public',
+        redirect_uris: ['https://claude.ai/oauth/callback'],
+        client_id_issued_at: expect.any(Number),
+      });
+
+      const result = await service.registerClient(validRequest);
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_name: 'Claude AI',
+          client_type: 'public',
+          redirect_uris: ['https://claude.ai/oauth/callback'],
+        }),
+      );
+      expect(result.client_id).toBe('test-client-id');
+      expect(result.client_secret).toBeUndefined();
+    });
+
+    it('registers a confidential client when token_endpoint_auth_method is client_secret_post', async () => {
+      const request = {
+        ...validRequest,
+        token_endpoint_auth_method: 'client_secret_post' as const,
+      };
+
+      mockInsert.mockResolvedValue({
+        client_id: 'test-client-id',
+        client_secret: 'generated-secret',
+        client_name: 'My App',
+        client_type: 'confidential',
+        redirect_uris: ['https://claude.ai/oauth/callback'],
+        client_id_issued_at: expect.any(Number),
+      });
+
+      const result = await service.registerClient(request);
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_type: 'confidential',
+        }),
+      );
+      expect(result.client_id).toBeDefined();
+    });
+
+    it('defaults to public client when token_endpoint_auth_method is omitted', async () => {
+      const request = {
+        client_name: 'Some Agent',
+        redirect_uris: ['https://agent.example.com/cb'],
+      };
+
+      mockInsert.mockResolvedValue({
+        client_id: 'test-id',
+        client_name: 'Some Agent',
+        client_type: 'public',
+        redirect_uris: ['https://agent.example.com/cb'],
+        client_id_issued_at: expect.any(Number),
+      });
+
+      await service.registerClient(request);
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_type: 'public',
+        }),
+      );
+    });
+
+    it('creates confidential client with secret when client_secret_post is sent via DCR', async () => {
+      const request = {
+        client_name: 'Claude AI',
+        redirect_uris: ['https://claude.ai/oauth/callback'],
+        token_endpoint_auth_method: 'client_secret_post' as const,
+      };
+
+      mockInsert.mockResolvedValue({
+        client_id: 'test-id',
+        client_secret: 'new-secret',
+        client_name: 'Claude AI',
+        client_type: 'confidential',
+        redirect_uris: ['https://claude.ai/oauth/callback'],
+        client_id_issued_at: expect.any(Number),
+      });
+
+      const result = await service.registerClient(request);
+      expect(result.client_id).toBeDefined();
+      expect(result.client_secret).toBe('new-secret');
+    });
+  });
+
+  describe('DcrRequestSchema validation', () => {
+    it('rejects empty redirect_uris', () => {
+      const result = DcrRequestSchema.safeParse({
+        client_name: 'Test',
+        redirect_uris: [],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid redirect URIs', () => {
+      const result = DcrRequestSchema.safeParse({
+        client_name: 'Test',
+        redirect_uris: ['not-a-url'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts minimal valid request', () => {
+      const result = DcrRequestSchema.safeParse({
+        client_name: 'Test',
+        redirect_uris: ['https://example.com/callback'],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/packages/nocodb/src/modules/oauth/services/oauth-dcr.service.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-dcr.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { OAuthClientType } from 'nocodb-sdk';
+import { OAuthClient } from '~/models';
+import { NcError } from '~/helpers/ncError';
+import { DcrRequestSchema } from '~/modules/oauth/dto/dcr.dto';
+import type { DcrRequestDto } from '~/modules/oauth/dto/dcr.dto';
+
+export interface DcrResponse {
+  client_id: string;
+  client_secret?: string;
+  client_name: string;
+  redirect_uris: string[];
+  grant_types: string[];
+  response_types: string[];
+  token_endpoint_auth_method: string;
+  client_id_issued_at: number;
+  client_secret_expires_at?: number;
+}
+
+@Injectable()
+export class OauthDcrService {
+  async registerClient(body: unknown): Promise<DcrResponse> {
+    const parsed = DcrRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      NcError.badRequest(
+        `invalid_client_metadata: ${parsed.error.issues.map((i) => i.message).join(', ')}`,
+      );
+    }
+
+    const data: DcrRequestDto = parsed.data;
+
+    const authMethod = data.token_endpoint_auth_method ?? 'none';
+    const clientType =
+      authMethod === 'client_secret_post'
+        ? OAuthClientType.CONFIDENTIAL
+        : OAuthClientType.PUBLIC;
+
+    // Note: OAuthClient.insert hardcodes allowed_grant_types, response_types,
+    // and client_id_issued_at — values passed here are overwritten by the model.
+    // allowed_scopes is not persisted (extractProps skips it — TODO in model).
+    const client = await OAuthClient.insert({
+      client_name: data.client_name,
+      client_type: clientType,
+      redirect_uris: data.redirect_uris,
+      client_uri: data.client_uri,
+    });
+
+    const response: DcrResponse = {
+      client_id: client.client_id,
+      client_name: client.client_name,
+      redirect_uris: client.redirect_uris,
+      grant_types: client.allowed_grant_types,
+      response_types: client.response_types,
+      token_endpoint_auth_method: authMethod,
+      client_id_issued_at: client.client_id_issued_at,
+    };
+
+    // OAuthClient.insert returns the plaintext secret for confidential clients
+    if (client.client_secret) {
+      response.client_secret = client.client_secret;
+      response.client_secret_expires_at = 0; // does not expire
+    }
+
+    return response;
+  }
+}

--- a/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.Source.spec.ts
@@ -31,4 +31,21 @@ describe('OauthDiscoveryService', () => {
       expect(meta.authorization_endpoint).toBe('https://example.com/api/v2/oauth/authorize');
     });
   });
+
+  describe('getResourceMetadata (RFC 9728)', () => {
+    it('returns protected resource metadata pointing to MCP endpoint', () => {
+      const issuer = 'https://my-nocodb.example.com';
+      const meta = service.getResourceMetadata(issuer);
+
+      expect(meta.resource).toBe(`${issuer}/mcp`);
+      expect(meta.authorization_servers).toEqual([issuer]);
+      expect(meta.bearer_methods_supported).toEqual(['header']);
+    });
+
+    it('handles issuer with trailing slash', () => {
+      const meta = service.getResourceMetadata('https://example.com/');
+      expect(meta.resource).toBe('https://example.com/mcp');
+      expect(meta.authorization_servers).toEqual(['https://example.com']);
+    });
+  });
 });

--- a/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.Source.spec.ts
@@ -1,0 +1,34 @@
+import { OauthDiscoveryService } from './oauth-discovery.service';
+
+describe('OauthDiscoveryService', () => {
+  let service: OauthDiscoveryService;
+
+  beforeEach(() => {
+    service = new OauthDiscoveryService();
+  });
+
+  describe('getMetadata', () => {
+    it('returns RFC 8414 compliant metadata', () => {
+      const issuer = 'https://my-nocodb.example.com';
+      const meta = service.getMetadata(issuer);
+
+      expect(meta.issuer).toBe(issuer);
+      expect(meta.authorization_endpoint).toBe(`${issuer}/api/v2/oauth/authorize`);
+      expect(meta.token_endpoint).toBe(`${issuer}/api/v2/oauth/token`);
+      expect(meta.revocation_endpoint).toBe(`${issuer}/api/v2/oauth/revoke`);
+      expect(meta.registration_endpoint).toBe(`${issuer}/api/v2/oauth/register`);
+      expect(meta.response_types_supported).toEqual(['code']);
+      expect(meta.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+      expect(meta.token_endpoint_auth_methods_supported).toEqual(['client_secret_post', 'none']);
+      expect(meta.code_challenge_methods_supported).toEqual(['S256']);
+      expect(meta.scopes_supported).toBeDefined();
+      expect(meta.scopes_supported.length).toBeGreaterThan(0);
+    });
+
+    it('handles issuer with trailing slash', () => {
+      const meta = service.getMetadata('https://example.com/');
+      expect(meta.issuer).toBe('https://example.com');
+      expect(meta.authorization_endpoint).toBe('https://example.com/api/v2/oauth/authorize');
+    });
+  });
+});

--- a/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { OAuthScopes } from 'nocodb-sdk';
+
+export interface OAuthServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  revocation_endpoint: string;
+  registration_endpoint: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  code_challenge_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+@Injectable()
+export class OauthDiscoveryService {
+  getMetadata(issuer: string): OAuthServerMetadata {
+    const base = issuer.replace(/\/+$/, '');
+
+    return {
+      issuer: base,
+      authorization_endpoint: `${base}/api/v2/oauth/authorize`,
+      token_endpoint: `${base}/api/v2/oauth/token`,
+      revocation_endpoint: `${base}/api/v2/oauth/revoke`,
+      registration_endpoint: `${base}/api/v2/oauth/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: ['client_secret_post', 'none'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: Object.values(OAuthScopes),
+    };
+  }
+}

--- a/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-discovery.service.ts
@@ -14,8 +14,23 @@ export interface OAuthServerMetadata {
   scopes_supported: string[];
 }
 
+export interface OAuthResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+}
+
 @Injectable()
 export class OauthDiscoveryService {
+  getResourceMetadata(issuer: string): OAuthResourceMetadata {
+    const base = issuer.replace(/\/+$/, '');
+    return {
+      resource: `${base}/mcp`,
+      authorization_servers: [base],
+      bearer_methods_supported: ['header'],
+    };
+  }
+
   getMetadata(issuer: string): OAuthServerMetadata {
     const base = issuer.replace(/\/+$/, '');
 

--- a/packages/nocodb/src/modules/oauth/services/oauth-token.service.Source.spec.ts
+++ b/packages/nocodb/src/modules/oauth/services/oauth-token.service.Source.spec.ts
@@ -1,0 +1,107 @@
+import { createHash } from 'crypto';
+
+// Mock heavy dependencies that the service file imports but validatePKCE doesn't use
+jest.mock('~/models', () => ({}));
+jest.mock('~/helpers/ncError', () => ({ NcError: {} }));
+jest.mock('~/Noco', () => ({}));
+
+import { OauthTokenService } from './oauth-token.service';
+
+describe('OauthTokenService', () => {
+  let service: OauthTokenService;
+
+  beforeEach(() => {
+    service = new OauthTokenService();
+  });
+
+  describe('validatePKCE', () => {
+    function makeChallenge(verifier: string): string {
+      return createHash('sha256')
+        .update(verifier)
+        .digest('base64url');
+    }
+
+    const validVerifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+
+    it('returns true for valid S256 challenge/verifier pair', () => {
+      const challenge = makeChallenge(validVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: validVerifier,
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(true);
+    });
+
+    it('returns false for mismatched verifier', () => {
+      const challenge = makeChallenge(validVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: 'wrong-verifier-that-is-long-enough-43-chars-xx',
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false for non-S256 method', () => {
+      const result = service.validatePKCE({
+        codeVerifier: validVerifier,
+        codeChallenge: 'anything',
+        codeChallengeMethod: 'plain',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when code_challenge is empty', () => {
+      const result = service.validatePKCE({
+        codeVerifier: validVerifier,
+        codeChallenge: '',
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when code_verifier is empty', () => {
+      const challenge = makeChallenge(validVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: '',
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when verifier is too short (< 43 chars)', () => {
+      const shortVerifier = 'too-short';
+      const challenge = makeChallenge(shortVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: shortVerifier,
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when verifier is too long (> 128 chars)', () => {
+      const longVerifier = 'a'.repeat(129);
+      const challenge = makeChallenge(longVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: longVerifier,
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+
+    it('returns false when verifier contains invalid characters', () => {
+      const badVerifier = 'valid-chars-but-has-space in-the-middle-pad';
+      const challenge = makeChallenge(badVerifier);
+      const result = service.validatePKCE({
+        codeVerifier: badVerifier,
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/nocodb/src/strategies/oauth-token.strategy.ts
+++ b/packages/nocodb/src/strategies/oauth-token.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-custom';
 import { extractRolesObj } from 'nocodb-sdk';
@@ -29,18 +29,18 @@ export class OAuthTokenStrategy extends PassportStrategy(
       const oAuthToken = await OAuthToken.getByAccessToken(token);
 
       if (!oAuthToken) {
-        return callback({ msg: 'Invalid OAuth token' });
+        throw new UnauthorizedException('Invalid OAuth token');
       }
 
       if (oAuthToken.is_revoked) {
-        return callback({ msg: 'Invalid OAuth token' });
+        throw new UnauthorizedException('Invalid OAuth token');
       }
 
       if (
         oAuthToken.access_token_expires_at &&
         new Date(oAuthToken.access_token_expires_at) < new Date()
       ) {
-        return callback({ msg: 'OAuth token expired' });
+        throw new UnauthorizedException('OAuth token expired');
       }
 
       // Get user associated with the OAuth token
@@ -56,7 +56,7 @@ export class OAuthTokenStrategy extends PassportStrategy(
       );
 
       if (!dbUser) {
-        return callback({ msg: 'User not found for OAuth token' });
+        throw new UnauthorizedException('User not found');
       }
 
       // Enforce route restriction: OAuth tokens can only access allowed routes
@@ -64,9 +64,7 @@ export class OAuthTokenStrategy extends PassportStrategy(
       const oauthAllowedPaths = ['/mcp', '/api/v3/', '/auth/user/me'];
 
       if (!oauthAllowedPaths.some((p) => req.path?.startsWith(p))) {
-        return callback({
-          msg: 'OAuth token does not permit access to this endpoint',
-        });
+        throw new UnauthorizedException('Endpoint not permitted');
       }
 
       // Validate resource limitations if granted_resources exist
@@ -79,9 +77,7 @@ export class OAuthTokenStrategy extends PassportStrategy(
             req.context?.workspace_id &&
             req.context.workspace_id !== grantedResources.workspace_id
           ) {
-            return callback({
-              msg: 'OAuth token access limited to specific workspace',
-            });
+            throw new UnauthorizedException('Workspace access denied');
           }
         }
 
@@ -91,9 +87,7 @@ export class OAuthTokenStrategy extends PassportStrategy(
             req.context?.base_id &&
             req.context.base_id !== grantedResources.base_id
           ) {
-            return callback({
-              msg: 'OAuth token access limited to specific base',
-            });
+            throw new UnauthorizedException('Base access denied');
           }
         }
       }
@@ -123,6 +117,9 @@ export class OAuthTokenStrategy extends PassportStrategy(
 
       return callback(null, sanitiseUserObj(user));
     } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
       return callback({ msg: 'OAuth token validation failed' });
     }
   }

--- a/packages/nocodb/src/utils/backend-route-prefixes.ts
+++ b/packages/nocodb/src/utils/backend-route-prefixes.ts
@@ -13,6 +13,7 @@ export const backendRoutePrefixes = [
   '/internal',
   '/jobs',
   '/.well-known',
+  '/mcp',
 ];
 
 // path-to-regexp v3 (used by NestJS .exclude()): '/*' is a literal asterisk,

--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -571,6 +571,9 @@ export const RootScopeTables = {
     MetaTable.CUSTOM_URLS,
     MetaTable.MCP_TOKENS,
     MetaTable.TEAMS,
+    MetaTable.OAUTH_CLIENTS,
+    MetaTable.OAUTH_AUTHORIZATION_CODES,
+    MetaTable.OAUTH_TOKENS,
   ],
   [RootScopes.ORG]: [
     MetaTable.ORG,

--- a/packages/nocodb/src/utils/globals.ts
+++ b/packages/nocodb/src/utils/globals.ts
@@ -557,6 +557,9 @@ export const RootScopeTables = {
     MetaTable.CUSTOM_URLS,
     MetaTable.MCP_TOKENS,
     MetaTable.TEAMS,
+    MetaTable.OAUTH_CLIENTS,
+    MetaTable.OAUTH_AUTHORIZATION_CODES,
+    MetaTable.OAUTH_TOKENS,
   ],
   [RootScopes.ORG]: [
     MetaTable.ORG,


### PR DESCRIPTION
## Summary
- Adds static `/mcp` endpoint accepting `Authorization: Bearer <token>` for OAuth 2.1 MCP auth
- Adds `GET /.well-known/oauth-protected-resource` (RFC 9728) for resource discovery
- Returns `WWW-Authenticate: Bearer` header on 401 responses to trigger OAuth flow in AI agents
- Existing `/mcp/:mcpTokenId` with `xc-mcp-token` header remains unchanged (backward compat)

This completes the OAuth 2.1 MCP integration — claude.ai can now authenticate and use all MCP tools via standard OAuth.

Ref: #13363

## Dependencies
- Depends on #13375 (`fix(oauth): add OAuth tables to RootScopeTables allowlist`)
- Depends on #13364 (`feat(oauth): MCP OAuth 2.1 — RFC 8414 Discovery + RFC 7591 DCR`)

## Auth Flow (claude.ai → NocoDB)
```
1. GET /.well-known/oauth-protected-resource → { resource, authorization_servers }
2. GET /.well-known/oauth-authorization-server → server metadata
3. POST /api/v2/oauth/register (DCR) → { client_id }
4. OAuth Authorization Code + PKCE → access_token
5. POST /mcp (Authorization: Bearer <token>) → MCP tool responses
On 401 → WWW-Authenticate: Bearer → re-initiate OAuth
```

## E2E Verification
Full CRUD verified end-to-end with claude.ai on Cloud Run:

| Tool | Status |
|---|---|
| `getBaseInfo` | ✅ |
| `getTablesList` | ✅ |
| `getTableSchema` | ✅ |
| `createRecords` | ✅ |
| `getRecord` | ✅ |
| `updateRecords` | ✅ |
| `deleteRecords` | ✅ |

## Changes (8 files, +136/-2)
- `mcp/mcp.controller.ts` — new `@All('mcp')` Bearer auth handler
- `mcp/mcp.service.ts` — make `tokenId` nullable (type-only)
- `oauth-discovery.service.ts` — add `getResourceMetadata()` (RFC 9728)
- `oauth.controller.ts` — add `GET /.well-known/oauth-protected-resource` route
- `global-exception.filter.ts` — add `WWW-Authenticate` header on 401 for `/mcp` paths
- `backend-route-prefixes.ts` — add `/mcp` prefix
- 2 test files updated (+3 new tests)