### PR TITLE
Add copy action to attachment thumbnails

### DIFF
--- a/packages/nc-gui/components/cell/attachment/index.vue
+++ b/packages/nc-gui/components/cell/attachment/index.vue
@@ -48,6 +48,12 @@ const cellEventHook = inject(CellEventHookInj, null)
 
 const { isMobileMode } = useGlobal()
 
+const { t } = useI18n()
+
+const { copy } = useCopy()
+
+const { getAttachmentSrc } = useAttachment()
+
 const {
   isPublic,
   isForm,
@@ -106,6 +112,16 @@ const onDropAction = function (...args: any[]) {
   }
 }
 const { isOverDropZone } = useDropZone(currentCellRef as any, onDropAction)
+
+const copyAttachmentUrl = async (item: Record<string, any>) => {
+  try {
+    const attachmentUrl = await getAttachmentSrc(item)
+    await copy(attachmentUrl)
+    message.info(t('msg.info.copiedToClipboard'))
+  } catch {
+    message.error(t('msg.error.copyToClipboardError'))
+  }
+}
 
 /** on new value, reparse our stored attachments */
 watch(
@@ -538,7 +554,7 @@ onUnmounted(() => {
             <div class="text-center w-full">{{ item.title }}</div>
           </template>
           <div
-            class="aspect-square"
+            class="aspect-square relative nc-attachment-thumb"
             :class="{
               'h-[24px]': !rowHeight || rowHeight === 1,
               'h-[32px]': rowHeight === 2,
@@ -555,6 +571,20 @@ onUnmounted(() => {
               object-fit="contain"
               @click="() => onFileClick(item)"
             />
+            <NcTooltip placement="bottom">
+              <template #title>
+                {{ $t('general.copy') }}
+              </template>
+              <NcButton
+                type="secondary"
+                size="xsmall"
+                :aria-label="$t('general.copy')"
+                class="nc-attachment-copy-url !absolute top-0.5 right-0.5 !p-0 !w-5 !h-5 !min-w-[fit-content] opacity-0 focus:opacity-100"
+                @click.stop.prevent="copyAttachmentUrl(item)"
+              >
+                <GeneralIcon icon="copy" class="h-3 w-3" />
+              </NcButton>
+            </NcTooltip>
           </div>
         </NcTooltip>
       </div>
@@ -658,6 +688,13 @@ onUnmounted(() => {
   }
   .nc-attachment-item {
     @apply relative;
+  }
+
+  .nc-attachment-thumb:hover,
+  .nc-attachment-thumb:focus-within {
+    .nc-attachment-copy-url {
+      @apply opacity-100;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- Add a one-click copy action to attachment thumbnails in grid cells.
- Resolve the copied value with `getAttachmentSrc()` so generated attachment URLs copy the same usable source as the preview.
- Keep thumbnail opening behavior intact and show existing copied/error notifications for the copy action.

Fixes #8923

## Testing

- `PNPM_HOME=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.pnpm-home XDG_DATA_HOME=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.xdg-data PNPM_STORE_DIR=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.pnpm-store npm_config_cache=/Users/arieleli/Documents/Codex/2026-05-24/can-you-help-me-find-an/.npm-cache npx pnpm@10.2.0 --dir packages/nc-gui exec eslint --ext ".js,.jsx,.ts,.tsx,.vue" components/cell/attachment/index.vue`
