### PR TITLE
fix: 移除对不存在的 gcp_marketplace 迁移文件的引用

### DIFF
--- a/packages/nocodb/src/meta/migrations/XcMigrationSourcev0.ts
+++ b/packages/nocodb/src/meta/migrations/XcMigrationSourcev0.ts
@@ -45,7 +45,6 @@ import * as nc_202603230000_subscription_last_paid_seat_count from './v0/nc_2026
 import * as nc_202603301109_fine_grained_api_tokens from './v0/nc_202603301109_fine_grained_api_tokens';
 import * as nc_202603310000_integration_links from './v0/nc_202603310000_integration_links';
 import * as nc_202604030000_installations_add_fk_user_id from './v0/nc_202604030000_installations_add_fk_user_id';
-import * as nc_202604040000_gcp_marketplace from './v0/nc_202604040000_gcp_marketplace';
 import * as nc_202604071200_default_org from './v0/nc_202604071200_default_org';
 import * as nc_202604071201_scim_config_default_role from './v0/nc_202604071201_scim_config_default_role';
 
@@ -104,8 +103,6 @@ export default class XcMigrationSourcev0 {
       'nc_202603301109_fine_grained_api_tokens',
       'nc_202603310000_integration_links',
       'nc_202604030000_installations_add_fk_user_id',
-
-      'nc_202604040000_gcp_marketplace',
       'nc_202604071200_default_org',
       'nc_202604071201_scim_config_default_role',
     ]);
@@ -211,9 +208,6 @@ export default class XcMigrationSourcev0 {
         return nc_202603310000_integration_links;
       case 'nc_202604030000_installations_add_fk_user_id':
         return nc_202604030000_installations_add_fk_user_id;
-
-      case 'nc_202604040000_gcp_marketplace':
-        return nc_202604040000_gcp_marketplace;
       case 'nc_202604071200_default_org':
         return nc_202604071200_default_org;
       case 'nc_202604071201_scim_config_default_role':


### PR DESCRIPTION
问题：
- XcMigrationSourcev0.ts 引用了 nc_202604040000_gcp_marketplace 迁移
- 该迁移文件从未被创建，导致后端启动时报 MODULE_NOT_FOUND 错误

解决方案：
- 从迁移源文件中移除对该缺失迁移的 import、注册和 switch case

这修复了本地开发环境中后端无法启动的问题。

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
