### PR TITLE
feat: add "Open in table" button to linked records dropdown

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { type ColumnType, type LinkToAnotherRecordType, isDateOrDateTimeCol } from 'nocodb-sdk'
+import { type ColumnType, type LinkToAnotherRecordType, type TableType, isDateOrDateTimeCol } from 'nocodb-sdk'
 import { PermissionEntity, PermissionKey, RelationTypes, isLinksOrLTAR } from 'nocodb-sdk'
 
 interface Prop {
@@ -13,7 +13,7 @@ interface Prop {
 
 const props = defineProps<Prop>()
 
-const emit = defineEmits(['update:modelValue', 'attachRecord', 'escape'])
+const emit = defineEmits(['update:modelValue', 'attachRecord', 'escape', 'openInTable'])
 
 const vModel = useVModel(props, 'modelValue', emit)
 
@@ -81,6 +81,8 @@ const {
 } = useLTARStoreOrThrow()
 
 const { withLoading } = useLoadingTrigger()
+
+const { openTable } = useTablesStore()
 
 const { isNew, state, removeLTARRef, addLTARRef } = useSmartsheetRowStoreOrThrow()
 
@@ -178,6 +180,12 @@ const addNewRecord = () => {
   isExpandedFormCloseAfterSave.value = true
   isNewRecord.value = true
   isBlueprintMode.value = false
+}
+
+const openLinkedTableInView = () => {
+  if (!relatedTableMeta.value?.id) return
+  vModel.value = false
+  openTable(relatedTableMeta.value as TableType)
 }
 
 const reloadViewDataListener = withLoading((params) => {
@@ -568,6 +576,20 @@ const handleKeyDown = (e: KeyboardEvent) => {
             <div class="flex items-center gap-1">
               <GeneralIcon icon="link2" class="!xs:hidden h-4 w-4" />
               {{ isMobileMode ? $t('title.linkMore') : $t('title.linkMoreRecords') }}
+            </div>
+          </NcButton>
+          <NcButton
+            v-if="!isPublic && !isForm && !isNew && isLinkedTableAccessible"
+            v-e="['c:links:open-in-table']"
+            data-testid="nc-child-list-button-open-in-table"
+            class="!hover:(bg-nc-bg-default text-nc-content-brand) !h-7 !text-small"
+            size="small"
+            type="secondary"
+            @click="openLinkedTableInView"
+          >
+            <div class="flex items-center gap-1">
+              <GeneralIcon icon="externalLink" class="!xs:hidden h-4 w-4" />
+              {{ $t('activity.openInTable') }}
             </div>
           </NcButton>
         </div>

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -2611,6 +2611,7 @@
     "linkRecord": "Link record",
     "addNewRecord": "Add new record",
     "newRecord": "New record",
+    "openInTable": "Open in table",
     "tableNameCreateNewRecord": "{tableName}: Create new record",
     "gotSavedLinkedSuccessfully": "{tableName} '{recordTitle}' got saved & linked successfully",
     "recordCreatedLinked": "Record Created & Linked",


### PR DESCRIPTION
Adds a navigation button in the linked records modal footer that allows users to quickly navigate to the related table, improving UX when working with linked records (resolves #12393)

Made-with: Cursor

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
