### PR TITLE
fix: set checkbox default to false for required columns in form submission (#13054)

### DIFF
--- a/packages/nc-gui/components/smartsheet/Form.vue
+++ b/packages/nc-gui/components/smartsheet/Form.vue
@@ -359,7 +359,7 @@ async function submitForm() {
 
   for (const col of localColumns.value) {
     if (col.show && col.title && isRequired(col, col.required) && formState.value[col.title] === undefined) {
-      formState.value[col.title] = null
+      formState.value[col.title] = col.uidt === UITypes.Checkbox ? false : null
     }
 
     // handle filter out conditionally hidden field data


### PR DESCRIPTION
## Problem

When creating a record via Form or Grid view with an unticked checkbox that has `NOT NULL` constraint (external DB), the submission fails with:
```
Add row failed: Missing required columns: is_xxx
```

Root cause: In `Form.vue`, the `submitForm()` function sets undefined required fields to `null`:
```ts
formState.value[col.title] = null
```

For checkbox columns, the correct default for an unchecked state is `false`, not `null`. External databases with `NOT NULL` boolean constraints reject `null` values.

## Fix

```ts
// Before
formState.value[col.title] = null

// After
formState.value[col.title] = col.uidt === UITypes.Checkbox ? false : null
```

## Testing

1. Link an external PostgreSQL database with a `NOT NULL` boolean column (default `false`)
2. Create a record via "New Record - Form" leaving the checkbox unticked
3. Submit should succeed with the boolean set to `false`

Fixes #13054
