### PR TITLE
fix(ai): use correct activeProjectId in callAiSchemaApi

### DIFF
--- a/packages/nc-gui/composables/useNocoAi.ts
+++ b/packages/nc-gui/composables/useNocoAi.ts
@@ -71,7 +71,7 @@ export const useNocoAi = createSharedComposable(() => {
 
   const callAiSchemaApi = async (operation: string, input: any, customBaseId?: string, skipMsgToast = false) => {
     try {
-      const baseId = customBaseId || workspaceStore.activeProjectId.value
+      const baseId = customBaseId || activeProjectId.value
 
       if (!aiIntegrationAvailable.value || !baseId) {
         return


### PR DESCRIPTION
## Change Summary
In `useNocoAi.ts`, the `callAiSchemaApi` function was reading `workspaceStore.activeProjectId` which does not exist on workspaceStore. `activeProjectId` is already correctly destructured from `basesStore` at the top of the composable. This caused `baseId` to be undefined in call sites like `generateTables`, `predictViews`, and `predictFilters`, making the API call fail silently.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test / Verification
Exercise any flow that calls `callAiSchemaApi` with no explicit `customBaseId` (e.g. AI "Suggest Tables", "Predict Views", "Predict Filters" from within a base) — `baseId` should now resolve correctly from `basesStore.activeProjectId` and the API call should succeed instead of silently bailing.

## Additional information
The same pattern is used correctly in `callAiUtilsApi` which uses `activeProjectId.value` — this change brings `callAiSchemaApi` in line with it. `workspaceStore` exposes `activeWorkspaceId` (used correctly by `callAiSchemaCreateApi`) but has never had `activeProjectId`.