### PR TITLE
fix dataRead returning nestedLimit as undefined and limiting to 5

### DIFF
--- a/packages/nocodb/src/services/v3/data-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-v3.service.ts
@@ -1348,6 +1348,8 @@ export class DataV3Service {
 
     const linksAsLtar = param.query[QUERY_STRING_LINKS_AS_LTAR] === 'true';
 
+    const nestedLimit = +param.query?.nestedLimit || BaseModelSqlv2.config.ltarV3Limit;
+
     return hasPrimaryKey(result)
       ? await this.transformRecordToV3Format({
           context: context,
@@ -1356,7 +1358,7 @@ export class DataV3Service {
           primaryKeys: primaryKeys,
           requestedFields: requestedFields,
           columns: columns,
-          nestedLimit: undefined,
+          nestedLimit: nestedLimit,
           skipSubstitutingColumnIds:
             param.query?.[QUERY_STRING_FIELD_ID_ON_RESULT] === 'true',
           reuse: {}, // Create reuse cache for this data read operation


### PR DESCRIPTION
## Change Summary

Fixes the dataRead endpoint in APIv3 silently capping linked records at 5 regardless of the ?nestedLimit= query param.
In DataV3Service.dataRead(), nestedLimit: undefined was passed to transformRecordToV3Format, which always fell back to BaseModelSqlv2.config.ltarV3Limit (5). The fix extracts nestedLimit from param.query the same way dataList and nestedDataList already do, making all three methods consistent.

Closes #13616  

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Create Table-1 and Table-2
Add 5+ rows to Table-2
In Table-1, create a one-to-many linked field to Table-2
Create a row in Table-1 and link all rows from Table-2
Call GET /api/v3/data/:baseName/:modelId/records/:rowId  previously returned only 5 linked records
Call GET /api/v3/data/:baseName/:modelId/records/:rowId?nestedLimit=25 now returns all linked records up to the specified limit
Calling without ?nestedLimit= still defaults to 5 - no regression

## Additional information / screenshots (optional)

dataList and nestedDataList in the same service already handled nestedLimit correctly. This was an oversight in dataRead causing an inconsistent API behavior.
