### PR TITLE
fix(gui): normalize calendar date fields using updateFormat

### DIFF
--- a/packages/nc-gui/components/smartsheet/calendar/DayView/DateField.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/DayView/DateField.vue
@@ -13,7 +13,7 @@ const { isUIAllowed } = useRoles()
 
 const { $e } = useNuxtApp()
 
-const { selectedDate, formattedData, formattedSideBarData, calendarRange, updateRowProperty, isSyncedFromColumn } =
+const { selectedDate, formattedData, formattedSideBarData, calendarRange, updateRowProperty, isSyncedFromColumn, updateFormat } =
   useCalendarViewStoreOrThrow()
 
 const fields = inject(FieldsInj, ref())
@@ -145,7 +145,7 @@ const dropEvent = (event: DragEvent) => {
       ...record,
       row: {
         ...record.row,
-        [fromCol.title!]: dayjs(newStartDate).format('YYYY-MM-DD HH:mm:ssZ'),
+        [fromCol.title!]: dayjs(newStartDate).format(updateFormat.value),
       },
     }
 
@@ -164,7 +164,7 @@ const dropEvent = (event: DragEvent) => {
       } else {
         endDate = newStartDate.clone()
       }
-      newRow.row[toCol.title!] = dayjs(endDate).format('YYYY-MM-DD HH:mm:ssZ')
+      newRow.row[toCol.title!] = dayjs(endDate).format(updateFormat.value)
       updateProperty.push(toCol.title!)
     }
 
@@ -198,7 +198,7 @@ const newRecord = () => {
   if (!isUIAllowed('dataEdit') || !calendarRange.value?.length || isSyncedFromColumn.value) return
   const record = {
     row: {
-      [calendarRange.value[0].fk_from_col!.title!]: selectedDate.value.format('YYYY-MM-DD HH:mm:ssZ'),
+      [calendarRange.value[0].fk_from_col!.title!]: selectedDate.value.format(updateFormat.value),
     },
   }
   emit('newRecord', record)

--- a/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
@@ -762,6 +762,22 @@ const addRecord = (date: dayjs.Dayjs) => {
   }
   emit('newRecord', newRecord)
 }
+
+const addRecordWithRange = (range: any, date: dayjs.Dayjs) => {
+  if (!isUIAllowed('dataEdit') || isSyncedTable.value) return
+  const record = {
+    row: {
+      [range.fk_from_col!.title!]: date.format(updateFormat.value),
+      ...(range.fk_to_col
+        ? {
+            [range.fk_to_col!.title!]: date.endOf('day').format(updateFormat.value),
+          }
+        : {}),
+    },
+  }
+  console.log('Sending date payload (addRecordWithRange):', record)
+  emit('newRecord', record)
+}
 </script>
 
 <template>
@@ -841,21 +857,7 @@ const addRecord = (date: dayjs.Dayjs) => {
                       v-for="(range, index) in calendarRange"
                       :key="index"
                       class="text-nc-content-gray-default font-semibold text-sm"
-                      @click="
-                      () => {
-                        const record = {
-                          row: {
-                            [range.fk_from_col!.title!]: (day.date).format('YYYY-MM-DD HH:mm:ssZ'),
-                            ...(range.fk_to_col
-                        ? {
-                            [range.fk_to_col!.title!]: (day.date).endOf('day').format('YYYY-MM-DD HH:mm:ssZ'),
-                          }
-                        : {}),
-                          },
-                        }
-                        emit('newRecord', record)
-                      }
-                    "
+                      @click="addRecordWithRange(range, day.date)"
                     >
                       <div class="flex items-center gap-1">
                         <LazySmartsheetHeaderIcon :column="range.fk_from_col" />
@@ -883,21 +885,7 @@ const addRecord = (date: dayjs.Dayjs) => {
                     size="xsmall"
                     type="secondary"
                     :disabled="!isAllowed"
-                    @click="
-                () => {
-                  const record = {
-                    row: {
-                      [calendarRange[0].fk_from_col!.title!]: (day.date).format('YYYY-MM-DD HH:mm:ssZ'),
-                      ...(calendarRange[0].fk_to_col
-                        ? {
-                            [calendarRange[0].fk_to_col!.title!]: (day.date).endOf('day').format('YYYY-MM-DD HH:mm:ssZ'),
-                          }
-                        : {}),
-                    },
-                  }
-                  emit('newRecord', record)
-                }
-              "
+                    @click="addRecordWithRange(calendarRange[0], day.date)"
                   >
                     <component :is="iconMap.plus" />
                   </NcButton>

--- a/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
+++ b/packages/nc-gui/components/smartsheet/calendar/MonthView.vue
@@ -775,7 +775,6 @@ const addRecordWithRange = (range: any, date: dayjs.Dayjs) => {
         : {}),
     },
   }
-  console.log('Sending date payload (addRecordWithRange):', record)
   emit('newRecord', record)
 }
 </script>


### PR DESCRIPTION
## Change Summary

Fixes #13880

This PR fixes an issue where creating records from Calendar view with a `Date` field could save the previous day in timezones ahead of UTC.

Previously, some Calendar view record-creation paths formatted `Date` values using timezone-aware datetime strings such as `YYYY-MM-DD HH:mm:ssZ`. For `Date` fields, this could be converted to UTC by the backend and stored as the previous date.

This change updates Calendar view record creation to use the existing `updateFormat` value so:
- `Date` fields are formatted as `YYYY-MM-DD`
- `DateTime` fields continue using datetime-aware formatting
- Calendar-created records save the selected date correctly even when the date input is not focused manually

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Manually verified locally:

- Created a table with a `Date` field.
- Created a Calendar view using that `Date` field.
- Selected a date from Calendar view.
- Created a record without manually focusing/clicking the Date input.
- Confirmed the record saves on the selected date instead of shifting to the previous day.
- Verified the fix is scoped to Calendar view Date-field record creation.

## Additional information / screenshots (optional)

Before this fix, Calendar view could initialize a `Date` field as a timezone-aware datetime value. After this fix, Calendar-created `Date` values are normalized using the existing `updateFormat` logic before save.

BEFORE:

<img width="651" height="375" alt="Screenshot 2026-05-21 at 11 18 09 PM" src="https://github.com/user-attachments/assets/91eaa1a6-6ce6-4994-8072-022b01a3f3bb" />


AFTER:

<img width="1464" height="816" alt="Screenshot 2026-05-21 at 11 34 06 PM" src="https://github.com/user-attachments/assets/f8190974-d47b-48b4-9137-94f163a9ae1d" />

