### PR TITLE
fix: make generate:sdk script cross-platform for Windows

### DIFF
--- a/packages/nocodb-sdk/package.json
+++ b/packages/nocodb-sdk/package.json
@@ -35,8 +35,7 @@
     "test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
     "test:unit": "ENV_FILE=./config/.env.test jest",
     "watch:build": "tsc -p tsconfig.json -w",
-    "generate:sdk": "node build-script/mergeAndGenerateSwaggerCE && pnpm dlx swagger-typescript-api@10.0.3 -r -p ./nc_swagger.json -o ./src/lib/  --axios --unwrap-response-data  --module-name-first-tag --type-suffix=Type --templates ../../scripts/sdk/templates; rm ./nc_swagger.json",
-    "preinstall": "npx only-allow pnpm"
+    "generate:sdk": "node build-script/mergeAndGenerateSwaggerCE && pnpm dlx swagger-typescript-api@10.0.3 -r -p ./nc_swagger.json -o ./src/lib/ --axios --unwrap-response-data --module-name-first-tag --type-suffix=Type --templates ../../scripts/sdk/templates && rimraf ./nc_swagger.json",    "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
     "@vue-flow/core": "^1.47.0",


### PR DESCRIPTION
## Change Summary
Fix Windows compatibility issue in the `generate:sdk` script that was breaking `pnpm bootstrap` on Windows.

The stray semicolon after the `--templates` path prevented custom templates from loading, causing incorrect SDK generation and the TypeScript error:

`Property 'delete' does not exist on type` in `filterUtils.ts:933`.

Addresses discussion: [#12587](https://github.com/nocodb/nocodb/discussions/12587)

## Change type
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test / Verification
- Tested on **Windows 11 + PowerShell**
- Tested on **Windows 11 + Git Bash**
- Ran `pnpm bootstrap` successfully with no errors
- No more "api template not found in undefined" warnings
- SDK builds correctly and `dbTableFilter.delete()` method is now properly generated

## Additional information / screenshots (optional)
**Root cause:**  
The line `--templates ../../scripts/sdk/templates;` caused `swagger-typescript-api` to read the templates directory literally as `templates;` (including the semicolon). Custom templates were therefore ignored and default templates were used instead.

**Fix:**  
- Removed the trailing semicolon  
- Changed `rm` to `rimraf` (already a dev dependency and cross-platform compatible)

