### PR TITLE
feat: add eq_id/neq_id/in_id/nin_id operators for Link field filtering by record ID

### DIFF
--- a/packages/nocodb-sdk/src/lib/parser/queryFilter/query-filter-lexer.ts
+++ b/packages/nocodb-sdk/src/lib/parser/queryFilter/query-filter-lexer.ts
@@ -37,6 +37,10 @@ export const COMPARISON_OPS = <const>[
   'isWithin',
   'btw',
   'nbtw',
+  'eq_id',
+  'neq_id',
+  'in_id',
+  'nin_id',
 ];
 
 export const COMPARISON_OPS_ALIAS = <const>[

--- a/packages/nocodb/src/db/field-handler/handlers/links/links.general.handler.ts
+++ b/packages/nocodb/src/db/field-handler/handlers/links/links.general.handler.ts
@@ -14,7 +14,8 @@ export class LinksGeneralHandler extends GenericFieldHandler {
     options: FilterOptions,
   ) {
     // V2 MO/OO: single-record semantics — filter by display value (like BT)
-    if (isBtLikeV2Junction(column)) {
+    // _id operators: always route to LTAR handler for primary key filtering
+    if (isBtLikeV2Junction(column) || filter.comparison_op?.endsWith('_id')) {
       return new LtarGeneralHandler().filter(knex, filter, column, options);
     }
 

--- a/packages/nocodb/src/db/field-handler/handlers/ltar/ltar.general.handler.ts
+++ b/packages/nocodb/src/db/field-handler/handlers/ltar/ltar.general.handler.ts
@@ -51,6 +51,15 @@ export class LtarGeneralHandler extends GenericFieldHandler {
         : RelationTypes.HAS_MANY;
     }
 
+    // _id operators: filter by related record's primary key instead of display value
+    const isIdOp = filter.comparison_op?.endsWith('_id') ?? false;
+    const effectiveFilter = isIdOp
+      ? new Filter({
+          ...filter,
+          comparison_op: filter.comparison_op.replace(/_id$/, ''),
+        })
+      : filter;
+
     if (relationType === RelationTypes.HAS_MANY) {
       const childTableAlias = getAlias(aliasCount);
 
@@ -117,12 +126,14 @@ export class LtarGeneralHandler extends GenericFieldHandler {
       const parseOperationResult = await parseConditionV2(
         childBaseModel,
         new Filter({
-          ...filter,
-          ...(filter.comparison_op in negatedMapping
-            ? negatedMapping[filter.comparison_op]
+          ...effectiveFilter,
+          ...(effectiveFilter.comparison_op in negatedMapping
+            ? negatedMapping[effectiveFilter.comparison_op]
             : {}),
           fk_model_id: childModel.id,
-          fk_column_id: (await getDisplayValueOfRefTable(context, column))?.id,
+          fk_column_id: isIdOp
+            ? childModel.primaryKey?.id
+            : (await getDisplayValueOfRefTable(context, column))?.id,
         }),
         aliasCount,
         childTableAlias,
@@ -210,12 +221,14 @@ export class LtarGeneralHandler extends GenericFieldHandler {
       const parseOperationResult = await parseConditionV2(
         parentBaseModel,
         new Filter({
-          ...filter,
-          ...(filter.comparison_op in negatedMapping
-            ? negatedMapping[filter.comparison_op]
+          ...effectiveFilter,
+          ...(effectiveFilter.comparison_op in negatedMapping
+            ? negatedMapping[effectiveFilter.comparison_op]
             : {}),
           fk_model_id: parentModel.id,
-          fk_column_id: (await getDisplayValueOfRefTable(context, column))?.id,
+          fk_column_id: isIdOp
+            ? parentModel.primaryKey?.id
+            : (await getDisplayValueOfRefTable(context, column))?.id,
         }),
         aliasCount,
         parentTableAlias,
@@ -362,12 +375,14 @@ export class LtarGeneralHandler extends GenericFieldHandler {
       const parseOperationResult = await parseConditionV2(
         parentBaseModel,
         new Filter({
-          ...filter,
-          ...(filter.comparison_op in negatedMapping
-            ? negatedMapping[filter.comparison_op]
+          ...effectiveFilter,
+          ...(effectiveFilter.comparison_op in negatedMapping
+            ? negatedMapping[effectiveFilter.comparison_op]
             : {}),
           fk_model_id: parentModel.id,
-          fk_column_id: (await getDisplayValueOfRefTable(context, column))?.id,
+          fk_column_id: isIdOp
+            ? parentModel.primaryKey?.id
+            : (await getDisplayValueOfRefTable(context, column))?.id,
         }),
         aliasCount,
         parentTableAlias,

--- a/packages/nocodb/src/db/field-handler/utils/handlerUtils.ts
+++ b/packages/nocodb/src/db/field-handler/utils/handlerUtils.ts
@@ -28,6 +28,8 @@ export function ncIsStringHasValue(val: string | undefined | null) {
 export const negatedMapping = {
   nlike: { comparison_op: 'like' },
   neq: { comparison_op: 'eq' },
+  neq_id: { comparison_op: 'eq_id' },
+  nin_id: { comparison_op: 'in_id' },
   blank: { comparison_op: 'notblank' },
   notchecked: { comparison_op: 'checked' },
   nanyof: { comparison_op: 'anyof' },


### PR DESCRIPTION
## Summary

Fixes #13762

V2 Link fields can only be filtered by display value (\`(author,eq,John)\`), with no way to filter by record ID. This is a breaking change from V1 where FK columns allowed \`(author_id,eq,5)\`.

### New operators

| Operator | Syntax | Description |
|----------|--------|-------------|
| \`eq_id\` | \`(author,eq_id,5)\` | Equal by related record ID |
| \`neq_id\` | \`(author,neq_id,5)\` | Not equal by ID |
| \`in_id\` | \`(author,in_id,1,2,3)\` | In list of IDs |
| \`nin_id\` | \`(author,nin_id,1,2,3)\` | Not in list of IDs |

Existing operators (\`eq\`, \`neq\`, \`in\`, etc.) continue to match by display value — fully backward compatible.

### Implementation

The \`_id\` suffix is detected in the LTAR filter handler. When present:
1. \`comparison_op\` is stripped to the base operator (\`eq_id\` → \`eq\`)
2. \`fk_column_id\` uses the related table's \`primaryKey\` instead of \`displayValue\`
3. The rest of the filter pipeline works unchanged

### Changes (4 files, ~30 lines)

- \`query-filter-lexer.ts\`: register operators in COMPARISON_OPS
- \`handlerUtils.ts\`: add negated mappings (\`neq_id\`→\`eq_id\`, \`nin_id\`→\`in_id\`)
- \`ltar.general.handler.ts\`: detect \`_id\` suffix → use primaryKey → strip suffix before parseConditionV2
- \`links.general.handler.ts\`: route \`_id\` operators to LtarGeneralHandler (instead of RollupGeneralHandler)

### Test plan

1. \`(field,eq_id,5)\` → returns records linked to ID 5
2. \`(field,in_id,1,2,3)\` → returns records linked to IDs 1, 2, or 3
3. \`(field,neq_id,5)\` → excludes records linked to ID 5
4. \`(field,eq,DisplayName)\` → still works (backward compat)