### PR TITLE
fix(canvas): flex-shrink chip layout with balanced line distribution for LTAR cells

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/BelongsTo.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/BelongsTo.ts
@@ -43,7 +43,8 @@ export const BelongsToCellRenderer: CellRenderer = {
     let returnData
 
     if (isValidValue(value)) {
-      const cellWidth = width - (!readonly && selected ? 34 : 0)
+      // Reserve space for action buttons (+/expand) when selected; reduced from 34 to 24px.
+      const cellWidth = width - (!readonly && selected ? 24 : 0)
 
       const cellValue =
         value && !Array.isArray(value) && typeof value === 'object'
@@ -71,6 +72,9 @@ export const BelongsToCellRenderer: CellRenderer = {
           renderAsTag: true,
           tagBgColor: getColor(themeV4Colors.brand['50'], 'var(--nc-bg-gray-light)'),
           tagHeight: 24,
+          // Independent left/right padding for balanced capsule appearance.
+          tagPaddingX: 6,
+          tagPaddingRight: 12,
         },
         meta: relatedTableMeta,
         x: x + 4,

--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/HasMany.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/HasMany.ts
@@ -1,5 +1,5 @@
 import type { ColumnType, LinkToAnotherRecordType, TableType } from 'nocodb-sdk'
-import { isBoxHovered, renderIconButton, renderSingleLineText } from '../../utils/canvas'
+import { defaultOffscreen2DContext, isBoxHovered, renderIconButton, renderSingleLineText } from '../../utils/canvas'
 import { PlainCellRenderer } from '../Plain'
 import { renderAsCellLookupOrLtarValue } from '../../utils/cell'
 
@@ -17,7 +17,6 @@ export const HasManyCellRenderer: CellRenderer = {
       spriteLoader,
       mousePosition,
       relatedTableMeta,
-      padding,
       renderCell,
       readonly,
       setCursor,
@@ -47,13 +46,21 @@ export const HasManyCellRenderer: CellRenderer = {
 
       return acc
     }, []) as { value: any; item: Record<string, any> }[]
-
     const initialX = x + 4
     const initialWidth = width - 8
+    // Use a fixed right boundary for layout to avoid cumulative rounding errors.
+    const rightBoundary = initialX + initialWidth
 
     let currentX = initialX
     let currentY = y + (rowHeightInPx['1'] === height ? 0 : 2)
-    let currentWidth = initialWidth
+    // Small compensation for slightly conservative renderer return values.
+    const chipEndCompensation = 4
+
+    // Clip to cell bounds to prevent overflow into adjacent cells.
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(x, y, width, height)
+    ctx.clip()
 
     /**
      * Chip info which is oldX, oldY, x, y, width, height, value is required when user click on chip item to expand record
@@ -68,12 +75,17 @@ export const HasManyCellRenderer: CellRenderer = {
       relatedTableMeta: undefined,
       readonly: true,
       height: rowHeightInPx['1']!,
-      padding: 10,
+      // Smaller padding to maximize usable content width.
+      padding: 4,
       textColor: getColor(themeV4Colors.brand['500']),
       tag: {
         renderAsTag: true,
         tagBgColor: getColor(themeV4Colors.brand['50'], 'var(--nc-bg-gray-light)'),
         tagHeight: 24,
+        // Tuned left/right padding for tighter chip appearance.
+        tagPaddingX: 6,
+        tagPaddingRight: 10,
+        tagSpacing: 2,
       },
       meta: relatedTableMeta,
     }
@@ -83,98 +95,199 @@ export const HasManyCellRenderer: CellRenderer = {
         ? renderCell(ctx, hmColumn, options)
         : PlainCellRenderer.render(ctx, options)
     }
+    const measureCellRenderer = (options: CellRendererOptions) => {
+      // Measure offscreen first to decide line breaks before committing to render.
+      return renderAsCellLookupOrLtarValue.includes(hmColumn.uidt)
+        ? renderCell(defaultOffscreen2DContext, hmColumn, options)
+        : PlainCellRenderer.render(defaultOffscreen2DContext, options)
+    }
 
     const maxLines = rowHeightTruncateLines(height, true)
-    let line = 1
-    let flag = false
-    const count = 1
-
-    for (const cell of cells) {
-      const point = cellRenderer({
+    // Minimum chip width to guarantee at least one visible character.
+    const minChipTextSafeWidth = 36
+    const chipSpacing = 2
+    const measureMaxWidth = Math.max(initialWidth, 1200)
+    const chipIdealWidths = cells.map((cell) => {
+      const p = measureCellRenderer({
         ...renderProps,
         value: cell.value,
-        x: currentX,
-        y: currentY,
-        width: currentWidth,
+        x: 0,
+        y: 0,
+        width: measureMaxWidth,
       })
+      return Math.max(minChipTextSafeWidth, p?.x ?? minChipTextSafeWidth)
+    })
+    const flexShrinkWidths = (idealWidths: number[], containerWidth: number, minWidth: number) => {
+      if (!idealWidths.length) return []
 
-      if (point?.x) {
-        // Add rendered chip info in return data
+      const widths = [...idealWidths]
+      let total = widths.reduce((acc, w) => acc + w, 0)
+      if (total <= containerWidth) return widths
+
+      let overflow = total - containerWidth
+      const frozen = new Array(widths.length).fill(false)
+
+      while (overflow > 0.1) {
+        let activeWeight = 0
+        for (let i = 0; i < widths.length; i++) {
+          if (!frozen[i]) activeWeight += widths[i]!
+        }
+        if (activeWeight <= 0) break
+
+        let consumed = 0
+        for (let i = 0; i < widths.length; i++) {
+          if (frozen[i]) continue
+          const current = widths[i]!
+          const shrink = overflow * (current / activeWeight)
+          const next = Math.max(minWidth, current - shrink)
+          consumed += current - next
+          widths[i] = next
+        }
+
+        overflow -= consumed
+        if (consumed <= 0.1) break
+
+        for (let i = 0; i < widths.length; i++) {
+          if (!frozen[i] && widths[i]! <= minWidth + 0.1) {
+            frozen[i] = true
+            widths[i] = minWidth
+          }
+        }
+      }
+
+      total = widths.reduce((acc, w) => acc + w, 0)
+      if (total > containerWidth) {
+        let extra = total - containerWidth
+        for (let i = widths.length - 1; i >= 0 && extra > 0; i--) {
+          const current = widths[i]!
+          if (current <= minWidth) continue
+          const reducible = current - minWidth
+          const cut = Math.min(reducible, extra)
+          widths[i] = current - cut
+          extra -= cut
+        }
+      }
+
+      return widths
+    }
+
+    let flag = false
+    let hasHiddenItems = false
+    let cellIndex = 0
+
+    for (let line = 1; line <= maxLines && cellIndex < cells.length; line++) {
+      const isLastLine = line === maxLines
+      const remainingLines = maxLines - line + 1
+      const lineY = y + (rowHeightInPx['1'] === height ? 0 : 2) + (line - 1) * 28
+      const remaining = cells.length - cellIndex
+
+      let reserveEllipsisWidth = 0
+      const maxChipsPerLine = Math.max(1, Math.floor((initialWidth + chipSpacing) / (minChipTextSafeWidth + chipSpacing)))
+      let lineCellsCount = 1
+
+      if (isLastLine) {
+        const lastLineCapacityNoEllipsis = Math.max(
+          1,
+          Math.floor((initialWidth + chipSpacing) / (minChipTextSafeWidth + chipSpacing)),
+        )
+        if (remaining > lastLineCapacityNoEllipsis) {
+          reserveEllipsisWidth = ellipsisWidth + 1
+        }
+        const lastLineCapacity = Math.max(
+          1,
+          Math.floor((Math.max(0, initialWidth - reserveEllipsisWidth) + chipSpacing) / (minChipTextSafeWidth + chipSpacing)),
+        )
+        lineCellsCount = Math.min(remaining, lastLineCapacity)
+      } else {
+        // Non-last line: use balanced soft threshold to distribute chips evenly across lines.
+        const maxCountByFeasibility = Math.max(1, remaining - (remainingLines - 1))
+        const hardLimit = Math.max(1, Math.min(maxChipsPerLine, maxCountByFeasibility))
+        // Balanced minimum: spread remaining chips across remaining lines to avoid lopsided layouts (e.g. 1-1-4).
+        const balancedMinCount = Math.max(1, Math.min(hardLimit, Math.ceil(remaining / remainingLines)))
+        const remainingIdealTotal = chipIdealWidths
+          .slice(cellIndex)
+          .reduce((acc, w, idx) => acc + w + (idx > 0 ? chipSpacing : 0), 0)
+        const softLineWidth =
+          remainingLines > 1
+            ? Math.max(minChipTextSafeWidth, Math.min(initialWidth, remainingIdealTotal / remainingLines))
+            : initialWidth
+
+        let lineIdealWidth = 0
+        let count = 0
+        while (count < hardLimit) {
+          const w = chipIdealWidths[cellIndex + count]!
+          const nextWidth = lineIdealWidth + (count > 0 ? chipSpacing : 0) + w
+          if (count > 0 && nextWidth > softLineWidth) break
+          lineIdealWidth = nextWidth
+          count++
+        }
+        lineCellsCount = Math.max(balancedMinCount, count)
+      }
+
+      const chipRightBoundary = rightBoundary - reserveEllipsisWidth
+      const availableLineWidth = Math.max(minChipTextSafeWidth, chipRightBoundary - initialX)
+      const lineIdealWidths = chipIdealWidths.slice(cellIndex, cellIndex + lineCellsCount)
+      const lineAssignedWidths = flexShrinkWidths(lineIdealWidths, availableLineWidth, minChipTextSafeWidth)
+
+      currentX = initialX
+      currentY = lineY
+
+      for (let j = 0; j < lineCellsCount; j++) {
+        const cell = cells[cellIndex + j]!
+        const widthCap = Math.max(minChipTextSafeWidth, lineAssignedWidths[j] ?? minChipTextSafeWidth)
+        const point = cellRenderer({
+          ...renderProps,
+          value: cell.value,
+          x: currentX,
+          y: currentY,
+          width: widthCap,
+        })
+
+        const cellRightBoundary = Math.min(chipRightBoundary, currentX + widthCap)
+        const boundedPointX = point?.x
+          ? Math.min(point.x + chipEndCompensation, cellRightBoundary)
+          : Math.min(currentX + widthCap, cellRightBoundary)
+
         returnData.push({
           oldX: currentX + 4,
           oldY: currentY + 4,
-          x: point.x,
-          y: point.y,
-          width: point.x - (currentX + 4),
-          height: point.y ? point.y - (currentY + 4) : 24,
+          x: boundedPointX,
+          y: point?.y ?? currentY + 24,
+          width: boundedPointX - (currentX + 4),
+          height: point?.y ? point.y - (currentY + 4) : 24,
           value: cell.item,
         })
 
-        // Show cursor pointer on hover over chip item
         if (
           !readonly &&
           selected &&
           isBoxHovered(
-            { x: currentX, y: currentY, width: point.x - currentX, height: point.y ? point.y - currentY : 24 },
+            { x: currentX, y: currentY, width: boundedPointX - currentX, height: point?.y ? point.y - currentY : 24 },
             mousePosition,
           )
         ) {
           setCursor('pointer')
         }
 
-        if (point?.x >= x + initialWidth - padding * 2 - (count < cells.length ? 50 - ellipsisWidth : 0)) {
-          if (line + 1 > maxLines) {
-            currentX = point?.x
-            flag = true
-            break
-          }
-
-          currentX = initialX
-          currentWidth = initialWidth
-          currentY = point?.y && y !== point?.y && point?.y - y >= 28 ? point?.y : currentY + 28
-          line += 1
-        } else {
-          currentWidth = currentX + currentWidth - point?.x
-          currentX = point?.x
-        }
-      } else {
-        // Add rendered chip info in return data
-        returnData.push({
-          oldX: currentX + 4,
-          oldY: currentY + 4,
-          x: currentX + currentWidth,
-          y: currentY + 24,
-          width: currentWidth,
-          height: 24,
-          value: cell.item,
-        })
-
-        // Show cursor pointer on hover over chip item
-        if (!readonly && selected && isBoxHovered({ x: currentX, y: currentY, width: currentWidth, height: 24 }, mousePosition)) {
-          setCursor('pointer')
-        }
-
-        if (line + 1 > maxLines) {
-          break
-        }
-
-        currentX = initialX
-        currentY = currentY + 28
-
-        currentWidth = initialWidth
-        line += 1
+        currentX = boundedPointX
       }
 
-      if (line > maxLines) {
+      cellIndex += lineCellsCount
+
+      if (isLastLine && cellIndex < cells.length) {
+        flag = true
+        hasHiddenItems = true
         break
       }
     }
 
     Object.assign(cellRenderStore, { ltar: returnData })
 
-    if (flag && count < cells.length) {
+    if (flag && hasHiddenItems) {
+      // Anchor ellipsis to right boundary for consistent visual alignment.
+      const ellipsisX = rightBoundary
       renderSingleLineText(ctx, {
-        x: currentX + 12,
+        x: ellipsisX,
         y,
         text: '...',
         maxWidth: ellipsisWidth,
@@ -185,6 +298,8 @@ export const HasManyCellRenderer: CellRenderer = {
         height,
       })
     }
+
+    ctx.restore()
 
     if (selected) {
       const borderRadius = 6

--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/ManyToMany.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/LTAR/ManyToMany.ts
@@ -1,5 +1,5 @@
 import type { ColumnType, LinkToAnotherRecordType, TableType } from 'nocodb-sdk'
-import { isBoxHovered, renderIconButton, renderSingleLineText } from '../../utils/canvas'
+import { defaultOffscreen2DContext, isBoxHovered, renderIconButton, renderSingleLineText } from '../../utils/canvas'
 import { PlainCellRenderer } from '../Plain'
 import { renderAsCellLookupOrLtarValue } from '../../utils/cell'
 
@@ -18,7 +18,6 @@ export const ManyToManyCellRenderer: CellRenderer = {
       spriteLoader,
       mousePosition,
       relatedTableMeta,
-      padding,
       renderCell,
       setCursor,
       cellRenderStore,
@@ -47,13 +46,19 @@ export const ManyToManyCellRenderer: CellRenderer = {
 
       return acc
     }, []) as { value: any; item: Record<string, any> }[]
-
     const initialX = x + 4
-    const initialWidth = width - 8
+    const initialWidth = width - 6
+    // Use a fixed right boundary for layout to avoid cumulative rounding errors.
+    const rightBoundary = initialX + initialWidth
 
     let currentX = initialX
     let currentY = y + (rowHeightInPx['1'] === height ? 0 : 2)
-    let currentWidth = initialWidth
+
+    // Clip to cell bounds to prevent overflow into adjacent cells.
+    ctx.save()
+    ctx.beginPath()
+    ctx.rect(x, y, width, height)
+    ctx.clip()
 
     /**
      * Chip info which is oldX, oldY, x, y, width, height, value is required when user click on chip item to expand record
@@ -68,12 +73,16 @@ export const ManyToManyCellRenderer: CellRenderer = {
       relatedTableMeta: undefined,
       readonly: true,
       height: rowHeightInPx['1']!,
-      padding: 10,
+      // Smaller padding to maximize usable content width.
+      padding: 4,
       textColor: getColor(themeV4Colors.brand['500']),
       tag: {
         renderAsTag: true,
         tagBgColor: getColor(themeV4Colors.brand['50'], 'var(--nc-bg-gray-light)'),
         tagHeight: 24,
+        // Tighter tag spacing for denser chip layout.
+        tagPaddingX: 6,
+        tagSpacing: 2,
       },
       meta: relatedTableMeta,
     }
@@ -83,93 +92,199 @@ export const ManyToManyCellRenderer: CellRenderer = {
         ? renderCell(ctx, m2mColumn, options)
         : PlainCellRenderer.render(ctx, options)
     }
+    const measureCellRenderer = (options: CellRendererOptions) => {
+      // Measure offscreen first to decide line breaks before committing to render.
+      return renderAsCellLookupOrLtarValue.includes(m2mColumn.uidt)
+        ? renderCell(defaultOffscreen2DContext, m2mColumn, options)
+        : PlainCellRenderer.render(defaultOffscreen2DContext, options)
+    }
 
     const maxLines = rowHeightTruncateLines(height, true)
-    let line = 1
-    let flag = false
-    let count = 1
-
-    for (const cell of cells) {
-      const point = cellRenderer({
+    // Small compensation for slightly conservative renderer return values.
+    const chipEndCompensation = 4
+    // Minimum chip width to guarantee at least one visible character.
+    const minChipTextSafeWidth = 36
+    const chipSpacing = 2
+    const measureMaxWidth = Math.max(initialWidth, 1200)
+    const chipIdealWidths = cells.map((cell) => {
+      const p = measureCellRenderer({
         ...renderProps,
         value: cell.value,
-        x: currentX,
-        y: currentY,
-        width: currentWidth,
+        x: 0,
+        y: 0,
+        width: measureMaxWidth,
       })
+      return Math.max(minChipTextSafeWidth, p?.x ?? minChipTextSafeWidth)
+    })
+    const flexShrinkWidths = (idealWidths: number[], containerWidth: number, minWidth: number) => {
+      if (!idealWidths.length) return []
 
-      if (point?.x) {
-        // Add rendered chip info in return data
+      const widths = [...idealWidths]
+      let total = widths.reduce((acc, w) => acc + w, 0)
+      if (total <= containerWidth) return widths
+
+      let overflow = total - containerWidth
+      const frozen = new Array(widths.length).fill(false)
+
+      while (overflow > 0.1) {
+        let activeWeight = 0
+        for (let i = 0; i < widths.length; i++) {
+          if (!frozen[i]) activeWeight += widths[i]!
+        }
+        if (activeWeight <= 0) break
+
+        let consumed = 0
+        for (let i = 0; i < widths.length; i++) {
+          if (frozen[i]) continue
+          const current = widths[i]!
+          const shrink = overflow * (current / activeWeight)
+          const next = Math.max(minWidth, current - shrink)
+          consumed += current - next
+          widths[i] = next
+        }
+
+        overflow -= consumed
+        if (consumed <= 0.1) break
+
+        for (let i = 0; i < widths.length; i++) {
+          if (!frozen[i] && widths[i]! <= minWidth + 0.1) {
+            frozen[i] = true
+            widths[i] = minWidth
+          }
+        }
+      }
+
+      total = widths.reduce((acc, w) => acc + w, 0)
+      if (total > containerWidth) {
+        let extra = total - containerWidth
+        for (let i = widths.length - 1; i >= 0 && extra > 0; i--) {
+          const current = widths[i]!
+          if (current <= minWidth) continue
+          const reducible = current - minWidth
+          const cut = Math.min(reducible, extra)
+          widths[i] = current - cut
+          extra -= cut
+        }
+      }
+
+      return widths
+    }
+
+    let flag = false
+    let hasHiddenItems = false
+    let cellIndex = 0
+
+    for (let line = 1; line <= maxLines && cellIndex < cells.length; line++) {
+      const isLastLine = line === maxLines
+      const remainingLines = maxLines - line + 1
+      const lineY = y + (rowHeightInPx['1'] === height ? 0 : 2) + (line - 1) * 28
+      const remaining = cells.length - cellIndex
+
+      let reserveEllipsisWidth = 0
+      const maxChipsPerLine = Math.max(1, Math.floor((initialWidth + chipSpacing) / (minChipTextSafeWidth + chipSpacing)))
+      let lineCellsCount = 1
+
+      if (isLastLine) {
+        const lastLineCapacityNoEllipsis = Math.max(
+          1,
+          Math.floor((initialWidth + chipSpacing) / (minChipTextSafeWidth + chipSpacing)),
+        )
+        if (remaining > lastLineCapacityNoEllipsis) {
+          reserveEllipsisWidth = ellipsisWidth + 1
+        }
+        const lastLineCapacity = Math.max(
+          1,
+          Math.floor((Math.max(0, initialWidth - reserveEllipsisWidth) + chipSpacing) / (minChipTextSafeWidth + chipSpacing)),
+        )
+        lineCellsCount = Math.min(remaining, lastLineCapacity)
+      } else {
+        // Non-last line: use balanced soft threshold to distribute chips evenly across lines.
+        const maxCountByFeasibility = Math.max(1, remaining - (remainingLines - 1))
+        const hardLimit = Math.max(1, Math.min(maxChipsPerLine, maxCountByFeasibility))
+        // Balanced minimum: spread remaining chips across remaining lines to avoid lopsided layouts (e.g. 1-1-4).
+        const balancedMinCount = Math.max(1, Math.min(hardLimit, Math.ceil(remaining / remainingLines)))
+        const remainingIdealTotal = chipIdealWidths
+          .slice(cellIndex)
+          .reduce((acc, w, idx) => acc + w + (idx > 0 ? chipSpacing : 0), 0)
+        const softLineWidth =
+          remainingLines > 1
+            ? Math.max(minChipTextSafeWidth, Math.min(initialWidth, remainingIdealTotal / remainingLines))
+            : initialWidth
+
+        let lineIdealWidth = 0
+        let count = 0
+        while (count < hardLimit) {
+          const w = chipIdealWidths[cellIndex + count]!
+          const nextWidth = lineIdealWidth + (count > 0 ? chipSpacing : 0) + w
+          if (count > 0 && nextWidth > softLineWidth) break
+          lineIdealWidth = nextWidth
+          count++
+        }
+        lineCellsCount = Math.max(balancedMinCount, count)
+      }
+
+      const chipRightBoundary = rightBoundary - reserveEllipsisWidth
+      const availableLineWidth = Math.max(minChipTextSafeWidth, chipRightBoundary - initialX)
+      const lineIdealWidths = chipIdealWidths.slice(cellIndex, cellIndex + lineCellsCount)
+      const lineAssignedWidths = flexShrinkWidths(lineIdealWidths, availableLineWidth, minChipTextSafeWidth)
+
+      currentX = initialX
+      currentY = lineY
+
+      for (let j = 0; j < lineCellsCount; j++) {
+        const cell = cells[cellIndex + j]!
+        const widthCap = Math.max(minChipTextSafeWidth, lineAssignedWidths[j] ?? minChipTextSafeWidth)
+        const point = cellRenderer({
+          ...renderProps,
+          value: cell.value,
+          x: currentX,
+          y: currentY,
+          width: widthCap,
+        })
+
+        const cellRightBoundary = Math.min(chipRightBoundary, currentX + widthCap)
+        const boundedPointX = point?.x
+          ? Math.min(point.x + chipEndCompensation, cellRightBoundary)
+          : Math.min(currentX + widthCap, cellRightBoundary)
+
         returnData.push({
           oldX: currentX + 4,
           oldY: currentY + 4,
-          x: point.x,
-          y: point.y,
-          width: point.x - (currentX + 4),
-          height: point.y ? point.y - (currentY + 4) : 24,
+          x: boundedPointX,
+          y: point?.y ?? currentY + 24,
+          width: boundedPointX - (currentX + 4),
+          height: point?.y ? point.y - (currentY + 4) : 24,
           value: cell.item,
         })
 
-        // Show cursor pointer on hover over chip item
         if (
           !readonly &&
           selected &&
           isBoxHovered(
-            { x: currentX, y: currentY, width: point.x - currentX, height: point.y ? point.y - currentY : 24 },
+            { x: currentX, y: currentY, width: boundedPointX - currentX, height: point?.y ? point.y - currentY : 24 },
             mousePosition,
           )
         ) {
           setCursor('pointer')
         }
 
-        if (point?.x >= x + initialWidth - padding * 2 - (count < cells.length ? 50 - ellipsisWidth : 0)) {
-          if (line + 1 > maxLines) {
-            currentX = point?.x
-            flag = true
-            break
-          }
-
-          currentX = initialX
-          currentWidth = initialWidth
-          currentY = point?.y && y !== point?.y && point?.y - y >= 28 ? point?.y : currentY + 28
-          line += 1
-        } else {
-          currentWidth = currentX + currentWidth - point?.x
-          currentX = point?.x
-        }
-      } else {
-        // Add rendered chip info in return data
-        returnData.push({
-          oldX: currentX,
-          oldY: currentY,
-          x: currentX + currentWidth,
-          y: currentY + 24,
-          width: currentWidth,
-          height: 24,
-          value: cell.item,
-        })
-
-        // Show cursor pointer on hover over chip item
-        if (!readonly && selected && isBoxHovered({ x: currentX, y: currentY, width: currentWidth, height: 24 }, mousePosition)) {
-          setCursor('pointer')
-        }
-
-        if (line + 1 > maxLines) {
-          break
-        }
-
-        currentX = initialX
-        currentY = currentY + 28
-
-        currentWidth = initialWidth
-        line += 1
+        currentX = boundedPointX
       }
-      count++
+
+      cellIndex += lineCellsCount
+
+      if (isLastLine && cellIndex < cells.length) {
+        flag = true
+        hasHiddenItems = true
+        break
+      }
     }
 
-    if (flag && count < cells.length) {
+    if (flag && hasHiddenItems) {
+      // Anchor ellipsis to right boundary for consistent visual alignment.
+      const ellipsisX = rightBoundary
       renderSingleLineText(ctx, {
-        x: currentX + 12,
+        x: ellipsisX,
         y,
         text: '...',
         maxWidth: ellipsisWidth,
@@ -180,6 +295,8 @@ export const ManyToManyCellRenderer: CellRenderer = {
         height,
       })
     }
+
+    ctx.restore()
 
     Object.assign(cellRenderStore, { ltar: returnData })
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/canvas.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/canvas.ts
@@ -1381,6 +1381,9 @@ export const renderTagLabel = (
   } = props
   const {
     tagPaddingX = 8,
+    // Backward-compatible: fall back to symmetric tagPaddingX when independent overrides are unset.
+    tagPaddingLeft = tagPaddingX,
+    tagPaddingRight = tagPaddingX,
     tagPaddingY = 0,
     tagHeight = 20,
     tagRadius = 6,
@@ -1391,7 +1394,8 @@ export const renderTagLabel = (
     tagBorderWidth,
   } = props.tag || {}
 
-  const maxWidth = width - padding * 2 - tagPaddingX * 2
+  // Compute available text width using independent left/right padding.
+  const maxWidth = width - padding * 2 - tagPaddingLeft - tagPaddingRight
 
   const initialY = rowHeightInPx['1'] === height ? y + height / 2 - tagHeight / 2 : y + padding - 4
 
@@ -1399,7 +1403,7 @@ export const renderTagLabel = (
     renderTag(ctx, {
       x: x + tagSpacing,
       y: initialY,
-      width: textWidth + tagPaddingX * 2,
+      width: textWidth + tagPaddingLeft + tagPaddingRight,
       height: tagHeight,
       radius: tagRadius,
       fillStyle: tagBgColor,
@@ -1410,7 +1414,7 @@ export const renderTagLabel = (
 
   if (renderAsMarkdown) {
     const { width: textWidth } = renderMarkdown(ctx, {
-      x: x + tagSpacing + tagPaddingX,
+      x: x + tagSpacing + tagPaddingLeft,
       y: initialY + tagPaddingY,
       text,
       maxWidth,
@@ -1429,7 +1433,7 @@ export const renderTagLabel = (
     _renderTag(textWidth)
 
     renderMarkdown(ctx, {
-      x: x + tagSpacing + tagPaddingX,
+      x: x + tagSpacing + tagPaddingLeft,
       y: initialY + tagPaddingY,
       text,
       maxWidth,
@@ -1445,12 +1449,12 @@ export const renderTagLabel = (
     })
 
     return {
-      x: x + tagSpacing + textWidth + tagPaddingX * 2,
+      x: x + tagSpacing + textWidth + tagPaddingLeft + tagPaddingRight,
       y: initialY + tagHeight,
     }
   } else {
     const { text: truncatedText, width: textWidth } = renderSingleLineText(ctx, {
-      x: x + tagSpacing + tagPaddingX,
+      x: x + tagSpacing + tagPaddingLeft,
       y,
       text,
       maxWidth,
@@ -1461,7 +1465,7 @@ export const renderTagLabel = (
     _renderTag(textWidth)
 
     renderSingleLineText(ctx, {
-      x: x + tagSpacing + tagPaddingX,
+      x: x + tagSpacing + tagPaddingLeft,
       y: initialY + tagPaddingY,
       text: truncatedText,
       maxWidth,
@@ -1472,7 +1476,7 @@ export const renderTagLabel = (
     })
 
     return {
-      x: x + tagSpacing + textWidth + tagPaddingX * 2,
+      x: x + tagSpacing + textWidth + tagPaddingLeft + tagPaddingRight,
       y: initialY + tagHeight,
     }
   }

--- a/packages/nc-gui/lib/types.ts
+++ b/packages/nc-gui/lib/types.ts
@@ -467,6 +467,9 @@ interface CellRendererOptions {
   tag?: {
     renderAsTag?: boolean
     tagPaddingX?: number
+    // Independent left/right padding overrides. Falls back to tagPaddingX when unset.
+    tagPaddingLeft?: number
+    tagPaddingRight?: number
     tagPaddingY?: number
     tagHeight?: number
     tagRadius?: number


### PR DESCRIPTION
## Summary

Replaces the greedy "first-come-first-served" chip layout in HasMany / ManyToMany / BelongsTo canvas renderers with a three-layer constraint model inspired by CSS Flexbox:

1. **Flex-shrink**: When chips overflow a line, shrink proportionally by ideal width ratio — a 100-character chip shrinks 20× more than a 5-character one. Chips that hit `minChipWidth` (36px) freeze; remaining overflow redistributes to unfrozen chips.

2. **Capacity limit**: Each line holds at most `floor((lineWidth + spacing) / (minWidth + spacing))` chips, preventing visual overcrowding.

3. **Balanced distribution**: Uses `softLineWidth = remainingIdealTotal / remainingLines` as a dynamic wrap threshold, recalculated after each line. Combined with `balancedMinCount = ceil(remaining / remainingLines)`, this prevents lopsided layouts like 1-1-4, producing 2-2-2 instead.

### Problems with the current layout

The existing algorithm uses a greedy sequential approach:

- **First-come-first-served**: The first chip gets all available width. If it has 100 characters, it takes the entire line, leaving subsequent chips with zero space.
- **Phantom fit bug**: Chips are measured with the *remaining* compressed width, so the internal renderer silently truncates text to fit, returning a small `measuredWidth` that fools the "does it fit?" check. This causes chips to be crushed into blank color bars before wrapping is triggered.
- **Cumulative width drift**: `currentWidth` is repeatedly subtracted from, accumulating floating-point errors that cause inconsistent right margins and ellipsis placement.
- **All-on-first-line**: With sufficient column width, all chips pile onto line 1 even when multiple lines are available, wasting vertical space.

### Additional improvements

- **Fixed right boundary**: All width calculations reference a single `rightBoundary` constant instead of cumulative subtraction.
- **Offscreen pre-measurement**: Chips are measured with unconstrained width (1200px) to get true ideal sizes before layout decisions.
- **Canvas clipping**: `ctx.save()/clip()/restore()` prevents drawing outside cell bounds.
- **Independent tag padding**: `tagPaddingLeft`/`tagPaddingRight` in `renderTagLabel` for fine-grained capsule spacing (backward-compatible — falls back to `tagPaddingX`).
- **Ellipsis anchoring**: `...` is always drawn at `rightBoundary` instead of trailing `currentX`.

## Before / After

<!-- @rejectliu: paste Before and After screen recordings here -->

**Before:**

https://github.com/user-attachments/assets/7d14f9ea-3fb8-4025-a97b-3e72b3273502



**After:**

https://github.com/user-attachments/assets/6a170b77-9518-4c73-a032-bb045c9a314c


