### PR TITLE
feat: add custom form email subject

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -2703,6 +2703,21 @@ const { message: templatedMessage } = useTemplatedMessage(
                               @change="onEmailChange"
                             />
                           </div>
+
+                          <div v-if="emailMe" class="flex flex-col gap-2 pt-2">
+                            <span class="text-nc-content-gray">{{ $t('msg.info.customEmailSubject') }}</span>
+                            <a-input
+                              :value="parseProp(formViewData?.meta)?.email_subject"
+                              :placeholder="`NocoDB Forms: Someone has responded to ${formViewData?.title || '{formTitle}'}`"
+                              :disabled="isLocked || !isEditable"
+                              @change="(e) => {
+                                const meta = parseProp(formViewData!.meta) || {}
+                                meta.email_subject = e.target.value
+                                formViewData!.meta = meta
+                                updateView()
+                              }"
+                            />
+                          </div>
                         </div>
 
                         <!-- Show this message -->

--- a/packages/nc-gui/lang/en.json
+++ b/packages/nc-gui/lang/en.json
@@ -3638,6 +3638,7 @@
       "submitAnotherForm": "Show 'Submit Another Form' button",
       "showBlankForm": "Show a blank form after 5 seconds",
       "emailForm": "Email responses to",
+      "customEmailSubject": "Custom email subject",
       "showSysFields": "Show system fields",
       "filterAutoApply": "Auto apply",
       "formDisplayMessage": "Display Message",

--- a/packages/nocodb/src/services/mail/mail.service.ts
+++ b/packages/nocodb/src/services/mail/mail.service.ts
@@ -441,11 +441,25 @@ export class MailService {
         case MailEvent.FORM_SUBMISSION: {
           const { formView, data, model, emails, base } = payload;
 
+          let meta = formView.meta as Record<string, any>;
+          if (typeof formView.meta === 'string') {
+            try {
+              meta = JSON.parse(formView.meta);
+            } catch (e) {}
+          }
+
+          let subject = `NocoDB Forms: Someone has responded to ${formView.title}`;
+          if (meta?.email_subject) {
+            subject = meta.email_subject
+              .replace(/{formTitle}/g, formView.title || '')
+              .replace(/{tableTitle}/g, model.title || '');
+          }
+
           // SKIP_STORING_MAIL_EVENTS — recipients + payload are end-user data
           await this.dispatchAndLog(mailerAdapter, ncMeta, {
             event: mailEvent,
             to: emails.join(','),
-            subject: `NocoDB Forms: Someone has responded to ${formView.title}`,
+            subject,
             html: await this.renderMail('FormSubmission', {
               formTitle: formView.title,
               tableTitle: model.title,


### PR DESCRIPTION
## Change Summary

Closes : #13891

Adds support for a custom email subject for form submission notification emails.

Users can now optionally configure a custom subject line in Form View settings under the existing “Email responses to” section. If no custom subject is provided, the existing default subject behavior remains unchanged.

This implementation stores the value inside the existing `formView.meta` configuration object, avoiding database migrations and unnecessary schema/API changes.

Supported placeholders:

* `{formTitle}`
* `{tableTitle}`

## Change type

* [x] feat: (new feature for the user, not a new feature for build script)

## Test/ Verification

### Manual Verification

* Created/opened a Form View
* Enabled “Email responses to”
* Verified the new “Custom email subject” input appears
* Confirmed custom value persists through view updates/refresh
* Verified fallback behavior when field is empty
* Verified placeholder interpolation for:

  * `{formTitle}`
  * `{tableTitle}`

### Code Verification

* Ran lint/build verification locally
* Confirmed only intended files were modified
* No generated SDK/swagger changes introduced
* No database migrations required


