### PR TITLE
fix: Lookup fields intermittently return null due to postProcessData race

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2/relation-data-fetcher.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/relation-data-fetcher.ts
@@ -37,22 +37,29 @@ export const relationDataFetcher = (param: {
       return data;
     }
 
-    const { ast, parsedQuery } = await getAst(context, {
-      model,
-      query,
-      extractOnlyPrimaries:
-        context.cacheMap?.get('relation_postProcessData') ?? false,
-    });
-
     if (!context.cacheMap) {
       context.cacheMap = new Map();
     }
-    // set context.cacheMap `relation_postProcessData` to ensure non-infinite loop
-    context.cacheMap.set('relation_postProcessData', true);
 
-    // nocoexecute
-    const result = await nocoExecute(ast, data, {}, parsedQuery);
-    return result;
+    let postProcessModels: Set<string> = context.cacheMap.get(
+      'relation_postProcessData_models',
+    );
+    if (!postProcessModels) {
+      postProcessModels = new Set();
+      context.cacheMap.set('relation_postProcessData_models', postProcessModels);
+    }
+
+    const extractOnlyPrimaries = postProcessModels.has(model.id);
+
+    const { ast, parsedQuery } = await getAst(context, {
+      model,
+      query,
+      extractOnlyPrimaries,
+    });
+
+    postProcessModels.add(model.id);
+
+    return await nocoExecute(ast, data, {}, parsedQuery);
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #13782

Replace the global boolean `relation_postProcessData` flag in `postProcessData` with a per-model `Set<string>` to fix intermittent `null` Lookup values caused by concurrent DataLoader resolution.

## Changes

**`packages/nocodb/src/db/BaseModelSqlv2/relation-data-fetcher.ts`**

The recursion guard in `postProcessData` used a single boolean on `context.cacheMap`. Once any relation finished processing, it set the flag to `true`, causing all other relations (potentially for different models) to degrade to `extractOnlyPrimaries=true`. Since DataLoader resolves concurrently, which relation sets the flag first is nondeterministic — making second-level Lookups intermittently return `null`.

The fix tracks processed models by ID in a `Set`. Only same-model re-entry (true circular references) degrades to primary-value-only extraction. Different models resolve fully regardless of completion order.

## Test plan

- [ ] Table chain A → B → C with second-level Lookup (A looks up a field from C through B)
- [ ] Webhook on table A returns the Lookup value consistently across multiple triggers
- [ ] Tables with self-referencing Links don't cause infinite recursion
- [ ] Performance: deeply nested relations (4+ levels) don't cause excessive data fetching

🤖 Generated with [Claude Code](https://claude.com/claude-code)