### PR TITLE
fix: V2 Link — auto-link and pre-fill when creating from HM/OM cell

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -147,6 +147,14 @@ const newRowState = computed(() => {
         colOpt.fk_child_column_id === colOpt1.fk_parent_column_id &&
         colOpt.fk_mm_model_id === colOpt1.fk_mm_model_id
       )
+    } else if (
+      (colOpt.type === RelationTypes.ONE_TO_MANY && colOpt1?.type === RelationTypes.MANY_TO_ONE) ||
+      (colOpt.type === RelationTypes.MANY_TO_ONE && colOpt1?.type === RelationTypes.ONE_TO_MANY)
+    ) {
+      return (
+        colOpt.fk_parent_column_id === colOpt1.fk_child_column_id &&
+        colOpt.fk_child_column_id === colOpt1.fk_parent_column_id
+      )
     } else {
       return (
         colOpt.fk_parent_column_id === colOpt1.fk_parent_column_id && colOpt.fk_child_column_id === colOpt1.fk_child_column_id
@@ -157,7 +165,7 @@ const newRowState = computed(() => {
   const relatedTableColOpt = colInRelatedTable?.colOptions as LinkToAnotherRecordType
   if (!relatedTableColOpt) return {}
 
-  if (relatedTableColOpt.type === RelationTypes.BELONGS_TO) {
+  if (relatedTableColOpt.type === RelationTypes.BELONGS_TO || relatedTableColOpt.type === RelationTypes.MANY_TO_ONE) {
     return {
       [colInRelatedTable.title as string]: row?.value?.row,
     }

--- a/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/UnLinkedItems.vue
@@ -205,6 +205,14 @@ const newRowState = computed(() => {
         colOpt.fk_child_column_id === colOpt1.fk_parent_column_id &&
         colOpt.fk_mm_model_id === colOpt1.fk_mm_model_id
       )
+    } else if (
+      (colOpt.type === RelationTypes.ONE_TO_MANY && colOpt1?.type === RelationTypes.MANY_TO_ONE) ||
+      (colOpt.type === RelationTypes.MANY_TO_ONE && colOpt1?.type === RelationTypes.ONE_TO_MANY)
+    ) {
+      return (
+        colOpt.fk_parent_column_id === colOpt1.fk_child_column_id &&
+        colOpt.fk_child_column_id === colOpt1.fk_parent_column_id
+      )
     } else {
       return (
         colOpt.fk_parent_column_id === colOpt1.fk_parent_column_id && colOpt.fk_child_column_id === colOpt1.fk_child_column_id
@@ -215,7 +223,7 @@ const newRowState = computed(() => {
   const relatedTableColOpt = colInRelatedTable?.colOptions as LinkToAnotherRecordType
   if (!relatedTableColOpt) return {}
 
-  if (relatedTableColOpt.type === RelationTypes.BELONGS_TO || relatedTableColOpt.type === RelationTypes.ONE_TO_ONE) {
+  if (relatedTableColOpt.type === RelationTypes.BELONGS_TO || relatedTableColOpt.type === RelationTypes.ONE_TO_ONE || relatedTableColOpt.type === RelationTypes.MANY_TO_ONE) {
     return {
       [colInRelatedTable.title as string]: row?.value?.row,
     }

--- a/packages/nc-gui/utils/dataUtils.ts
+++ b/packages/nc-gui/utils/dataUtils.ts
@@ -7,6 +7,7 @@ import {
   integerPreservingRollupFunctions,
   integerRollupFunctions,
   isAIPromptCol,
+  isBtLikeV2Junction,
   isCreatedOrLastModifiedByCol,
   isCreatedOrLastModifiedTimeCol,
   isIntegerUiType,
@@ -114,7 +115,8 @@ export async function populateInsertObject({
     if (
       ltarState &&
       col.uidt === UITypes.LinkToAnotherRecord &&
-      (<LinkToAnotherRecordType>col.colOptions).type === RelationTypes.BELONGS_TO
+      (<LinkToAnotherRecordType>col.colOptions).type === RelationTypes.BELONGS_TO &&
+      !isBtLikeV2Junction(col)
     ) {
       if (ltarState[col.title!] || row[col.title!]) {
         const ltarVal = ltarState[col.title!] || row[col.title!]

--- a/packages/nocodb/src/db/BaseModelSqlv2/nested-link-preparator.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/nested-link-preparator.ts
@@ -1,4 +1,4 @@
-import { isLinkV2, type NcRequest, RelationTypes } from 'nocodb-sdk';
+import { isBtLikeV2Junction, isLinkV2, type NcRequest, RelationTypes } from 'nocodb-sdk';
 import type { IBaseModelSqlV2 } from '~/db/IBaseModelSqlV2';
 import {
   extractIdPropIfObjectOrReturn,
@@ -85,9 +85,9 @@ export class NestedLinkPreparator {
           dbDriver: baseModel.dbDriver,
         });
 
-        // V2 OO uses junction table (like MO), not FK-based like V1 OO
+        // V2 OO/BT uses junction table (like MO), not FK-based like V1
         const effectiveType =
-          isLinkV2(col) && colOptions.type === RelationTypes.ONE_TO_ONE
+          isLinkV2(col) && isBtLikeV2Junction(col)
             ? RelationTypes.MANY_TO_ONE
             : colOptions.type;
 


### PR DESCRIPTION
## Summary

Fixes #13770

After V1→V2 Link upgrade, clicking "+" in a HM/OM cell to create a child record did not pre-fill the reverse BT/MO field or establish the link.

### Root causes & fixes

| File | Issue | Fix |
|------|-------|-----|
| \`nested-link-preparator.ts\` | V2 BT not routed to junction table path | Use \`isBtLikeV2Junction()\` to route through MO code path |
| \`dataUtils.ts\` | FK assignment for deleted V2 FK column | Skip FK assignment when \`isBtLikeV2Junction\` |
| \`LinkedItems.vue\` / \`UnLinkedItems.vue\` | V2 om↔mo cross-match failure + missing MO type check | Add om/mo cross-match + include MO in single-record check |

Junction table row is created within the INSERT transaction → webhooks see the link at trigger time.