### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs (supply-chain hardening)

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Get PR Commits
         id: "get-pr-commits"
-        uses: tim-actions/get-pr-commits@master
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@master
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21  # master
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/docker-readme-publish.yml
+++ b/.github/workflows/docker-readme-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v2
+        uses: peter-evans/dockerhub-description@616d1b63e806b630b975af3b4fe3304307b20f40  # v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/jest-unit-test.yml
+++ b/.github/workflows/jest-unit-test.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320  # v5
         with:
           version: 10
       - name: Setup Node

--- a/.github/workflows/on-event-issue-closed.yml
+++ b/.github/workflows/on-event-issue-closed.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Discord notify
-        uses: rjstone/discord-webhook-notify@v1
+        uses: rjstone/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993  # v1
         with:
           severity: info
           details: 'Closed : ${{ github.event.issue.title }}(#${{ github.event.issue.number }}) :  ${{ github.event.issue.html_url }}'


### PR DESCRIPTION
## Change Summary

Pins every third-party GitHub Action currently on a mutable tag to the exact commit that tag resolves to today, across 4 workflow file(s) (5 references, 5 distinct actions), keeping a `# tag` comment on each line. This repo already configures renovate, so these SHA pins can be kept current automatically (it bumps the pin and updates the `# tag` comment), adding no ongoing maintenance.

## Change type

- [x] chore: (updating grunt tasks etc; no production code change)

Supply-chain hardening of CI config; no production code change. Pinning to an immutable SHA is the [GitHub-recommended practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions.

## Test/ Verification

Verification level: **static**.
- SHA resolution: confirmed the pinned SHA is the commit the tag currently resolves to.
- Syntax: workflow YAML parsed/linted cleanly.
- I have **not** run this repository's CI; this is a configuration ref change only, no behavior change.

## Additional information / screenshots (optional)

Ref-only changes; first-party `actions/*` and actions you own are left alone.

<sub>Prepared by [TaskBounty](https://task-bounty.com). The pinned SHA was verified against the upstream tag. Glad to adjust or close if this isn't useful.</sub>