### PR TITLE
fix: include viewId in comment copy URL to open correct view

### DIFF
--- a/packages/nc-gui/components/smartsheet/expanded-form/Sidebar/Comments.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/Sidebar/Comments.vue
@@ -23,6 +23,8 @@ const { basesUser } = storeToRefs(basesStore)
 
 const meta = inject(MetaInj, ref())
 
+const activeView = inject(ActiveViewInj, ref())
+
 const {
   deleteComment,
   resolveComment,
@@ -112,9 +114,13 @@ const saveComment = async () => {
 }
 
 const copyComment = async (comment: CommentType) => {
+  const viewId = activeView.value?.fk_model_id === meta.value?.id ? activeView.value?.id : undefined
+
   await copy(
     encodeURI(
-      `${dashboardUrl?.value}/${route.params.typeOrId}/${route.params.baseId}/${meta.value?.id}?rowId=${primaryKey.value}&commentId=${comment.id}`,
+      `${dashboardUrl?.value}/${route.params.typeOrId}/${route.params.baseId}/${meta.value?.id}${
+        viewId ? `/${viewId}` : ''
+      }?rowId=${primaryKey.value}&commentId=${comment.id}`,
     ),
   )
 }

--- a/packages/nc-gui/components/smartsheet/expanded-form/presentors/Discussion/EntryComment.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/presentors/Discussion/EntryComment.vue
@@ -17,6 +17,8 @@ const route = useRoute()
 
 const meta = inject(MetaInj, ref())
 
+const activeView = inject(ActiveViewInj, ref())
+
 /* stores */
 
 const { loadComments, resolveComment, updateComment, deleteComment, primaryKey } = useRowCommentsOrThrow()
@@ -120,9 +122,13 @@ function onCommentBlur() {
 }
 
 async function copyComment(comment: CommentType) {
+  const viewId = activeView.value?.fk_model_id === meta.value?.id ? activeView.value?.id : undefined
+
   await copy(
     encodeURI(
-      `${dashboardUrl?.value}/${route.params.typeOrId}/${route.params.baseId}/${meta.value?.id}?rowId=${primaryKey.value}&commentId=${comment.id}`,
+      `${dashboardUrl?.value}/${route.params.typeOrId}/${route.params.baseId}/${meta.value?.id}${
+        viewId ? `/${viewId}` : ''
+      }?rowId=${primaryKey.value}&commentId=${comment.id}`,
     ),
   )
 }


### PR DESCRIPTION
## Summary
- Comment "Copy URL" was missing `viewId` in the generated link, causing it to always open the default/first view instead of the current one
- Added `ActiveViewInj` inject in both `Sidebar/Comments.vue` and `Discussion/EntryComment.vue`
- Uses `activeView.fk_model_id === meta.id` guard so viewId is only included when the active view belongs to the same table (safe for LTAR expanded forms)

Ref https://github.com/nocodb/nocodb/issues/13451

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
