### PR TITLE
Nc fix: detect postgres text to varchar sync changes

### DIFF
--- a/packages/nocodb-sdk/src/lib/index.ts
+++ b/packages/nocodb-sdk/src/lib/index.ts
@@ -117,3 +117,4 @@ export * from '~/lib/DocumentRevision';
 export * from '~/lib/docs';
 export * from '~/lib/entityNameValidation';
 export * from '~/lib/smartText';
+export * from '~/lib/metaDiffUtils';

--- a/packages/nocodb-sdk/src/lib/metaDiffUtils.spec.ts
+++ b/packages/nocodb-sdk/src/lib/metaDiffUtils.spec.ts
@@ -1,0 +1,263 @@
+import { isColumnTypeChanged } from './metaDiffUtils';
+
+describe('isColumnTypeChanged', () => {
+  // ── Generic dt change (all dialects) ──────────────────────────────────────
+
+  it('returns true when dt changes', () => {
+    expect(
+      isColumnTypeChanged('pg', { dt: 'text' }, { dt: 'character varying' }),
+    ).toBe(true);
+  });
+
+  it('returns false when dt and dtxp are both unchanged', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: 100 },
+        { dt: 'character varying', dtxp: 100 },
+      ),
+    ).toBe(false);
+  });
+
+  // ── PostgreSQL: text → varchar ────────────────────────────────────────────
+
+  it('PG: detects text → character varying', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'text', dtxp: null },
+        { dt: 'character varying', dtxp: 1 },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: no false-positive for text → text (no change)', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'text', dtxp: null },
+        { dt: 'text', dtxp: null },
+      ),
+    ).toBe(false);
+  });
+
+  it('PG: detects character varying → text', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: 100 },
+        { dt: 'text', dtxp: null },
+      ),
+    ).toBe(true);
+  });
+
+  // ── PostgreSQL: varchar length change ─────────────────────────────────────
+
+  it('PG: detects varchar(100) → varchar(1) as type change', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: 100 },
+        { dt: 'character varying', dtxp: 1 },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: detects varchar(1) → varchar(100)', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: 1 },
+        { dt: 'character varying', dtxp: 100 },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: detects unbounded varchar → varchar(255)', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: null },
+        { dt: 'character varying', dtxp: 255 },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: detects varchar(255) → unbounded varchar', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: 255 },
+        { dt: 'character varying', dtxp: null },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: no false-positive when varchar length unchanged (number vs string coercion)', () => {
+    // NocoDB stores dtxp as a string in its metadata DB; PostgreSQL returns
+    // an integer.  The comparison must treat '100' and 100 as the same.
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: '100' },
+        { dt: 'character varying', dtxp: 100 },
+      ),
+    ).toBe(false);
+  });
+
+  it('PG: no false-positive when varchar length is both null', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'character varying', dtxp: null },
+        { dt: 'character varying', dtxp: null },
+      ),
+    ).toBe(false);
+  });
+
+  // ── PostgreSQL: char(n) ───────────────────────────────────────────────────
+
+  it('PG: detects char(1) → char(10)', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'char', dtxp: 1 },
+        { dt: 'char', dtxp: 10 },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: no false-positive for char length unchanged', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'char', dtxp: 5 },
+        { dt: 'char', dtxp: 5 },
+      ),
+    ).toBe(false);
+  });
+
+  // ── PostgreSQL: text (no length parameter) ────────────────────────────────
+
+  it('PG: no false-positive for two text columns (both dtxp null/undefined)', () => {
+    // text has no character_maximum_length; dtxp is always null/undefined
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        { dt: 'text', dtxp: null },
+        { dt: 'text', dtxp: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  // ── PostgreSQL: native enum ───────────────────────────────────────────────
+
+  it('PG: detects native enum option list change', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b',
+          udt_typtype: 'e',
+          internal_meta: { pg_enum_type_name: 'mood' },
+        },
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b,c',
+          udt_typtype: 'e',
+          data_type_custom: 'mood',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: detects native enum type rename (different data_type_custom)', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b',
+          udt_typtype: 'e',
+          internal_meta: { pg_enum_type_name: 'mood' },
+        },
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b',
+          udt_typtype: 'e',
+          data_type_custom: 'status',
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('PG: no false-positive for unchanged native enum', () => {
+    expect(
+      isColumnTypeChanged(
+        'pg',
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b',
+          udt_typtype: 'e',
+          internal_meta: { pg_enum_type_name: 'mood' },
+        },
+        {
+          dt: 'USER-DEFINED',
+          dtxp: 'a,b',
+          udt_typtype: 'e',
+          data_type_custom: 'mood',
+        },
+      ),
+    ).toBe(false);
+  });
+
+  // ── MySQL: enum / set ─────────────────────────────────────────────────────
+
+  it('MySQL: detects enum option list change', () => {
+    expect(
+      isColumnTypeChanged(
+        'mysql2',
+        { dt: 'enum', dtxp: "'a','b'" },
+        { dt: 'enum', dtxp: "'a','b','c'" },
+      ),
+    ).toBe(true);
+  });
+
+  it('MySQL: no false-positive for enum unchanged', () => {
+    expect(
+      isColumnTypeChanged(
+        'mysql2',
+        { dt: 'enum', dtxp: "'a','b'" },
+        { dt: 'enum', dtxp: "'a','b'" },
+      ),
+    ).toBe(false);
+  });
+
+  // ── MySQL: varchar dtxp NOT compared (no regression) ─────────────────────
+
+  it('MySQL: does NOT flag varchar length change (PG-only length check)', () => {
+    // The PG-only condition must not fire for MySQL sources.
+    expect(
+      isColumnTypeChanged(
+        'mysql2',
+        { dt: 'varchar', dtxp: 100 },
+        { dt: 'varchar', dtxp: 1 },
+      ),
+    ).toBe(false);
+  });
+
+  // ── SQLite ────────────────────────────────────────────────────────────────
+
+  it('SQLite: detects dt change', () => {
+    expect(
+      isColumnTypeChanged('sqlite3', { dt: 'TEXT' }, { dt: 'INTEGER' }),
+    ).toBe(true);
+  });
+
+  it('SQLite: no false-positive when dt unchanged', () => {
+    expect(
+      isColumnTypeChanged('sqlite3', { dt: 'TEXT' }, { dt: 'TEXT' }),
+    ).toBe(false);
+  });
+});

