### PR TITLE
fix(nocodb-sdk): use correct dbTableFilterDelete method in filterUtils to resolve bootstrap TS error

### DIFF
--- a/packages/nocodb-sdk/src/lib/filter/filterUtils.ts
+++ b/packages/nocodb-sdk/src/lib/filter/filterUtils.ts
@@ -940,7 +940,7 @@ export const deleteFilterWithSub = async (
       result = [...result, ...(await deleteFilterWithSub($api, child))];
     }
   }
-  await $api.dbTableFilter.delete(filter.id);
+  await $api.dbTableFilter.dbTableFilterDelete(filter.id);
   result.push(filter.id);
   return result;
 };


### PR DESCRIPTION


## Change Summary

Fixed a TypeScript error in packages/nocodb-sdk/src/lib/filter/filterUtils.ts:943 where .delete() was being called on the dbTableFilter object, but the SDK generates dbTableFilterDelete as the correct method name. This caused pnpm bootstrap to fail for all developers setting up locally.
Fixes #13602 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification
On develop branch, run pnpm bootstrap
Observe the following error:

packages/nocodb-sdk/src/lib/filter/filterUtils.ts:943:28
Property 'delete' does not exist on type '{ dbTableFilterRead... }'

Apply this fix — change .delete(filter.id) to .dbTableFilterDelete(filter.id) on line 943
Run pnpm bootstrap again
Bootstrap completes successfully with no TypeScript errors.

## Additional information / screenshots (optional)
BEFORE:
<img width="1847" height="828" alt="Screenshot 2026-04-24 011013" src="https://github.com/user-attachments/assets/d7bff970-c24f-4955-b144-ba345be27566" />


AFTER:
<img width="1799" height="270" alt="Screenshot 2026-04-24 011319" src="https://github.com/user-attachments/assets/190b5d57-06a4-46fa-9df8-03faeb23e41b" />


Anything for maintainers to be made aware of
