### PR TITLE
chore: migrate CI workflows to Ubicloud runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   validate-swagger-json:
-    runs-on: ubuntu-22.04
+    runs-on: ubicloud-standard-2
     timeout-minutes: 10
     if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'trigger-CI') || !github.event.pull_request.draft }}
     steps:

--- a/.github/workflows/cleanup-caches-by-branch.yml
+++ b/.github/workflows/cleanup-caches-by-branch.yml
@@ -5,7 +5,7 @@ on:
       - closed
 jobs:
   cleanup:
-    runs-on: ubuntu-22.04
+    runs-on: ubicloud-standard-2
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/dispatch-oss.yml
+++ b/.github/workflows/dispatch-oss.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-22.04
+    runs-on: ubicloud-standard-2
     steps:
     - uses: actions/github-script@v6
       with:


### PR DESCRIPTION
## Summary

Migrate 3 GitHub Actions workflows from GitHub-hosted `ubuntu-22.04` runners to `ubicloud-standard-2` runners for cost savings.

### Workflows changed

- **cleanup-caches-by-branch.yml** — cache cleanup on PR close
- **ci-cd.yml** — `validate-swagger-json` job
- **dispatch-oss.yml** — OSS dispatch on push to develop

### Why

Ubicloud runners are significantly cheaper than GitHub-hosted runners while providing equivalent compute. This change reduces CI costs with no functional impact — all three jobs run standard Linux tasks (jq validation, gh CLI, GitHub API calls) that are fully compatible with Ubicloud's Ubuntu-based runners.