### PR TITLE
fix(gui): refresh decimal field on form navigation

### DIFF
--- a/packages/nc-gui/components/cell/Decimal/DecimalInput.vue
+++ b/packages/nc-gui/components/cell/Decimal/DecimalInput.vue
@@ -316,20 +316,34 @@ onBeforeUnmount(() => {
     removeEvents(inputRef.value as HTMLInputElement)
   }
 })
-
 watch(vModel, (newValue) => {
-  if (
-    !inputRef.value ||
-    newValue ||
-    inputRef.value.value === getFormattedModelValue() ||
-    inputRef.value.value === (newValue?.toString() || '')
-  ) {
+  if (!inputRef.value) return
+  // If the input already matches the formatted value or the bare string representation, do nothing.
+  if (inputRef.value.value === getFormattedModelValue() || inputRef.value.value === (newValue?.toString() || '')) {
     return
   }
-
-  // Clear input value if vModel is null and input value is not empty and not a dot or minus
-  if (!newValue && inputRef.value.value && !['.', '-'].includes(inputRef.value.value)) {
+  const decSep = props.decimalSeparator || '.'
+  let cleaned = inputRef.value.value.replace(new RegExp(`[^0-9\\-\\${decSep}]`, 'g'), '')
+  if (decSep !== '.') {
+    cleaned = cleaned.replace(new RegExp(`\\${decSep}`, 'g'), '.')
+  }
+  const parsedValue = Number(cleaned)
+  // If the parsed numeric value of the current input matches the new vModel,
+  // it means this change was triggered by the user typing (e.g., "10." -> vModel=10).
+  // We should NOT overwrite the input so we don't break their typing flow.
+  if (parsedValue === newValue || (ncIsNaN(parsedValue) && !newValue)) {
+    if (!newValue && inputRef.value.value && !['-', decSep].includes(inputRef.value.value)) {
+      inputRef.value.value = ''
+    }
+    return
+  }
+  // Otherwise, this is an external change (e.g. navigating records in Form view).
+  if (newValue === null || newValue === undefined) {
     inputRef.value.value = ''
+  } else {
+    // Refresh the input value. Apply thousand separators only if the field is not currently focused.
+    const isFocused = document.activeElement === inputRef.value
+    refreshVModel(!isFocused)
   }
 })
 </script>


### PR DESCRIPTION
## Change Summary

Closes #13861

Fixed an issue where decimal fields in Form View did not refresh correctly when navigating between records using the up/down controls.

The decimal input watcher was returning early for truthy values, so values like `10.25` or `99.50` were not reflected in the input when the active row changed.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Manually verified the fix in Form View:

- Created records with different decimal values.
- Opened the records in Form View.
- Navigated between records using the up/down controls.
- Confirmed decimal fields now refresh correctly when the active record changes.
- Confirmed empty/null decimal values are handled correctly.

## Additional information / screenshots (optional)


https://github.com/user-attachments/assets/383dd3af-d251-4c6e-82e0-aa82a5b4c914

