### PR TITLE
fix: bulkUpdate silently fails — prepareMetaUpdateQuery stub returns undefined

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -4359,6 +4359,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         await transaction.commit();
       } catch (ex) {
         await transaction.rollback();
+        throw ex;
       }
 
       if (apiVersion === NcApiVersion.V3) {
@@ -8447,7 +8448,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
           runAfterForLoop.push(() => {
             if (!updatedColIds.length) return;
 
-            data[column.column_name] = prepareMetaUpdateQuery({
+            const metaUpdateQuery = prepareMetaUpdateQuery({
               knex: this.dbDriver,
               colIds: updatedColIds,
               props: {
@@ -8456,6 +8457,9 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
               },
               metaColumn: column,
             });
+            if (metaUpdateQuery !== undefined) {
+              data[column.column_name] = metaUpdateQuery;
+            }
           });
 
         continue;

--- a/packages/nocodb/src/utils/dataUtils.ts
+++ b/packages/nocodb/src/utils/dataUtils.ts
@@ -173,6 +173,7 @@ export function batchUpdate(
 
   columns.forEach((column) => {
     const filteredData = data.filter((row) => !ncIsUndefined(row[column]));
+    if (filteredData.length === 0) return;
     updateObj[column] = kn.raw(
       `CASE ?? ${filteredData
         .map(() => 'WHEN ? THEN ?')


### PR DESCRIPTION
## Summary

Fixes #13778

All v2 API PATCH/update operations silently fail on open-source edition when the table has a \`UITypes.Meta\` column (\`nc_row_meta\`). The API returns success but the data is not updated.

### Root cause

\`prepareMetaUpdateQuery\` is a stub in the open-source edition that returns \`void\` (undefined). The caller in \`prepareNocoData\` assigns the return value unconditionally:

\`\`\`ts
data[column.column_name] = prepareMetaUpdateQuery({ ... });
// → data['nc_row_meta'] = undefined
\`\`\`

\`batchUpdate\` then generates an invalid CASE statement with no WHEN clause for this column. The transaction fails but the catch block silently swallows the error.

### Why EE is not affected

EE's \`prepareMetaUpdateQuery\` returns a real \`Knex.Raw\` query, so the value is never \`undefined\`.

### Changes

1. **\`BaseModelSqlv2.ts\`** — Check \`prepareMetaUpdateQuery\` return value before assignment
2. **\`dataUtils.ts\`** — Skip columns with empty \`filteredData\` in \`batchUpdate\` (defensive)
3. **\`BaseModelSqlv2.ts\`** — Re-throw exception in \`bulkUpdate\` catch block after rollback

## Test plan

1. PATCH a record via v2 API on open-source edition with PG
2. Verify the update actually persists (was silently rolling back before)