### PR TITLE
fix(gui): auto-link record when creating from Has Many "+" button (V2 Link)

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -227,6 +227,7 @@ const onCreatedRecord = async (record: any) => {
   if (!isNewRecord.value) return
 
   if (!isNew.value) {
+    await link(record)
     vModel.value = false
   } else {
     await addLTARRef(record, injectedColumn?.value as ColumnType)


### PR DESCRIPTION
## Summary

Fixes #13770

After V1→V2 Link field upgrade, creating a new record from a Has Many cell's "+" button no longer auto-links the child to the parent.

**Root cause:** \`LinkedItems.vue\` \`onCreatedRecord()\` closes the dialog without calling \`link()\` for existing parent records, relying on \`populateInsertObject()\` to write the FK value. After V2 upgrade, FK columns are deleted and replaced by junction tables, so this implicit link path no longer works.

**Fix:** Explicitly call \`link(record)\` (already available from \`useLTARStoreOrThrow()\`) for existing parent records. This inserts the junction table row via the \`nestedAdd\` API, matching the behavior of manually linking an existing record.

### Webhook timing caveat

This fix calls \`link()\` **after** the record is created, meaning the create webhook fires before the link is established. In V1, the FK was part of the INSERT statement, so webhooks always saw the relation at trigger time.

A more thorough fix would be to update \`populateInsertObject()\` / \`nestedInsert()\` in the backend to handle V2 Link fields and create the junction table entry as part of the record creation flow. This PR is a minimal frontend-only fix; the backend approach is noted in #13770 as a follow-up.

## Changes

- \`packages/nc-gui/components/virtual-cell/components/LinkedItems.vue\`: Add \`await link(record)\` in the existing-parent branch of \`onCreatedRecord()\`