### PR TITLE
fix: prevent MariaDB delete failures from relation expansion (#14035)

### DIFF
--- a/packages/nocodb/src/db/BaseModelSqlv2.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2.ts
@@ -178,6 +178,12 @@ const JSON_COLUMN_TYPES = [UITypes.Button];
 const ORDER_STEP_INCREMENT = 1;
 
 const MAX_RECURSION_DEPTH = 2;
+const DELETE_SNAPSHOT_SAFE_VIRTUAL_TYPES = new Set<string>([
+  UITypes.CreatedTime,
+  UITypes.LastModifiedTime,
+  UITypes.CreatedBy,
+  UITypes.LastModifiedBy,
+]);
 
 const SELECT_REGEX = /^(\(|)select/i;
 const INSERT_REGEX = /^(\(|)insert/i;
@@ -334,6 +340,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       extractOrderColumn = false,
       ignoreRls = false,
       fk_display_value_column_id,
+      excludeVirtualColumns = false,
       skipPublicRedaction = false,
     }: {
       ignoreView?: boolean;
@@ -344,6 +351,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       extractOrderColumn?: boolean;
       ignoreRls?: boolean;
       fk_display_value_column_id?: string | null;
+      excludeVirtualColumns?: boolean;
       skipPublicRedaction?: boolean;
     } = {},
   ): Promise<any> {
@@ -358,6 +366,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       throwErrorIfInvalidParams,
       extractOnlyPrimaries,
       extractOrderColumn,
+      excludeVirtualColumns,
       apiVersion,
       fk_display_value_column_id,
       skipSubstitutingColumnIds:
@@ -418,7 +427,15 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         throw e;
       logger.log(e);
       return this.readByPk(id, true, query, {
+        ignoreView,
+        getHiddenColumn,
+        throwErrorIfInvalidParams,
+        extractOnlyPrimaries,
         apiVersion,
+        extractOrderColumn,
+        ignoreRls,
+        fk_display_value_column_id,
+        excludeVirtualColumns,
         skipPublicRedaction,
       });
     }
@@ -777,6 +794,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       skipSortBasedOnOrderCol?: boolean;
       ignoreRls?: boolean;
       deletedOnly?: boolean;
+      excludeVirtualColumns?: boolean;
     } = {},
   ): Promise<any> {
     const {
@@ -788,6 +806,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       skipSortBasedOnOrderCol = false,
       ignoreRls: ignoreRlsOpt = false,
       deletedOnly = false,
+      excludeVirtualColumns = false,
     } = options;
 
     const columns = await this.model.getColumns(this.context);
@@ -799,12 +818,19 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     const linksAsLtar =
       args.linksAsLtar === true || args.linksAsLtar === 'true';
 
+    const selectColumns = excludeVirtualColumns
+      ? columns.filter(
+          (c) =>
+            !isVirtualCol(c) || DELETE_SNAPSHOT_SAFE_VIRTUAL_TYPES.has(c.uidt),
+        )
+      : columns;
+
     await this.selectObject({
       qb,
       fieldsSet: args.fieldsSet,
       viewId: this.viewId,
       validateFormula,
-      columns,
+      columns: selectColumns,
       linksAsLtar,
     });
     if (+rest?.shuffle) {
@@ -993,6 +1019,13 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         ignoreViewFilterAndSort,
         ignorePagination,
         validateFormula: true,
+        throwErrorIfInvalidParams,
+        limitOverride,
+        skipSubstitutingColumnIds: options.skipSubstitutingColumnIds,
+        skipSortBasedOnOrderCol,
+        ignoreRls: ignoreRlsOpt,
+        deletedOnly,
+        excludeVirtualColumns,
       });
     }
 
@@ -2564,6 +2597,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         validateFormula: false,
         ignoreView: true,
         getHiddenColumn: true,
+        excludeVirtualColumns: true,
         source,
       });
       await this.beforeDelete(id, cookie);
@@ -3276,6 +3310,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     disableOptimization?: boolean;
     view?: View;
     ignoreRls?: boolean;
+    excludeVirtualColumns?: boolean;
     skipPublicRedaction?: boolean;
   }): Promise<any> {
     return this.readByPk(
@@ -3286,6 +3321,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
         ignoreView: params.ignoreView,
         getHiddenColumn: params.getHiddenColumn,
         ignoreRls: params.ignoreRls,
+        excludeVirtualColumns: params.excludeVirtualColumns,
         skipPublicRedaction: params.skipPublicRedaction,
       },
     );
