### PR TITLE
fix: support 'in' filter operator for Date/DateTime columns

### DIFF
--- a/packages/nocodb/src/db/field-handler/handlers/date-time/date-time.general.handler.ts
+++ b/packages/nocodb/src/db/field-handler/handlers/date-time/date-time.general.handler.ts
@@ -70,7 +70,7 @@ export class DateTimeGeneralHandler extends GenericFieldHandler {
           filter.value === null ||
           typeof filter.value === 'undefined' ||
           filter.value === '' ||
-          filter.comparison_op === 'in'
+          filter.comparison_op === 'in' && Array.isArray(filter.value)
         )
       ) {
         const dateTimeValue = await parseDateTimeValue(filter.value, {

--- a/packages/nocodb/src/db/field-handler/handlers/date-time/date-time.general.handler.ts
+++ b/packages/nocodb/src/db/field-handler/handlers/date-time/date-time.general.handler.ts
@@ -53,6 +53,7 @@ export class DateTimeGeneralHandler extends GenericFieldHandler {
       'isnot',
       'is',
       'isWithin',
+      'in',
     ];
     if (!supportedOperations.includes(filter.comparison_op)) {
       return {
@@ -69,7 +70,7 @@ export class DateTimeGeneralHandler extends GenericFieldHandler {
           filter.value === null ||
           typeof filter.value === 'undefined' ||
           filter.value === '' ||
-          (filter.comparison_op === 'in' && Array.isArray(filter.value))
+          filter.comparison_op === 'in'
         )
       ) {
         const dateTimeValue = await parseDateTimeValue(filter.value, {
@@ -378,6 +379,15 @@ export class DateTimeGeneralHandler extends GenericFieldHandler {
         anchorDate = now.add(Number(filter.value), 'day');
         break;
     }
+    // for 'in' operator, bypass date-specific parsing and delegate to generic handler
+    if (filter.comparison_op === 'in') {
+      return await this.handleFilter(
+        { val: filter.value, sourceField: field },
+        { knex, filter, column },
+        options,
+      );
+    }
+
     // for straight date value without sub op
     if (!filter.comparison_sub_op && filter.value) {
       anchorDate = this.parseFilterValue(


### PR DESCRIPTION
The 'in' operator was missing from the supportedOperations list in DateTimeGeneralHandler.verifyFilter, causing filter verification to fail with "Operation in is not supported for type Date". Additionally, the filter value validation tried to parse comma-separated 'in' values as a single date, and the filter method tried date-specific parsing instead of delegating to the generic WHERE IN handler.

Resolves #13427

## Change Summary

When connect an external MariaDB database and have a table with a Date column, NocoDB crashes if a view has an "in" filter on that date (e.g. show rows where date is one of Jan 15 or Feb 20).

The problem was that nobody told the date handler that "in" is a valid filter. So the backend rejected it outright. Even after allowing it, the date handler tried to read "2026-01-15,2026-02-20" as one date instead of splitting it up and checking each value separately.

The fix adds "in" to the list of allowed date filters and routes it to the existing generic handler that already knows how to do WHERE date IN (...) queries. Two small changes in one file.


## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)
[Screencast from 2026-04-03 18-33-30.webm](https://github.com/user-attachments/assets/758151d6-914c-4197-8b94-9ac31f20cf86)

Anything for maintainers to be made aware of