--- a/packages/nocodb-sdk/src/lib/metaDiffUtils.ts
+++ b/packages/nocodb-sdk/src/lib/metaDiffUtils.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helper for schema-sync column-type change detection.
+ *
+ * Kept separate from the NestJS service so it can be unit-tested without a
+ * full application context.  Import from `nocodb-sdk` or directly from this
+ * file.
+ */
+
+/**
+ * Returns true when a column's database type (or its length/precision for
+ * parameterised types) has changed in a way that NocoDB must sync.
+ *
+ * Rules:
+ *  - All dialects: raw `dt` string inequality triggers a change.
+ *  - MySQL/mysql2:  enum/set option-list (`dtxp`) changes trigger a change.
+ *  - PG: `character varying` / `char` / `character` length (`dtxp`) changes
+ *    trigger a change even when the base type string stays the same.
+ *    String coercion handles the number (PostgreSQL) vs string (NocoDB
+ *    metadata DB) mismatch.
+ *  - PG native enum: option-list or underlying enum type name changes.
+ */
+export function isColumnTypeChanged(
+  sourceType: string,
+  oldCol: {
+    dt?: string;
+    dtxp?: any;
+    udt_typtype?: string;
+    internal_meta?: any;
+  },
+  column: {
+    dt?: string;
+    dtxp?: any;
+    udt_typtype?: string;
+    data_type_custom?: string;
+  },
+): boolean {
+  return (
+    // Base type changed (all dialects)
+    oldCol.dt !== column.dt ||
+    // MySQL / mysql2: enum or set option list changed
+    (['mysql', 'mysql2'].includes(sourceType) &&
+      ['set', 'enum'].includes(column.dt) &&
+      column.dtxp !== oldCol.dtxp) ||
+    // PG: length-parameterised types — detect varchar(n) / char(n) length
+    // changes even when the base dt string stays 'character varying'.
+    // String coercion avoids number/string inequality when PostgreSQL
+    // returns an integer and NocoDB's metadata DB stores a string.
+    (sourceType === 'pg' &&
+      ['character varying', 'char', 'character'].includes(column.dt) &&
+      String(column.dtxp ?? '') !== String(oldCol.dtxp ?? '')) ||
+    // PG native enum: option list or underlying enum type name changed
+    (sourceType === 'pg' &&
+      column.udt_typtype === 'e' &&
+      (column.dtxp !== oldCol.dtxp ||
+        column.data_type_custom !== oldCol.internal_meta?.pg_enum_type_name))
+  );
+}

