### PR TITLE
feat(gui): add new record action in expanded form menu

### DIFF
--- a/packages/nc-gui/components/smartsheet/expanded-form/MoreOptionsMenu.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/MoreOptionsMenu.vue
@@ -26,6 +26,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emits = defineEmits<{
+  newRecord: []
   duplicateStart: []
   duplicateApplied: []
   afterDelete: []
@@ -71,6 +72,7 @@ const duplicatingRowInProgress = ref(false)
 const visibleMoreOptions = computed(() => {
   if (props.templateMode || props.blueprintMode) {
     return {
+      newRecord: false,
       reloadRecord: false,
       copyRecordUrl: false,
       sendRecord: false,
@@ -83,6 +85,7 @@ const visibleMoreOptions = computed(() => {
   }
 
   const result = {
+    newRecord: isUIAllowed('dataEdit', baseRoles.value) && !isSqlView.value && !isMobileMode.value,
     reloadRecord: !isEeUI && !!props.rowId,
     copyRecordUrl: !isNew.value && !!props.rowId,
     sendRecord: appInfo.value.ee && !isNew.value && !!props.rowId && !isPublic.value,
@@ -99,7 +102,7 @@ const visibleMoreOptions = computed(() => {
     // Only meaningful when there's a standalone copy-URL button — in compact mode
     // the dropdown is the ONLY surface for copy-URL, so it must always render.
     allHiddenExceptCopyRecordUrl:
-      !props.compact && !result.reloadRecord && !result.sendRecord && !result.duplicateRecord && !result.deleteRecord,
+      !props.compact && !result.newRecord && !result.reloadRecord && !result.sendRecord && !result.duplicateRecord && !result.deleteRecord,
   }
 })
 
@@ -231,6 +234,37 @@ const onConfirmDeleteRowClick = async () => {
             {{ $t('activity.sendRecord') }}
           </div>
         </NcMenuItem>
+        <NcTooltip v-if="visibleMoreOptions.newRecord && meta?.synced" placement="left">
+          <template #title>
+            {{ $t('msg.info.insertNotAvailableForSyncedTable') }}
+          </template>
+          <NcMenuItem disabled>
+            <div class="flex gap-2 items-center" data-testid="nc-expanded-form-new-record">
+              <component :is="iconMap.plus" class="cursor-pointer" />
+              <span class="-ml-0.25">
+                {{ $t('activity.newRecord') }}
+              </span>
+            </div>
+          </NcMenuItem>
+        </NcTooltip>
+        <PermissionsTooltip
+          v-else-if="visibleMoreOptions.newRecord"
+          :entity="PermissionEntity.TABLE"
+          :entity-id="meta?.id"
+          :permission="PermissionKey.TABLE_RECORD_ADD"
+          placement="right"
+        >
+          <template #default="{ isAllowed }">
+            <NcMenuItem :disabled="!isAllowed" @click="isAllowed && emits('newRecord')">
+              <div v-e="['c:row-expand:new-record']" class="flex gap-2 items-center" data-testid="nc-expanded-form-new-record">
+                <component :is="iconMap.plus" class="cursor-pointer" />
+                <span class="-ml-0.25">
+                  {{ $t('activity.newRecord') }}
+                </span>
+              </div>
+            </NcMenuItem>
+          </template>
+        </PermissionsTooltip>
         <NcTooltip v-if="visibleMoreOptions.duplicateRecord && meta?.synced" placement="left">
           <template #title>
             {{ $t('msg.info.duplicateNotAvailableForSyncedTable') }}

--- a/packages/nc-gui/components/smartsheet/expanded-form/index.vue
+++ b/packages/nc-gui/components/smartsheet/expanded-form/index.vue
@@ -998,6 +998,7 @@ export default {
             :blueprint-mode="props.blueprintMode"
             :view="props.view"
             :row-id="rowId"
+            @new-record="addNewRow"
             @duplicate-start="onDuplicateStart"
             @after-delete="onAfterDelete"
             @request-close="onClose(true)"


### PR DESCRIPTION
## Change Summary

Closes #13854

Added a "New Record" action to the Expanded Form more-options menu.

Previously, users could duplicate, delete, or send a record from the expanded form view, but there was no quick way to immediately create another record while staying inside the same workflow.

This change adds a "New Record" option that resets the form and opens a fresh record form without requiring the user to navigate back manually. The implementation reuses the existing `addNewRow` logic to keep behavior consistent with the current Grid/Form record creation flow.

## Change type

* [x] feat: (new feature for the user, not a new feature for build script)
* [ ] fix: (bug fix for the user, not a fix to a build script)
* [ ] docs: (changes to the documentation)
* [ ] style: (formatting, missing semi colons, etc; no production code change)
* [ ] refactor: (refactoring production code, eg. renaming a variable)
* [ ] test: (adding missing tests, refactoring tests; no production code change)
* [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Verified locally by:

1. Opening a table in Grid View
2. Opening a record in Expanded Form view
3. Clicking the three-dot more-options menu
4. Confirming the new "New Record" action appears above "Duplicate Record"
5. Clicking "New Record" successfully resets the form and opens a fresh empty record form while staying in the same view

Also verified that existing actions such as Duplicate, Delete, and Send Record continue to work as expected.

## Additional information / screenshots (optional)

This change is limited to the expanded form menu components and does not introduce backend or API changes.
<img width="946" height="651" alt="Screenshot 2026-05-20 at 12 26 01 AM" src="https://github.com/user-attachments/assets/e9e1d5c9-8979-497c-b15a-b3dc780b6a71" />