@@ -4140,6 +4176,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
     apiVersion?: NcApiVersion;
     args?: Record<string, any>;
     extractOnlyPrimaries?: boolean;
+    excludeVirtualColumns?: boolean;
     deletedOnly?: boolean;
     fk_display_value_column_id?: string | null;
   }) {
@@ -4153,6 +4190,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
       model: this.model,
       query: args.args || {},
       extractOnlyPrimaries: args.extractOnlyPrimaries,
+      excludeVirtualColumns: args.excludeVirtualColumns,
       fk_display_value_column_id: args.fk_display_value_column_id,
     });
 
@@ -4167,6 +4205,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
           limitOverride: chunk.length,
           ignoreViewFilterAndSort: true,
           deletedOnly: args.deletedOnly,
+          excludeVirtualColumns: args.excludeVirtualColumns,
         },
       );
       chunkData = await nocoExecute(ast, chunkData, {}, args.args || {});
@@ -4801,6 +4840,7 @@ class BaseModelSqlv2 implements IBaseModelSqlV2 {
             {
               limitOverride: tempToRead.length,
               ignoreViewFilterAndSort: true,
+              excludeVirtualColumns: true,
             },
           );
 

--- a/packages/nocodb/src/db/BaseModelSqlv2/delete.ts
+++ b/packages/nocodb/src/db/BaseModelSqlv2/delete.ts
@@ -557,6 +557,7 @@ export class BaseModelDelete {
       {
         limitOverride: ids.length,
         ignoreViewFilterAndSort: true,
+        excludeVirtualColumns: true,
       },
     );
     const trx = await this.baseModel.dbDriver.transaction();
@@ -948,6 +949,7 @@ export class BaseModelDelete {
     const oldRecords = await this.baseModel.chunkList({
       pks: rowIds,
       deletedOnly: true,
+      excludeVirtualColumns: true,
     });
 
     // Strict-equality check (`oldRecords.length !== rowIds.length`) caused the

--- a/packages/nocodb/src/db/IBaseModelSqlV2.ts
+++ b/packages/nocodb/src/db/IBaseModelSqlV2.ts
@@ -41,6 +41,7 @@ export interface IBaseModelSqlV2 {
       extractOnlyPrimaries?: boolean;
       apiVersion?: NcApiVersion;
       extractOrderColumn?: boolean;
+      excludeVirtualColumns?: boolean;
     },
   ): Promise<any>;
   execAndParse(
@@ -119,6 +120,7 @@ export interface IBaseModelSqlV2 {
       extractOnlyPrimaries?: boolean;
       apiVersion?: NcApiVersion;
       extractOrderColumn?: boolean;
+      excludeVirtualColumns?: boolean;
     },
   ): Promise<any>;
 
