### PR TITLE
fix: allow ordering linked records

### DIFF
--- a/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
+++ b/packages/nc-gui/components/virtual-cell/components/LinkedItems.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
+import Draggable from 'vuedraggable'
 import { type ColumnType, type LinkToAnotherRecordType, isDateOrDateTimeCol } from 'nocodb-sdk'
 import { PermissionEntity, PermissionKey, RelationTypes, isLinksOrLTAR } from 'nocodb-sdk'
 
@@ -89,6 +90,7 @@ const {
   fetchChildrenChunk,
   clearChildrenCache,
   resetChildrenCache,
+  reorderLinkedRecords,
 } = useLTARStoreOrThrow()
 
 const { withLoading } = useLoadingTrigger()
@@ -420,6 +422,39 @@ const visibleRows = computed(() => {
   })
 })
 
+const isDraggingLinkedRows = ref(false)
+
+const draggableRows = ref<Record<string, any>[]>([])
+
+const canReorderLinkedRows = computed(() => {
+  return (
+    !isPublic.value &&
+    !readOnly.value &&
+    !isForm.value &&
+    !isNew.value &&
+    !childrenListPagination.query &&
+    !isSingleTargetRelation.value
+  )
+})
+
+const showDraggableLinkedRows = computed(
+  () => canReorderLinkedRows.value && draggableRows.value.length === visibleRows.value.length,
+)
+
+watch(
+  visibleRows,
+  (rows) => {
+    if (isDraggingLinkedRows.value || !canReorderLinkedRows.value) return
+    draggableRows.value = rows.filter((row) => !row._placeholder)
+  },
+  { immediate: true },
+)
+
+const onLinkedRowsDragChange = async (event: { moved?: unknown }) => {
+  if (!event?.moved) return
+  await reorderLinkedRecords(draggableRows.value)
+}
+
 onUnmounted(() => {
   resetChildrenListOffsetCount()
   resetChildrenCache()
@@ -526,38 +561,80 @@ const { handleSearchKeydown: handleKeyDown } = useLTARListKeyNav({
             <!-- Top spacer for virtual scroll -->
             <div :style="{ height: `${rowSlice.start * ROW_HEIGHT}px` }" />
 
-            <template v-for="item in visibleRows" :key="item._index">
-              <!-- Skeleton placeholder for unloaded rows -->
-              <div
-                v-if="item._placeholder"
-                :style="{ height: `${ROW_HEIGHT}px` }"
-                class="flex flex-row gap-3 px-3 py-2 transition-all relative border-b-1 border-nc-border-gray-medium"
-              >
-                <div class="flex items-center">
-                  <a-skeleton-image class="!h-11 !w-11 !rounded-md overflow-hidden children:(!h-full !w-full)" />
+            <Draggable
+              v-if="showDraggableLinkedRows"
+              v-model="draggableRows"
+              item-key="_index"
+              handle=".nc-linked-row-drag-handle"
+              ghost-class="nc-linked-row-ghost"
+              @change="onLinkedRowsDragChange"
+              @start="isDraggingLinkedRows = true"
+              @end="isDraggingLinkedRows = false"
+            >
+              <template #item="{ element: item }">
+                <div class="flex items-stretch border-b-1 border-nc-border-gray-medium">
+                  <button
+                    class="nc-linked-row-drag-handle flex w-7 flex-none cursor-grab items-center justify-center text-nc-content-gray-muted hover:text-nc-content-gray-subtle"
+                    type="button"
+                    @click.stop
+                  >
+                    <GeneralIcon icon="dragVertical" class="h-4 w-4" />
+                  </button>
+                  <LazyVirtualCellComponentsListItem
+                    :attachment="attachmentCol"
+                    :display-value-type-and-format-prop="displayValueTypeAndFormatProp"
+                    :fields="fields"
+                    :display-value-column="relatedTableDisplayValueColumn"
+                    :is-linked="item._isLinked"
+                    :is-loading="item._isLoading"
+                    :is-selected="false"
+                    :related-table-display-value-prop="relatedTableDisplayValueProp"
+                    :row="item"
+                    class="flex-1"
+                    data-testid="nc-child-list-item"
+                    @link-or-unlink="linkOrUnLink(item, String(item._index))"
+                    @expand="onClick(item)"
+                    @keydown.space.prevent.stop="() => linkOrUnLink(item, String(item._index))"
+                    @keydown.enter.prevent.stop="() => linkOrUnLink(item, String(item._index))"
+                  />
                 </div>
-                <div class="flex flex-col gap-2 flex-grow justify-center">
-                  <a-skeleton-input active class="h-4 !w-48 !rounded-md overflow-hidden" size="small" />
+              </template>
+            </Draggable>
+
+            <template v-else>
+              <template v-for="item in visibleRows" :key="item._index">
+                <!-- Skeleton placeholder for unloaded rows -->
+                <div
+                  v-if="item._placeholder"
+                  :style="{ height: `${ROW_HEIGHT}px` }"
+                  class="flex flex-row gap-3 px-3 py-2 transition-all relative border-b-1 border-nc-border-gray-medium"
+                >
+                  <div class="flex items-center">
+                    <a-skeleton-image class="!h-11 !w-11 !rounded-md overflow-hidden children:(!h-full !w-full)" />
+                  </div>
+                  <div class="flex flex-col gap-2 flex-grow justify-center">
+                    <a-skeleton-input active class="h-4 !w-48 !rounded-md overflow-hidden" size="small" />
+                  </div>
                 </div>
-              </div>
-              <!-- Actual ListItem for loaded rows -->
-              <LazyVirtualCellComponentsListItem
-                v-else
-                :attachment="attachmentCol"
-                :display-value-type-and-format-prop="displayValueTypeAndFormatProp"
-                :fields="fields"
-                :display-value-column="relatedTableDisplayValueColumn"
-                :is-linked="item._isLinked"
-                :is-loading="item._isLoading"
-                :is-selected="!!(isSearchInputFocused && childrenListPagination.query && item._index === 0)"
-                :related-table-display-value-prop="relatedTableDisplayValueProp"
-                :row="item"
-                data-testid="nc-child-list-item"
-                @link-or-unlink="linkOrUnLink(item, String(item._index))"
-                @expand="onClick(item)"
-                @keydown.space.prevent.stop="() => linkOrUnLink(item, String(item._index))"
-                @keydown.enter.prevent.stop="() => linkOrUnLink(item, String(item._index))"
-              />
+                <!-- Actual ListItem for loaded rows -->
+                <LazyVirtualCellComponentsListItem
+                  v-else
+                  :attachment="attachmentCol"
+                  :display-value-type-and-format-prop="displayValueTypeAndFormatProp"
+                  :fields="fields"
+                  :display-value-column="relatedTableDisplayValueColumn"
+                  :is-linked="item._isLinked"
+                  :is-loading="item._isLoading"
+                  :is-selected="!!(isSearchInputFocused && childrenListPagination.query && item._index === 0)"
+                  :related-table-display-value-prop="relatedTableDisplayValueProp"
+                  :row="item"
+                  data-testid="nc-child-list-item"
+                  @link-or-unlink="linkOrUnLink(item, String(item._index))"
+                  @expand="onClick(item)"
+                  @keydown.space.prevent.stop="() => linkOrUnLink(item, String(item._index))"
+                  @keydown.enter.prevent.stop="() => linkOrUnLink(item, String(item._index))"
+                />
+              </template>
             </template>
 
             <!-- Bottom spacer for virtual scroll -->
@@ -694,6 +771,10 @@ const { handleSearchKeydown: handleKeyDown } = useLTARListKeyNav({
 
 :deep(.ant-skeleton-element .ant-skeleton-image-svg) {
   @apply !w-7;
+}
+
+:deep(.nc-linked-row-ghost) {
+  @apply bg-nc-bg-gray-extralight opacity-70;
 }
 
 :deep(.nc-filter-input-wrapper) {

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -1,5 +1,6 @@
 import type { ColumnType, LinkToAnotherRecordType, PaginatedType, RequestParams, TableType } from 'nocodb-sdk'
 import {
+  ContentType,
   RelationTypes,
   UITypes,
   dateFormats,
@@ -123,6 +124,7 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
     const { t } = useI18n()
 
     const isPublic: Ref<boolean> = inject(IsPublicInj, ref(false))
+    const readOnly = inject(ReadonlyInj, ref(false))
 
     const colOptions = computed(() => column.value?.colOptions as LinkToAnotherRecordType)
 
@@ -1165,6 +1167,32 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
       childrenCachedTotalRows.value = 0
     }
 
+    const reorderLinkedRecords = async (rows: Record<string, any>[]) => {
+      if (isNewRow?.value || !rowId.value || isPublic.value || readOnly.value) return
+
+      const refRowIds = rows.map((row) => getRelatedTableRowId(row)).filter((id) => id != null)
+      if (!refRowIds.length) return
+
+      try {
+        await $api.request({
+          path: `/api/v2/tables/${meta.value.id}/links/${column?.value?.id}/records/${encodeURIComponent(rowId.value)}/order`,
+          method: 'PATCH',
+          body: refRowIds,
+          type: ContentType.Json,
+          format: 'json',
+        })
+
+        resetChildrenCache()
+        await loadChildrenList(true)
+        _reloadData?.({ shouldShowLoading: false, path: path.value })
+        $e('a:links:reorder')
+      } catch (e: any) {
+        message.error(`Reordering linked records failed: ${await extractSdkResponseErrorMsg(e)}`)
+        resetChildrenCache()
+        await loadChildrenList(true)
+      }
+    }
+
     const debounceLoadChildrenExcludedList = useDebounceFn(loadChildrenExcludedList, 500)
 
     const debounceLoadChildrenList = useDebounceFn(loadChildrenList, 500)
@@ -1211,6 +1239,7 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
     return {
       relatedTableMeta,
       isLinkedTableAccessible,
+      isSingleTargetRelation,
       loadRelatedTableMeta,
       targetViewColumns,
       targetViewColumnsById,
@@ -1228,6 +1257,7 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
       meta,
       unlink,
       link,
+      reorderLinkedRecords,
       loadChildrenExcludedList,
       loadChildrenList,
       isChildrenExcludedListLinked,

--- a/packages/nocodb/src/controllers/data-table.controller.ts
+++ b/packages/nocodb/src/controllers/data-table.controller.ts
@@ -292,6 +292,30 @@ export class DataTableController {
     });
   }
 
+  @Patch(['/api/v2/tables/:modelId/links/:columnId/records/:rowId/order'])
+  @Acl('nestedDataLink')
+  async nestedReorderLinks(
+    @TenantContext() context: NcContext,
+    @Req() req: NcRequest,
+    @Param('modelId') modelId: string,
+    @Query('viewId') viewId: string,
+    @Param('columnId') columnId: string,
+    @Param('rowId') rowId: string,
+    @Body()
+    refRowIds: string[] | number[] | Record<string, any>[],
+  ) {
+    return await this.dataTableService.nestedReorderLinks(context, {
+      modelId,
+      rowId,
+      query: req.query,
+      viewId,
+      columnId,
+      refRowIds,
+      cookie: req,
+      user: req.user,
+    });
+  }
+
   // todo: naming
   @Post(['/api/v2/tables/:modelId/links/:columnId/records'])
   @Acl('nestedDataListCopyPasteOrDeleteAll')

--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -90,6 +90,7 @@ import { baseModelInsert } from '~/db/BaseModelSqlv2/insert';
 import {
   addOrRemoveLinks,
   extractCorrespondingLinkColumn,
+  reorderLinks,
 } from '~/db/BaseModelSqlv2/add-remove-links';
 import applyAggregation from '~/db/aggregation';
 import { groupBy as baseModelGroupBy } from '~/db/BaseModelSqlv2/group-by';
@@ -8331,6 +8332,23 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     });
 
     return addOrRemoveLinks(this).removeLinks(params);
+  }
+
+  async reorderLinks(params: {
+    cookie: any;
+    childIds: (string | number | Record<string, any>)[];
+    colId: string;
+    rowId: string;
+  }) {
+    await this.checkPermission({
+      entity: PermissionEntity.FIELD,
+      entityId: params.colId,
+      permission: PermissionKey.RECORD_FIELD_EDIT,
+      user: params.cookie?.user,
+      req: params.cookie,
+    });
+
+    return reorderLinks(this)(params);
   }
 
   async ooRead(

--- a/packages/nocodb/src/db/BaseModelSqlv2/add-remove-links.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/add-remove-links.ts
@@ -22,6 +22,232 @@ import {
 } from '~/helpers/dbHelpers';
 import { Model } from '~/models';
 
+export const LINK_ORDER_COLUMN = 'nc_order';
+
+const isMissingColumnError = (error: any) =>
+  ['no such column', 'does not exist', 'unknown column'].some((msg) =>
+    error?.message?.toLowerCase?.().includes(msg),
+  );
+
+const isDuplicateColumnError = (error: any) =>
+  ['duplicate column', 'already exists', 'duplicate column name'].some((msg) =>
+    error?.message?.toLowerCase?.().includes(msg),
+  );
+
+export const ensureLinkOrderColumn = async (
+  baseModel: IBaseModelSqlV2,
+  tableName: string,
+) => {
+  try {
+    await baseModel.dbDriver(tableName).select(LINK_ORDER_COLUMN).limit(1);
+    return;
+  } catch (e) {
+    if (!isMissingColumnError(e)) throw e;
+  }
+
+  try {
+    await baseModel.dbDriver.schema.alterTable(tableName, (table) => {
+      table.decimal(LINK_ORDER_COLUMN, 40, 20);
+    });
+  } catch (e) {
+    if (!isDuplicateColumnError(e)) throw e;
+  }
+};
+
+export const hasLinkOrderColumn = async (
+  baseModel: IBaseModelSqlV2,
+  tableName: string,
+) => {
+  try {
+    await baseModel.dbDriver(tableName).select(LINK_ORDER_COLUMN).limit(1);
+    return true;
+  } catch (e) {
+    if (isMissingColumnError(e)) return false;
+    throw e;
+  }
+};
+
+const ensureLinkOrderColumnForQuery = async (
+  baseModel: IBaseModelSqlV2,
+  tableName: string,
+) => {
+  await ensureLinkOrderColumn(baseModel, tableName);
+};
+
+const getNextLinkOrder = async (
+  baseModel: IBaseModelSqlV2,
+  tableName: string,
+  groupColumn: string,
+  groupValue: unknown,
+  amount: number,
+) => {
+  await ensureLinkOrderColumnForQuery(baseModel, tableName);
+
+  const result = await baseModel
+    .dbDriver(tableName)
+    .where(groupColumn, groupValue)
+    .max(`${LINK_ORDER_COLUMN} as maxOrder`)
+    .first();
+  const maxOrder = Number(result?.maxOrder ?? 0);
+
+  return Array.from({ length: amount }).map((_, i) => maxOrder + i + 1);
+};
+
+const validateLinkRefIds = (
+  context: NcContext,
+  refIds: (string | number | Record<string, any>)[],
+  refModel: Model,
+) => {
+  for (const refId of Array.isArray(refIds) ? refIds : [refIds]) {
+    if (typeof refId === 'object') {
+      for (const primaryKey of refModel.primaryKeys) {
+        if (
+          ncIsNullOrUndefined(
+            dataWrapper(refId).getByColumnNameTitleOrId(primaryKey),
+          )
+        ) {
+          NcError.get(context).unprocessableEntity(
+            `Validation failed: Missing primary key column "${
+              primaryKey.title
+            }" in request for model "${
+              refModel.title
+            }". RefId: ${JSON.stringify(refId)}`,
+          );
+        }
+      }
+    } else if (ncIsNullOrUndefined(refId)) {
+      NcError.get(context).unprocessableEntity(
+        'Validation failed: RefId is null or undefined',
+      );
+    }
+  }
+};
+
+export const reorderLinks = (baseModel: IBaseModelSqlV2) => {
+  return async ({
+    colId,
+    rowId,
+    childIds,
+  }: {
+    colId: string;
+    rowId: string;
+    childIds: (string | number | Record<string, any>)[];
+  }) => {
+    const column = (await baseModel.model.getColumns(baseModel.context)).find(
+      (c) => c.id === colId,
+    );
+
+    if (!column || !isMMOrMMLike(column)) {
+      NcError.get(baseModel.context).badRequest(
+        'Ordering linked records is only supported for junction-table relations',
+      );
+    }
+
+    const colOptions = await column.getColOptions<LinkToAnotherRecordColumn>(
+      baseModel.context,
+    );
+    const { childContext, parentContext, mmContext } =
+      await colOptions.getParentChildContext(baseModel.context);
+
+    const childColumn = await colOptions.getChildColumn(childContext);
+    const parentColumn = await colOptions.getParentColumn(parentContext);
+    const childTable = await childColumn.getModel(childContext);
+    const parentTable = await parentColumn.getModel(parentContext);
+    const assocTable = await colOptions.getMMModel(mmContext);
+    const vChildCol = await colOptions.getMMChildColumn(mmContext);
+    const vParentCol = await colOptions.getMMParentColumn(mmContext);
+
+    const childBaseModel = await Model.getBaseModelSQL(childContext, {
+      model: childTable,
+      dbDriver: baseModel.dbDriver,
+    });
+    const parentBaseModel = await Model.getBaseModelSQL(parentContext, {
+      model: parentTable,
+      dbDriver: baseModel.dbDriver,
+    });
+    const assocBaseModel = await Model.getBaseModelSQL(mmContext, {
+      model: assocTable,
+      dbDriver: baseModel.dbDriver,
+    });
+
+    const assocTn = assocBaseModel.getTnPath(assocTable);
+
+    const row = await childBaseModel.readByPk(
+      rowId,
+      false,
+      {},
+      {
+        ignoreView: true,
+        getHiddenColumn: true,
+      },
+    );
+    if (!row) NcError.get(baseModel.context).recordNotFound(rowId);
+
+    const normalizedChildIds = childIds.map((id) =>
+      id !== null && typeof id === 'object'
+        ? parentBaseModel.extractPksValues(id, true)
+        : id,
+    );
+    validateLinkRefIds(baseModel.context, normalizedChildIds, parentTable);
+
+    const childFkValue = dataWrapper(row).getByColumnNameTitleOrId(childColumn);
+
+    await ensureLinkOrderColumnForQuery(baseModel, assocTn as string);
+
+    const existingRowsQb = baseModel
+      .dbDriver(assocTn)
+      .select(vChildCol.column_name, vParentCol.column_name)
+      .where(vChildCol.column_name, childFkValue);
+
+    const existingRows = await assocBaseModel.execAndParse(
+      existingRowsQb,
+      null,
+      { raw: true },
+    );
+    const linkedIds = new Set(
+      existingRows.map((r) => String(r[vParentCol.column_name])),
+    );
+
+    for (const id of normalizedChildIds) {
+      if (!linkedIds.has(String(id))) {
+        NcError.get(baseModel.context).recordNotFound(String(id));
+      }
+    }
+
+    const orderedIds = normalizedChildIds.map((id) => String(id));
+    const remainingIds = existingRows
+      .map((r) => String(r[vParentCol.column_name]))
+      .filter((id) => !orderedIds.includes(id));
+    const allIds = [...orderedIds, ...remainingIds];
+
+    for (const [index, id] of allIds.entries()) {
+      await assocBaseModel.execAndParse(
+        baseModel
+          .dbDriver(assocTn)
+          .where(vChildCol.column_name, childFkValue)
+          .where(vParentCol.column_name, id)
+          .update({ [LINK_ORDER_COLUMN]: index + 1 }),
+        null,
+        { raw: true },
+      );
+    }
+
+    await childBaseModel.updateLastModified({
+      model: childTable,
+      updatedColIds: [column.id],
+      rowIds: [rowId],
+    });
+
+    baseModel.dbDriver.attachToTransaction(async () => {
+      await childBaseModel
+        .getNonTransactionalClone()
+        .broadcastLinkUpdates([rowId]);
+    });
+
+    return true;
+  };
+};
+
 /**
  * Extract the corresponding link column in the referencing table using a given LTAR column and the referenced table
  * @param context - The NcContext
@@ -429,6 +655,18 @@ export const addOrRemoveLinks = (baseModel: IBaseModelSqlV2) => {
 
             // if no new links, return true
             if (!insertData.length) return true;
+
+            const linkOrders = await getNextLinkOrder(
+              baseModel,
+              vTn as string,
+              vChildCol.column_name,
+              dataWrapper(row).getByColumnNameTitleOrId(childColumn),
+              insertData.length,
+            );
+            insertData = insertData.map((data, index) => ({
+              ...data,
+              [LINK_ORDER_COLUMN]: linkOrders[index],
+            }));
           }
 
           // V2 cardinality enforcement: remove conflicting junction rows before insert

--- a/packages/nocodb/src/db/BaseModelSqlv2/relation-data-fetcher.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/relation-data-fetcher.ts
@@ -12,6 +12,10 @@ import { Filter, Model, View } from '~/models';
 import { hasTableVisibilityAccess } from '~/helpers/tableHelpers';
 import Noco from '~/Noco';
 import { nocoExecute } from '~/utils/nocoExecute';
+import {
+  hasLinkOrderColumn,
+  LINK_ORDER_COLUMN,
+} from '~/db/BaseModelSqlv2/add-remove-links';
 
 const GROUP_COL = '__nc_group_id';
 
@@ -20,6 +24,15 @@ export const relationDataFetcher = (param: {
   logger: Logger;
 }) => {
   const { baseModel } = param;
+
+  const applyLinkOrder = async (qb: any, mmTableName: string) => {
+    try {
+      if (!(await hasLinkOrderColumn(baseModel, mmTableName))) return;
+      qb.orderBy(`${mmTableName}.${LINK_ORDER_COLUMN}`, 'asc');
+    } catch (e) {
+      param.logger.warn(`Failed to apply linked record order: ${e.message}`);
+    }
+  };
 
   async function postProcessData(
     context: NcContext,
@@ -304,6 +317,8 @@ export const relationDataFetcher = (param: {
       });
 
       if (!sort || sort === '') {
+        await applyLinkOrder(qb, vtn as string);
+
         const view = relColOptions.fk_target_view_id
           ? await View.get(refContext, relColOptions.fk_target_view_id)
           : await View.getFirstCollaborativeView(refContext, refTable.id);
@@ -823,6 +838,9 @@ export const relationDataFetcher = (param: {
         skipViewFilter: true,
         prioritizePvSort: true,
       });
+      if (!sort || sort === '') {
+        await applyLinkOrder(qb, vtn as string);
+      }
 
       const mmListSoftDeleteFilter = await refBaseModel.getSoftDeleteFilter();
 

--- a/packages/nocodb/src/db/IBaseModelSqlV2.ts
+++ b/packages/nocodb/src/db/IBaseModelSqlV2.ts
@@ -410,6 +410,12 @@ export interface IBaseModelSqlV2 {
   >;
 
   broadcastLinkUpdates(ids: Array<string>): Promise<void>;
+  reorderLinks(params: {
+    cookie: any;
+    childIds: (string | number | Record<string, any>)[];
+    colId: string;
+    rowId: string;
+  }): Promise<boolean>;
   getSource(): Promise<Source>;
   /**
    * Creates a non-transactional clone of this instance for operations

--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -6168,6 +6168,23 @@ export class ColumnsService implements IColumnsService {
           altered: 1,
           uidt: UITypes.ForeignKey,
         },
+        {
+          cn: 'nc_order',
+          column_name: 'nc_order',
+          title: 'nc_order',
+          rqd: false,
+          pk: false,
+          ai: false,
+          cdf: null,
+          dt: 'decimal',
+          np: 40,
+          ns: 20,
+          dtxp: '40,20',
+          dtxs: '',
+          altered: 1,
+          uidt: UITypes.Order,
+          system: true,
+        },
       );
 
       await sqlMgr.sqlOpPlus(param.source, 'tableCreate', {
@@ -7182,6 +7199,23 @@ export class ColumnsService implements IColumnsService {
         un: parentPK.un,
         altered: 1,
         uidt: UITypes.ForeignKey,
+      },
+      {
+        cn: 'nc_order',
+        column_name: 'nc_order',
+        title: 'nc_order',
+        rqd: false,
+        pk: false,
+        ai: false,
+        cdf: null,
+        dt: 'decimal',
+        np: 40,
+        ns: 20,
+        dtxp: '40,20',
+        dtxs: '',
+        altered: 1,
+        uidt: UITypes.Order,
+        system: true,
       },
     ];
 

--- a/packages/nocodb/src/services/data-table.service.ts
+++ b/packages/nocodb/src/services/data-table.service.ts
@@ -700,6 +700,43 @@ export class DataTableService {
     return true;
   }
 
+  async nestedReorderLinks(
+    context: NcContext,
+    param: {
+      cookie: any;
+      viewId: string;
+      modelId: string;
+      columnId: string;
+      query: any;
+      refRowIds: string[] | number[] | Record<string, any>[];
+      rowId: string;
+      user?: any;
+    },
+  ) {
+    this.validateIds(context, param.refRowIds);
+
+    const { model, view } = await this.getModelAndView(context, param);
+
+    const source = await Source.get(context, model.source_id);
+
+    const baseModel = await Model.getBaseModelSQL(context, {
+      id: model.id,
+      viewId: view?.id,
+      dbDriver: await NcConnectionMgrv2.get(source),
+    });
+
+    const column = await this.getColumn(context, param);
+
+    await baseModel.reorderLinks({
+      colId: column.id,
+      childIds: param.refRowIds,
+      rowId: param.rowId,
+      cookie: param.cookie,
+    });
+
+    return true;
+  }
+
   // todo: naming & optimizing
   async nestedListCopyPasteOrDeleteAll(
     context: NcContext,


### PR DESCRIPTION
## Summary
- add persistent `nc_order` ordering for many-to-many junction links, including lazy backfill for existing junction tables when links are added or reordered
- add a nested links reorder API endpoint and backend permission/validation path
- add drag handles in the linked-records popup so linked records can be reordered visually

Fixes #11485

## Testing
- `./node_modules/.bin/eslint src/db/BaseModelSqlv2/add-remove-links.ts src/db/BaseModelSqlv2/relation-data-fetcher.ts src/db/BaseModelSqlv2.ts src/services/data-table.service.ts src/controllers/data-table.controller.ts`
- `./node_modules/.bin/eslint components/virtual-cell/components/LinkedItems.vue composables/useLTARStore.ts`
- `git diff --check`
- `./node_modules/.bin/run-p 'build:*'` in `packages/nocodb-sdk`
- `./node_modules/.bin/tsc --noEmit --pretty false` in `packages/nocodb` currently fails on existing repo/environment type resolution issues such as `NcRequest` express fields and missing optional/local modules (`@noco-local-integrations/core`, `moment`, `nc-gui/utils/debug`, etc.)
