### PR TITLE
Upstream/v3 ltar update fixes

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2/ltar-cols-updater.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/ltar-cols-updater.ts
@@ -72,12 +72,22 @@ export const LTARColsUpdater = (param: {
             existingLinks = [existingLinks];
           }
 
-          const idsToLink = [
-            ...(Array.isArray(d[col.title])
-              ? d[col.title]
-              : [d[col.title]]
-            ).map((rec) => baseModel.extractPksValues(rec, true)),
-          ];
+          // Normalize the requested-link value into an array of PKs.
+          // `null` (or an array containing null) means "set this field
+          // to no links" — translate that to an empty target list so
+          // the diff below produces only unlinks. Without this, a null
+          // value would be passed through to addLinks/validateRefIds
+          // and throw on the typeof-null-is-object quirk.
+          const requestedValue = d[col.title];
+          const requestedItems =
+            requestedValue === null || requestedValue === undefined
+              ? []
+              : Array.isArray(requestedValue)
+              ? requestedValue.filter((v) => v !== null && v !== undefined)
+              : [requestedValue];
+          const idsToLink = requestedItems.map((rec) =>
+            baseModel.extractPksValues(rec, true),
+          );
 
           // check for any missing links then unlink
           const idsToUnlink = existingLinks

--- a/packages/nocodb/src/db/CustomKnex.ts
+++ b/packages/nocodb/src/db/CustomKnex.ts
@@ -1052,6 +1052,7 @@ type CustomKnex = Knex & {
   _cteGenerator?: CTEGenerator;
   cteGenerator?: (context?: NcContext) => CTEGenerator;
   applyCte?: (qb: Knex.QueryInterface) => void;
+  clearCte?: () => void;
 };
 
 type CustomTransaction = Knex.Transaction & {
@@ -1258,6 +1259,29 @@ function CustomKnex(
 
           _nested: { enumerable: true, writable: true, value: 0 },
           _aborted: { enumerable: true, writable: true, value: false },
+
+          // CTE methods inherited from the parent customKnex.
+          // BaseModelSqlv2 callers occasionally end up holding a
+          // transaction as their `_dbDriver` (e.g. ltar-cols-updater
+          // creates a trx, then mmList constructs a child baseModel
+          // with `dbDriver: baseModel.dbDriver` — the getter returns
+          // the active trx, not the parent kn). `execAndParse` calls
+          // `this.knex.applyCte(qb)` and would otherwise throw
+          // `applyCte is not a function`. Delegate to the parent so
+          // CTE state is shared (the generator is keyed by knex
+          // instance, and a transaction runs against the same pool).
+          cteGenerator: {
+            enumerable: true,
+            value: (context?: NcContext) => kn.cteGenerator(context),
+          },
+          applyCte: {
+            enumerable: true,
+            value: (qb: Knex.QueryInterface) => kn.applyCte(qb),
+          },
+          clearCte: {
+            enumerable: true,
+            value: () => kn.clearCte(),
+          },
         });
 
         return trx;

--- a/packages/nocodb/src/helpers/dbHelpers.ts
+++ b/packages/nocodb/src/helpers/dbHelpers.ts
@@ -849,6 +849,13 @@ export const dataWrapper = (data: any) => {
       id: string;
       title: string;
     }) => {
+      // Guard: callers occasionally pass null/undefined (e.g. an LTAR
+      // field with `null` value to mean unlink). The `in` operator
+      // throws on non-objects; treat as "not present".
+      if (data === null || typeof data !== 'object') {
+        return undefined;
+      }
+
       if (column.column_name in data) {
         return data[column.column_name];
       }

--- a/packages/nocodb/src/services/v3/data-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-v3.service.ts
@@ -536,17 +536,21 @@ export class DataV3Service {
         // common shorthand variants — capital `Id` (the default PK
         // column title in NocoDB), `ID`, or a bare scalar primary key.
         if (Array.isArray(fieldValue)) {
+          // Normalize first, drop entries that didn't yield a usable PK,
+          // then convert. Doing the filter before the map avoids passing
+          // null into convertRecordIdToInternal.
           transformedFields[key] = fieldValue
-            .map((nestedRecord) =>
+            .map((nestedRecord) => this.extractRecordIdFromNested(nestedRecord))
+            .filter((normalized): normalized is { id: any } => normalized !== null)
+            .map((normalized) =>
               this.convertRecordIdToInternal(
                 context,
-                this.extractRecordIdFromNested(nestedRecord),
+                normalized,
                 relatedPrimaryKey,
                 relatedPrimaryKeys,
                 getPrimaryKey,
               ),
-            )
-            .filter((v) => v !== null);
+            );
         } else if (fieldValue !== null && fieldValue !== undefined) {
           const normalized = this.extractRecordIdFromNested(fieldValue);
           if (normalized !== null) {

--- a/packages/nocodb/src/services/v3/data-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-v3.service.ts
@@ -530,31 +530,34 @@ export class DataV3Service {
 
         const fieldValue = fields[key];
 
-        // Handle v3 format consistently for all relation types
+        // Handle v3 format consistently for all relation types. Each
+        // shape funnels through `extractRecordIdFromNested` so we can
+        // accept the canonical lowercase `id` envelope as well as
+        // common shorthand variants — capital `Id` (the default PK
+        // column title in NocoDB), `ID`, or a bare scalar primary key.
         if (Array.isArray(fieldValue)) {
-          // Array of records - each should have id property
-          transformedFields[key] = fieldValue.map((nestedRecord) =>
-            this.convertRecordIdToInternal(
+          transformedFields[key] = fieldValue
+            .map((nestedRecord) =>
+              this.convertRecordIdToInternal(
+                context,
+                this.extractRecordIdFromNested(nestedRecord),
+                relatedPrimaryKey,
+                relatedPrimaryKeys,
+                getPrimaryKey,
+              ),
+            )
+            .filter((v) => v !== null);
+        } else if (fieldValue !== null && fieldValue !== undefined) {
+          const normalized = this.extractRecordIdFromNested(fieldValue);
+          if (normalized !== null) {
+            transformedFields[key] = this.convertRecordIdToInternal(
               context,
-              nestedRecord,
+              normalized,
               relatedPrimaryKey,
               relatedPrimaryKeys,
               getPrimaryKey,
-            ),
-          );
-        } else if (
-          fieldValue &&
-          typeof fieldValue === 'object' &&
-          fieldValue.id
-        ) {
-          // Single record with id property (v3 format)
-          transformedFields[key] = this.convertRecordIdToInternal(
-            context,
-            fieldValue,
-            relatedPrimaryKey,
-            relatedPrimaryKeys,
-            getPrimaryKey,
-          );
+            );
+          }
         } else if (fieldValue === null) {
           transformedFields[key] = null;
         }
@@ -562,6 +565,23 @@ export class DataV3Service {
     }
 
     return transformedFields;
+  }
+
+  /**
+   * Normalize a user-supplied LTAR record reference to the internal
+   * `{ id }` envelope. Accepts:
+   *   - a scalar (number | string) — treated as the PK directly
+   *   - an object with `id` / `Id` / `ID` — extracts whichever is set
+   *   - anything else — returns null (caller filters)
+   */
+  private extractRecordIdFromNested(value: any): { id: any } | null {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'object') {
+      const pk = value.id ?? value.Id ?? value.ID;
+      if (pk === undefined || pk === null) return null;
+      return { id: pk };
+    }
+    return { id: value };
   }
 
   /**


### PR DESCRIPTION
## Change Summary

Fix `v3 PATCH /api/v3/data/{baseId}/{tableId}/records` so it accepts `LinkToAnotherRecord` fields without crashing. Currently every such payload returns HTTP 500 with `TypeError: this.knex.applyCte is not a function`. Four small bug fixes across CustomKnex, the v3 transform, dataWrapper, and the LTAR cols updater. Net `+87 / -26` across 4 files.

Trigger chain (regression introduced by da23a74ffb "use trx for updateLTARCols"):
bulkUpdate → updateLTARCols
updateLTARCols creates trx, builds trxBaseModel
trxBaseModel.dbDriver getter returns the trx (not the parent kn)
mmList constructs a refBaseModel with dbDriver: baseModel.dbDriver
refBaseModel._dbDriver = trx
refBaseModel.execAndParse → this.knex.applyCte(qb)
this.knex returns _dbDriver (= trx); applyCte is undefined → throws.

Commits in this PR:
1. **fix(db): inherit CTE methods on customKnex transactions** — root cause fix. The transactions returned by `customKnex().transaction()` weren't carrying the parent's `applyCte` / `clearCte` / `cteGenerator` methods. Add them as delegating properties on the trx-decoration block; CTE state is connection-pool-scoped so sharing the parent's state is correct. Also extends the `CustomKnex` type with `clearCte?`.
2. **fix(db): guard `dataWrapper.getByColumnNameTitleOrId` against null/non-object** — once (1) is fixed, the next failure is `TypeError: Cannot use 'in' operator to search for 'id' in null` from the wrapper used unconditionally on a null LTAR value. Treat null/undefined/non-object as "column not present" → return undefined.
3. **fix(v3): accept LTAR field shape variants in record update** — the v3 transform only accepted `{ id: <pk> }` envelopes. Common shorthand crashed (`{ Client: { Id: 1 } }`, `{ Client: 1 }`, `{ Client: [{ Id: 1 }] }`, `{ Client: [1] }`). Funnel every shape through one normalizer that accepts `id` / `Id` / `ID` on objects and bare scalars.
4. **fix(v3): treat null LTAR field value as "unlink everything"** — `PATCH /records` with `{ <ltar>: null }` is the documented unlink path. The updater wrapped null in `[null]` and let it leak into `validateRefIds`, which tripped `typeof null === 'object'` and threw a confusing `Missing primary key column` error. Normalize null to an empty target list before the diff so only unlinks fire.
No issue number — happy to file one if maintainers prefer that workflow.
## Change type
- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
## Test/ Verification
End-to-end verified locally and on a Coolify-deployed instance running this branch. Setup: a `Clients` table (Id, Title) and a `Features` table with a `Client` LTAR field of `mo` type pointing at Clients, one row in each. Test runner uses the official `@modelcontextprotocol/sdk` client over Streamable HTTP for the MCP path, and direct `curl` for the REST path.
### Before (`develop` HEAD, no fixes)
PATCH /api/v3/data/{baseId}/{tableId}/records
body: [{"id":1,"fields":{"Client":{"id":1}}}]

→ HTTP 500
{
"innerError": {
"message": "this.knex.applyCte is not a function",
"stack": "TypeError: this.knex.applyCte is not a function
at BaseModelSqlv2.execAndParse (BaseModelSqlv2.ts:6707:17)
at Object.mmList (relation-data-fetcher.ts:327:43)
at Object.update [as updateLTARCols] (ltar-cols-updater.ts:52:29)
at BaseModelSqlv2.bulkUpdate (BaseModelSqlv2.ts:4214:9)
..."
}
}

Every payload shape that touches an LTAR field returns 500.
### After (this PR)
Direct `PATCH /api/v3/data/.../records`:
[LINKED] obj capital Id { Client: { Id: 1 } }
[LINKED] obj lowercase id { Client: { id: 1 } }
[LINKED] scalar 1 { Client: 1 }
[LINKED] array of obj Id { Client: [{ Id: 1 }] }
[LINKED] array of obj id { Client: [{ id: 1 }] }
[LINKED] scalar in array { Client: [1] }
[LINKED] scalar+link mix Title + Client both set
[UNLINKED] null unlink { Client: null }

All eight return HTTP 200, the link is present in the response body, and a follow-up `GET /records/1` confirms the link is persisted. Same eight cases pass through the MCP `updateRecords` tool, which now uses the unmodified `dataUpdate` path with no LTAR-aware workaround in the MCP layer.
No regressions on the previously-working paths I tested:
- `createRecords` with embedded LTAR (`POST /api/v3/data/.../records`) — still works.
- `POST` / `DELETE /api/v2/tables/{tableId}/links/{linkFieldId}/records/{recordId}` — still work.
- v3 PATCH with non-LTAR scalar fields only — still works.
I haven't added an automated regression test in this PR — happy to add one in a follow-up commit if you'd like; tell me where you'd want it (e.g. `packages/nocodb/tests/...`).
## Additional information / screenshots (optional)
- The fixes are independent. (1) is the root cause; (2)/(3)/(4) become visible only once (1) is fixed but address pre-existing bugs in the LTAR payload-handling code path. They could be reviewed together or split if you'd prefer four separate PRs — I kept them together because they're all on the same code path and the integration test only passes with all four.
- One out-of-scope behavior I noticed but did **not** change: when `_activeTransaction` is set on a `BaseModelSqlv2`, the `dbDriver` getter at `BaseModelSqlv2.ts:218` returns the transaction, and several callers pass that into child baseModel constructors as the new `dbDriver`. This pattern is what made the `applyCte` regression surface in the first place — a child baseModel ends up with `_dbDriver = trx` instead of the parent customKnex. Fixing it at the customKnex layer (this PR) makes the existing pattern safe; refactoring all the callsites to pass the parent kn explicitly with transaction as a separate param would be a bigger change and seemed out of scope here.
- Tested on SQLite locally and on the deployed Coolify instance. I haven't manually re-run against Postgres or MySQL — the fix is at the customKnex layer, which is database-agnostic, but flagging in case you want me to verify on those backends before merge.