@@ -355,7 +357,9 @@ export interface IBaseModelSqlV2 {
     apiVersion?: NcApiVersion;
     args?: any;
     extractOnlyPrimaries?: boolean;
+    excludeVirtualColumns?: boolean;
     deletedOnly?: boolean;
+    fk_display_value_column_id?: string | null;
   }): Promise<any[]>;
 
   list(
@@ -379,6 +383,7 @@ export interface IBaseModelSqlV2 {
       throwErrorIfInvalidParams?: boolean;
       limitOverride?: number;
       skipSubstitutingColumnIds?: boolean;
+      excludeVirtualColumns?: boolean;
     },
   ): Promise<any>;
   selectObject(params: {

--- a/packages/nocodb/src/helpers/getAst.ts
+++ b/packages/nocodb/src/helpers/getAst.ts
@@ -4,6 +4,7 @@ import {
   isDeletedCol,
   isHiddenCol,
   isLinksOrLTAR,
+  isVirtualCol,
   isOrderCol,
   isSystemColumn,
   NcApiVersion,
@@ -43,6 +44,12 @@ const logger = new Logger('getAst');
 
 // Cap on recursive nested-LTAR expansion. See `_depth` param doc on getAst.
 const GET_AST_MAX_DEPTH = 8;
+const DELETE_SNAPSHOT_SAFE_VIRTUAL_TYPES = new Set<string>([
+  UITypes.CreatedTime,
+  UITypes.LastModifiedTime,
+  UITypes.CreatedBy,
+  UITypes.LastModifiedBy,
+]);
 
 type Ast = {
   [key: string]: 1 | true | null | Ast;
@@ -69,6 +76,7 @@ const getAst = async (
     includeSortAndFilterColumns = false,
     includeRowColorColumns = false,
     includeButtonFilterColumns = false,
+    excludeVirtualColumns = false,
     skipSubstitutingColumnIds = false,
     fk_display_value_column_id,
     _depth = 0,
@@ -88,6 +96,7 @@ const getAst = async (
     includeSortAndFilterColumns?: boolean;
     includeRowColorColumns?: boolean;
     includeButtonFilterColumns?: boolean;
+    excludeVirtualColumns?: boolean;
     skipSubstitutingColumnIds?: boolean;
     fk_display_value_column_id?: string | null;
     // Internal: recursion depth for nested LTAR expansion. Bounded to
@@ -312,6 +321,15 @@ const getAst = async (
   const ast: Ast = {};
 
   for (const col of columns) {
+    if (
+      excludeVirtualColumns &&
+      isVirtualCol(col) &&
+      !DELETE_SNAPSHOT_SAFE_VIRTUAL_TYPES.has(col.uidt)
+    ) {
+      ast[getFieldKey(col)] = false;
+      continue;
+    }
+
     let value: number | boolean | { [key: string]: any } = 1;
     // TODO: also get from col.id
     const nestedFields =
@@ -452,7 +470,8 @@ const getAst = async (
     ) {
       isRequested = false;
     } else if (isCreatedOrLastModifiedByCol(col) && col.system) {
-      isRequested = false;
+      isRequested =
+        excludeVirtualColumns && DELETE_SNAPSHOT_SAFE_VIRTUAL_TYPES.has(col.uidt);
     } else if (isOrderCol(col) && col.system) {
       isRequested = extractOrderColumn || getHiddenColumn;
     } else if (isDeletedCol(col) && col.system) {

--- a/packages/nocodb/src/helpers/getAstSource.spec.ts
+++ b/packages/nocodb/src/helpers/getAstSource.spec.ts
@@ -1,0 +1,188 @@
+import { RelationTypes, UITypes } from 'nocodb-sdk';
+import getAst from './getAst';
+
+describe('getAst delete snapshot planning', () => {
+  const makeModel = ({ throwOnVirtualColOptions = true } = {}) => {
+    const relationDependencyColumn = {
+      id: 'col_relation_fk',
+      title: 'RelationFk',
+      column_name: 'relation_fk',
+      uidt: UITypes.ForeignKey,
+    } as any;
+    const lookupTargetColumn = {
+      id: 'col_lookup_target',
+      title: 'LookupTarget',
+      column_name: 'lookup_target',
+      uidt: UITypes.SingleLineText,
+    } as any;
+    const relationColumn: any = {
+      id: 'col_relation',
+      title: 'Relation',
+      column_name: 'relation',
+      uidt: UITypes.LinkToAnotherRecord,
+      getColOptions: jest.fn(async () => ({
+        type: RelationTypes.BELONGS_TO,
+        getRelContext: jest.fn(() => ({ refContext: {} })),
+        getChildColumn: jest.fn(async () => relationDependencyColumn),
+      })),
+    };
+    const lookupColOptions = {
+      getRelationColumn: jest.fn(async () => relationColumn),
+      getLookupColumn: jest.fn(async () => lookupTargetColumn),
+    };
+    const virtualColOptionsImpl = throwOnVirtualColOptions
+      ? async () => {
+          throw new Error('virtual dependencies should not be expanded');
+        }
+      : async () => lookupColOptions;
+
+    const columns: any[] = [
+      {
+        id: 'col_id',
+        title: 'Id',
+        column_name: 'id',
+        uidt: UITypes.ID,
+        pk: true,
+      },
+      {
+        id: 'col_name',
+        title: 'Name',
+        column_name: 'name',
+        uidt: UITypes.SingleLineText,
+      },
+      {
+        id: 'col_created_time',
+        title: 'CreatedTime',
+        column_name: 'created_at',
+        uidt: UITypes.CreatedTime,
+        system: true,
+      },
+      {
+        id: 'col_last_modified_time',
+        title: 'LastModifiedTime',
+        column_name: 'updated_at',
+        uidt: UITypes.LastModifiedTime,
+        system: true,
+      },
+      {
+        id: 'col_created_by',
+        title: 'CreatedBy',
+        column_name: 'created_by',
+        uidt: UITypes.CreatedBy,
+        system: true,
+      },
+      {
+        id: 'col_last_modified_by',
+        title: 'LastModifiedBy',
+        column_name: 'updated_by',
+        uidt: UITypes.LastModifiedBy,
+        system: true,
+      },
+      {
+        id: 'col_formula',
+        title: 'Formula',
+        column_name: 'formula',
+        uidt: UITypes.Formula,
+      },
+      {
+        id: 'col_rollup',
+        title: 'Rollup',
+        column_name: 'rollup',
+        uidt: UITypes.Rollup,
+      },
+      {
+        id: 'col_lookup',
+        title: 'Lookup',
+        column_name: 'lookup',
+        uidt: UITypes.Lookup,
+        getColOptions: jest.fn(virtualColOptionsImpl),
+      },
+      {
+        id: 'col_link',
+        title: 'Link',
+        column_name: 'link',
+        uidt: UITypes.LinkToAnotherRecord,
+        getColOptions: jest.fn(
+          throwOnVirtualColOptions
+            ? virtualColOptionsImpl
+            : async () => ({
+                type: RelationTypes.BELONGS_TO,
+                getChildColumn: jest.fn(async () => relationDependencyColumn),
+              }),
+        ),
+      },
+    ];
+
+    return {
+      columns,
+      primaryKeys: [columns[0]],
+      displayValue: columns[1],
+    } as any;
+  };
+
+  it('excludes unsafe virtual columns when building delete snapshot dependencies', async () => {
+    const model = makeModel();
+
+    const { ast, dependencyFields } = await getAst({} as any, {
+      model,
+      query: {},
+      getHiddenColumn: true,
+      excludeVirtualColumns: true,
+    });
+
+    expect(ast).toMatchObject({
+      Id: 1,
+      Name: 1,
+      CreatedTime: 1,
+      LastModifiedTime: 1,
+      CreatedBy: true,
+      LastModifiedBy: true,
+      Formula: false,
+      Rollup: false,
+      Lookup: false,
+      Link: false,
+    });
+    expect(dependencyFields.fieldsSet).toEqual(
+      new Set([
+        'Id',
+        'Name',
+        'CreatedTime',
+        'LastModifiedTime',
+        'CreatedBy',
+        'LastModifiedBy',
+      ]),
+    );
+    expect(
+      model.columns.find((col) => col.title === 'Lookup').getColOptions,
+    ).not.toHaveBeenCalled();
+    expect(
+      model.columns.find((col) => col.title === 'Link').getColOptions,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('keeps normal read planning unchanged when virtual exclusion is disabled', async () => {
+    const model = makeModel({ throwOnVirtualColOptions: false });
+
+    const { ast } = await getAst({} as any, {
+      model,
+      query: {},
+      getHiddenColumn: true,
+      excludeVirtualColumns: false,
+    });
+
+    expect(ast).toMatchObject({
+      Id: 1,
+      Name: 1,
+      Formula: 1,
+      Rollup: 1,
+      Lookup: 1,
+      Link: 1,
+    });
+    expect(
+      model.columns.find((col) => col.title === 'Lookup').getColOptions,
+    ).toHaveBeenCalled();
+    expect(
+      model.columns.find((col) => col.title === 'Link').getColOptions,
+    ).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Fix MariaDB delete failure caused by relation expansion in pre-delete snapshots
 #14035

### Summary

This PR fixes a MariaDB-specific delete failure where record deletion could fail with `ERR_DATABASE_OP_FAILED` / `ER_PARSE_ERROR` before the actual DELETE statement was executed.

### Root Cause

Delete operations first fetch old-record snapshots for hooks, audit logging, file cleanup, and notifications. These reads could include virtual relation/computed fields (Lookup, LTAR, Rollup, Formula), triggering relation-expansion SQL that generated `LEFT OUTER JOIN LATERAL (...)`, which MariaDB rejects.

### Fix

Introduced an internal `excludeVirtualColumns` option for delete snapshot reads.

When enabled, delete snapshots:

* Skip Lookup, LTAR, Rollup, and Formula expansion
* Avoid relation-expansion SQL generation
* Preserve required system fields (`CreatedTime`, `LastModifiedTime`, `CreatedBy`, `LastModifiedBy`)

The flag is applied only to delete snapshot reads, leaving normal read/list behavior unchanged.

### Covered Flows

* Single delete
* Bulk delete
* UI delete
* API v2 delete
* API v3 delete
* Bulk delete all
* Permanent delete

### Testing

* Added regression coverage for delete snapshot planning.
* Verified delete paths propagate the new flag correctly.
* Runtime validation on MariaDB 10.6/10.11 will be completed through CI.

