### PR TITLE
fix(public-shared-view): include Kanban group-by column on grouped data endpoint when hidden

### DIFF
--- a/packages/nocodb/src/services/public-datas.service.ts
+++ b/packages/nocodb/src/services/public-datas.service.ts
@@ -11,7 +11,15 @@ import type { GridViewColumn, LinkToAnotherRecordColumn } from '~/models';
 import type { NcContext } from '~/interface/config';
 import type { DependantFields } from '~/helpers/getAst';
 import { nocoExecute } from '~/utils';
-import { Base, Column, FormView, Model, Source, View } from '~/models';
+import {
+  Base,
+  Column,
+  FormView,
+  KanbanView,
+  Model,
+  Source,
+  View,
+} from '~/models';
 import { NcError } from '~/helpers/catchError';
 import getAst from '~/helpers/getAst';
 import { PagedResponseImpl } from '~/helpers/PagedResponse';
@@ -92,6 +100,19 @@ export class PublicDatasService {
 
       if (view.type === ViewTypes.GRID && (vc as GridViewColumn).group_by) {
         groupByColumnIds.add(vc.fk_column_id);
+      }
+    }
+
+    // Kanban views always group records by `fk_grp_col_id`, even when that
+    // column is hidden from the view. The frontend issues a grouped-data
+    // request keyed on that column id, so it must be accessible via the
+    // shared-view group endpoint regardless of `show`. The values are
+    // already visible in the UI as stack headers, so allowing access here
+    // doesn't leak any data that isn't otherwise rendered.
+    if (view.type === ViewTypes.KANBAN) {
+      const kanbanView = await KanbanView.get(context, view.id);
+      if (kanbanView?.fk_grp_col_id) {
+        groupByColumnIds.add(kanbanView.fk_grp_col_id);
       }
     }
 


### PR DESCRIPTION
## Change Summary

Fix shared Kanban views failing to load when the group-by (stack-by) column is hidden in the view. closes: #13732

The shared-view grouped-data endpoint validates the requested `groupColumnId` against the set of *visible* or *group-by* columns. For Grid views, columns toggled `group_by` were already added to that set, but the Kanban grouping column (stored on `KanbanView.fk_grp_col_id`) was not — so when a user hid the stack-by column, the public endpoint returned `400 {"msg":"Column not accessible in this shared view"}` and the shared Kanban never finished loading.

This patch adds the Kanban's `fk_grp_col_id` to `groupByColumnIds` in `getVisibleColumnInfo`, mirroring the existing Grid pattern. The grouping column's values are already rendered as stack headers in the shared UI, so allowing access here doesn't leak data that isn't otherwise visible.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat
- [ ] docs
- [ ] style
- [ ] refactor
- [ ] test
- [ ] chore

## Test/ Verification

End-to-end repro against a local dev backend:

1. Sign up admin, create a table, add a `Status` (single-select) column with `Todo`/`Doing`/`Done` options, insert several rows.
2. Create a Kanban view grouped by `Status`.
3. Hide the `Status` column in the Kanban view (`PATCH /api/v1/db/meta/views/:viewId/columns/:viewColId  {"show": false}`).
4. Enable the shared view and copy the UUID.
5. Hit `GET /api/v1/db/public/shared-view/:uuid/group/:statusColId`.

| | Before | After |
|---|---|---|
| Response | `400 {"msg":"Column not accessible in this shared view"}` | `200` + grouped data (stacks for `Todo`, `Doing`, `Done`, plus `null`/uncategorized) |

`tsc --noEmit` clean on `packages/nocodb`.

## Additional information / screenshots

Authenticated (non-shared) Kanban views were not affected, because `getDataGroupBy` in `datas.service.ts` does not enforce this column-access check. The fix only loosens the shared-view check for the Kanban grouping column specifically; all other column-access rules (filters, sorts, aggregations, `where` clauses, `fields`/`f` query params) remain unchanged.