### PR TITLE
fix: add system theme option for shared form view

### DIFF
--- a/packages/nc-gui/components/dlg/share-and-collaborate/SharePage.vue
+++ b/packages/nc-gui/components/dlg/share-and-collaborate/SharePage.vue
@@ -206,6 +206,7 @@ const surveyMode = computed({
 const themeOptions = [
   { label: 'Light', value: 'light' },
   { label: 'Dark', value: 'dark' },
+  { label: 'System', value: 'system' },
 ]
 
 const themeSetLocal = ref(false)
@@ -627,7 +628,7 @@ const copyCustomUrl = async (custUrl = '') => {
                 v-model:value="defaultTheme"
                 data-testid="nc-modal-share-view__themeSelect"
                 :options="themeOptions"
-                class="w-full nc-select-shadow"
+                class="nc-modal-share-view-theme-select w-full nc-select-shadow"
                 :disabled="isReadOnly"
               />
             </div>
@@ -713,7 +714,8 @@ const copyCustomUrl = async (custUrl = '') => {
   }
 }
 
-.nc-modal-share-view-language-select.ant-select {
+.nc-modal-share-view-language-select.ant-select,
+.nc-modal-share-view-theme-select.ant-select {
   .ant-select-selector {
     @apply !rounded-lg;
   }

--- a/packages/nc-gui/composables/useTheme.ts
+++ b/packages/nc-gui/composables/useTheme.ts
@@ -241,8 +241,8 @@ export const useTheme = createSharedComposable(() => {
     const themeParam = route.value.query?.['nc-theme'] || route.value.query?.theme
     if (isSharedViewRoute(route.value) && themeParam) {
       const queryTheme = themeParam as string
-      if (['light', 'dark'].includes(queryTheme)) {
-        selectedTheme.value = queryTheme as 'light' | 'dark'
+      if (['light', 'dark', 'system'].includes(queryTheme)) {
+        selectedTheme.value = queryTheme as ThemeMode
       }
     }
 

--- a/packages/nc-gui/lib/types.ts
+++ b/packages/nc-gui/lib/types.ts
@@ -192,7 +192,7 @@ interface SharedViewMeta extends Record<string, any> {
   transitionDuration?: number // in ms
   withTheme?: boolean
   theme?: Partial<ThemeConfig>
-  defaultTheme?: 'light' | 'dark'
+  defaultTheme?: 'light' | 'dark' | 'system'
   allowCSVDownload?: boolean
   rtl?: boolean
   preFillEnabled?: boolean


### PR DESCRIPTION
## Change Summary

- Adds a **System** theme option to the shared form view theme selector, allowing the form to follow the browser/OS `prefers-color-scheme` preference
- Updates `SharedViewMeta.defaultTheme` type to include `'system'`
- Accepts `nc-theme=system` query parameter on shared view routes

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