--- a/packages/nocodb/src/services/meta-diffs.service.ts
+++ b/packages/nocodb/src/services/meta-diffs.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
   AppEvents,
-  ClientType,
   isAIPromptCol,
   isLinksOrLTAR,
   isMMOrMMLike,
@@ -9,7 +8,6 @@ import {
   MetaEventType,
   ModelTypes,
   RelationTypes,
-  SqlUiFactory,
   UITypes,
 } from 'nocodb-sdk';
 import { pluralize, singularize } from 'inflection';
@@ -55,6 +53,38 @@ const applyChangesPriorityOrder = [
   MetaDiffType.VIEW_COLUMN_REMOVE,
   MetaDiffType.TABLE_RELATION_REMOVE,
 ];
+
+/**
+ * Returns true when a column's database type (or its length/precision for
+ * parameterised types) has changed in a way that NocoDB must sync.
+ *
+ * Extracted as a pure function so it can be unit-tested independently of the
+ * full getMetaDiff / syncBaseMeta pipeline.
+ */
+export function isColumnTypeChanged(
+  sourceType: string,
+  oldCol: { dt?: string; dtxp?: any; udt_typtype?: string; internal_meta?: any },
+  column: { dt?: string; dtxp?: any; udt_typtype?: string; data_type_custom?: string },
+): boolean {
+  return (
+    // Base type changed
+    oldCol.dt !== column.dt ||
+    // MySQL: enum/set option list changed
+    (['mysql', 'mysql2'].includes(sourceType) &&
+      ['set', 'enum'].includes(column.dt) &&
+      column.dtxp !== oldCol.dtxp) ||
+    // PG: length-parameterised types — detect varchar(n) length changes even
+    // when the base dt string stays 'character varying'.
+    (sourceType === 'pg' &&
+      ['character varying', 'char', 'character'].includes(column.dt) &&
+      String(column.dtxp ?? '') !== String(oldCol.dtxp ?? '')) ||
+    // PG native enum: option list or underlying enum type name changed
+    (sourceType === 'pg' &&
+      column.udt_typtype === 'e' &&
+      (column.dtxp !== oldCol.dtxp ||
+        column.data_type_custom !== oldCol.internal_meta?.pg_enum_type_name))
+  );
+}
 
 type MetaDiff = {
   title?: string;
@@ -270,19 +300,7 @@ export class MetaDiffsService {
         const [oldCol] = oldMeta.columns.splice(oldColIdx, 1);
 
         if (
-          oldCol.dt !== column.dt ||
-          // if mysql and data type is set or enum then compare dtxp as well
-          (['mysql', 'mysql2'].includes(source.type) &&
-            ['set', 'enum'].includes(column.dt) &&
-            column.dtxp !== oldCol.dtxp) ||
-          // PG native enum: dt stays 'USER-DEFINED' but option list can
-          // change via ALTER TYPE ADD/RENAME VALUE, or the underlying enum
-          // type itself can be swapped (different udt_name).
-          (source.type === 'pg' &&
-            column.udt_typtype === 'e' &&
-            (column.dtxp !== oldCol.dtxp ||
-              column.data_type_custom !==
-                oldCol.internal_meta?.pg_enum_type_name))
+          isColumnTypeChanged(source.type, oldCol, column)
         ) {
           tableProp.detectedChanges.push({
             type: MetaDiffType.TABLE_COLUMN_TYPE_CHANGE,
@@ -712,19 +730,7 @@ export class MetaDiffsService {
         const [oldCol] = oldMeta.columns.splice(oldColIdx, 1);
 
         if (
-          oldCol.dt !== column.dt ||
-          // if mysql and data type is set or enum then compare dtxp as well
-          (['mysql', 'mysql2'].includes(source.type) &&
-            ['set', 'enum'].includes(column.dt) &&
-            column.dtxp !== oldCol.dtxp) ||
-          // PG native enum: dt stays 'USER-DEFINED' but option list can
-          // change via ALTER TYPE ADD/RENAME VALUE, or the underlying enum
-          // type itself can be swapped (different udt_name).
-          (source.type === 'pg' &&
-            column.udt_typtype === 'e' &&
-            (column.dtxp !== oldCol.dtxp ||
-              column.data_type_custom !==
-                oldCol.internal_meta?.pg_enum_type_name))
+          isColumnTypeChanged(source.type, oldCol, column)
         ) {
           tableProp.detectedChanges.push({
             type: MetaDiffType.TABLE_COLUMN_TYPE_CHANGE,
@@ -852,7 +858,6 @@ export class MetaDiffsService {
 
     // @ts-ignore
     const sqlClient = await NcConnectionMgrv2.getSqlClient(source);
-    const sqlUi = SqlUiFactory.create({ client: source.type ?? ClientType.PG });
     const changes = await this.getMetaDiff(context, sqlClient, base, source);
 
     /* Get all relations */
@@ -982,12 +987,16 @@ export class MetaDiffsService {
                 {},
               );
 
-              // check if new type is compatible with old uidt
-              const allowedDatatypes = sqlUi.getDataTypeListForUiType(column);
-
-              // if UIDT not compatible with new type then change uidt
-              if (!allowedDatatypes?.includes(column.dt)) {
+              // When the base data type (dt) has changed (e.g. text →
+              // character varying), recompute the UI type from the new DB
+              // type so the column reflects reality.
+              // When only the length/precision changed (same dt, different
+              // dtxp) preserve the stored uidt — the user may have
+              // intentionally chosen a different UI type for that column.
+              if (column.dt !== change.column.dt) {
                 column.uidt = metaFact.getUIDataType(column);
+              } else {
+                column.uidt = change.column.uidt;
               }
 
               column.title = change.column.title;


### PR DESCRIPTION
## Change Summary

Fixes PostgreSQL schema sync issue where `text → varchar(n)` / `character varying(n)` changes were ignored, causing stale UI type (`LongText`) to persist.

Closes #13864

---

## Change type

- [x] fix
- [x] refactor
- [x] test

---

## Root Cause

1. **varchar(n) length changes not detected**
   - `dt` comparison failed because both types resolve to `character varying`
   - PostgreSQL returns numeric length, NocoDB stores string → needed coercion

2. **UIDT not updated after text → varchar change**
   - `getDataTypeListForUiType()` received incomplete column (missing `uidt`)
   - fallback included all DB types → `LongText` incorrectly preserved

---

## Changes

### meta-diffs.service.ts

- Added `isColumnTypeChanged()` helper
- Added PG-specific detection for `varchar(n)` length changes using `dtxp` comparison
- Fixed UIDT update logic:
  - If `dt` changes → recompute `uidt`
  - Else → preserve existing `uidt`

### metaDiffUtils.ts (new)

- Extracted `isColumnTypeChanged` for reuse and testing

### metaDiffUtils.spec.ts (new)

- Added 22 tests covering:
  - text ↔ varchar detection
  - varchar length changes
  - no false positives
  - cross-DB cases (MySQL, SQLite, PG enums)
  - string/number coercion cases

---

## Test / Verification

- PostgreSQL `text → varchar(1)` correctly updates UI type
- No false diff on repeated sync
- `varchar(100) → varchar(1)` detected properly
- All 22 unit tests pass






<img width="947" height="227" alt="Screenshot 2026-05-30 at 2 36 07 AM" src="https://github.com/user-attachments/assets/83d6d90c-1b3d-4f8c-82f8-f256757466f9" />
