### PR TITLE
feat: implement All Columns search in toolbar

### DIFF
--- a/packages/nc-gui/components/smartsheet/toolbar/SearchData.vue
+++ b/packages/nc-gui/components/smartsheet/toolbar/SearchData.vue
@@ -62,15 +62,16 @@ const isSearchResultVisible = computed(() => {
 })
 
 const columns = computed(() => {
+  const allColumnsOption = { id: 'all', title: 'All Columns' } as unknown as ColumnType
   if (isList.value && listViewStore?.selectedLevel.value?.fk_model_id) {
     const levelTableId = listViewStore.selectedLevel.value.fk_model_id
     const baseId = (meta.value as TableType)?.base_id
     const levelMeta = getMetaByKey(baseId, levelTableId)
     if (levelMeta?.columns) {
-      return (levelMeta.columns as ColumnType[]).filter((column) => isSearchableColumn(column))
+      return [allColumnsOption, ...(levelMeta.columns as ColumnType[]).filter((column) => isSearchableColumn(column))]
     }
   }
-  return (meta.value as TableType)?.columns?.filter((column) => isSearchableColumn(column)) ?? []
+  return [allColumnsOption, ...((meta.value as TableType)?.columns?.filter((column) => isSearchableColumn(column)) ?? [])]
 })
 
 watch(

--- a/packages/nc-gui/composables/useSmartsheetStore.ts
+++ b/packages/nc-gui/composables/useSmartsheetStore.ts
@@ -137,11 +137,32 @@ const [useProvideSmartsheetStore, useSmartsheetStore] = useInjectionState(
         where = whereQueryFromUrl.value
       }
 
+      const searchQuery = search.value.query.trim()
+
+      if (search.value.field === 'all') {
+        if (!searchQuery) {
+          search.value.isValidFieldQuery = true
+          return where
+        }
+
+        const searchableCols = (meta.value as TableType)?.columns?.filter((c) => isSearchableColumn(c)) || []
+        const validQueries = searchableCols
+          .map((c) => getValidSearchQueryForColumn(c, searchQuery, meta.value as TableType, { getWhereQueryAs: 'string' }) as string)
+          .filter(Boolean)
+
+        if (!validQueries.length) {
+          search.value.isValidFieldQuery = false
+          return where
+        }
+
+        search.value.isValidFieldQuery = true
+        const allQuery = `(${validQueries.join('~or')})`
+        return `${where ? `${where}~and` : ''}${allQuery}`
+      }
+
       const col =
         (meta.value as TableType)?.columns?.find(({ id }) => id === search.value.field) ||
         (meta.value as TableType)?.columns?.find((v) => v.pv)
-
-      const searchQuery = search.value.query.trim()
 
       if (!col || !searchQuery) {
         search.value.isValidFieldQuery = true


### PR DESCRIPTION
## Summary
- Adds "All Columns" search mode to the smartsheet toolbar
- When search field is set to "all", query matches across all searchable columns using OR logic
- Prevents Ctrl+F shortcut from interfering with the smart text panel search

## Changes
- `packages/nc-gui/composables/useSmartsheetStore.ts` — Build multi-column search query when `search.field === "all"`, joining valid column queries with `~or`
- `packages/nc-gui/components/smartsheet/toolbar/SearchData.vue` — Skip Ctrl+F handler when focus is inside the smart text panel

## References
- ref: #5617
- ref: #8763