### PR TITLE
Nc fix: skip grid keyboard handlers during IME composition

### DIFF
--- a/packages/nc-gui/components/smartsheet/Cell.vue
+++ b/packages/nc-gui/components/smartsheet/Cell.vue
@@ -173,6 +173,8 @@ const vModel = computed({
 })
 
 const navigate = (dir: NavigateDir, e: KeyboardEvent) => {
+  if (e.isComposing) return
+
   if (isJSON(column.value)) return
 
   if (currentRow.value.rowMeta.changed || currentRow.value.rowMeta.new) {

--- a/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
+++ b/packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue
@@ -950,6 +950,7 @@ const {
         return true
       }
     } else if (e.key === 'Enter') {
+      if (e.isComposing) return
       if (e.shiftKey) {
         // add a line break for types like LongText / JSON
         return true

--- a/packages/nc-gui/components/smartsheet/grid/Table.vue
+++ b/packages/nc-gui/components/smartsheet/grid/Table.vue
@@ -676,6 +676,7 @@ const {
         return true
       }
     } else if (e.key === 'Enter') {
+      if (e.isComposing) return
       if (e.shiftKey) {
         // add a line break for types like LongText / JSON
         return true

--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
@@ -85,6 +85,9 @@ export function useKeyboardNavigation({
   const meta = inject(MetaInj, ref())
 
   const _handleKeyDown = async (e: KeyboardEvent) => {
+    // Skip keyboard handling during IME composition (e.g. Japanese, Chinese, Korean input)
+    if (e.isComposing) return
+
     if (isViewSearchActive() || isCreateViewActive() || isActiveElementInsideScriptPane() || isActiveElementInsideExtension())
       return
     const activeDropdownEl = document.querySelector(

--- a/packages/nc-gui/composables/useMultiSelect/index.ts
+++ b/packages/nc-gui/composables/useMultiSelect/index.ts
@@ -963,6 +963,9 @@ export function useMultiSelect(
   const handleThrottledKeyDownAction = useThrottleFn(handleKeyDownAction, 60)
 
   const handleKeyDown = async (e: KeyboardEvent) => {
+    // Skip keyboard handling during IME composition (e.g. Japanese, Chinese, Korean input)
+    if (e.isComposing) return
+
     // invoke the keyEventHandler if provided and return if it returns true
 
     if (isArrayStructure ? await keyEventHandler?.(e) : keyEventHandler?.(e)) {


### PR DESCRIPTION
## Summary
- Adds `e.isComposing` guards to all grid keyboard handlers so Enter key during IME composition (Japanese, Chinese, Korean input) is not intercepted by the grid
- Fixes Phone/URL/Email fields clearing input on IME Enter, and Title field jumping to next row
- Covers all grid variants: standard Table, InfiniteTable, Canvas grid, and Cell-level navigation

## Files Changed
- `packages/nc-gui/components/smartsheet/Cell.vue` — guard in `navigate()`
- `packages/nc-gui/composables/useMultiSelect/index.ts` — guard in `handleKeyDown()`
- `packages/nc-gui/components/smartsheet/grid/Table.vue` — guard in Enter handler
- `packages/nc-gui/components/smartsheet/grid/InfiniteTable.vue` — guard in Enter handler
- `packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts` — guard in `_handleKeyDown()`

## Test plan
- [x] Enable Japanese (Romaji) IME on macOS
- [x] Open a grid view with Title, Phone, URL, Email fields
- [x] Type hiragana (e.g. "nihon") and press Enter to confirm IME conversion
- [x] Verify input is preserved and focus stays in the cell
- [x] Verify normal Enter behavior (navigation, exit edit mode) still works without IME
