### PR TITLE
fix(gui): defer relation field updates until save in expanded form

### DIFF
--- a/packages/nc-gui/composables/useExpandedFormStore.ts
+++ b/packages/nc-gui/composables/useExpandedFormStore.ts
@@ -81,6 +81,10 @@ const [useProvideExpandedFormStore, useExpandedFormStore] = useInjectionState(
     }
     const rowStore = useProvideSmartsheetRowStore(row, changedColumns)
 
+    // Deferred relation (LTAR) edits queued by useLTARStore.link()/unlink() while this form is
+    // open for an existing record; replayed on Save by applyPendingLtarOps(). See #14013.
+    const { pendingLtarOps } = rowStore
+
     const activeView = inject(ActiveViewInj, ref())
     const { comments, resolveComment, loadComments, updateComment, deleteComment, saveComment, isCommentsLoading } =
       useProvideRowComments(meta, row)
@@ -336,6 +340,42 @@ const [useProvideExpandedFormStore, useExpandedFormStore] = useInjectionState(
       return $state.user?.value?.email === email
     }
 
+    /**
+     * Replay queued relation (LTAR) edits against the backend using the existing nested
+     * link/unlink API — the deferred counterpart of the immediate calls in `useLTARStore`.
+     * Ops are drained one-by-one so a mid-way failure leaves the remaining ops queued (and
+     * the record dirty) for retry, while already-applied ops are not re-sent. See #14013.
+     */
+    const applyPendingLtarOps = async () => {
+      while (pendingLtarOps.value.length) {
+        const op = pendingLtarOps.value[0]
+
+        if (op.op === 'link') {
+          await $api.dbTableRow.nestedAdd(
+            NOCO,
+            op.baseId,
+            op.tableId,
+            encodeURIComponent(op.rowId),
+            op.type,
+            op.columnId,
+            encodeURIComponent(op.relatedRowId),
+          )
+        } else {
+          await $api.dbTableRow.nestedRemove(
+            NOCO,
+            op.baseId,
+            op.tableId,
+            encodeURIComponent(op.rowId),
+            op.type,
+            op.columnId,
+            encodeURIComponent(op.relatedRowId),
+          )
+        }
+
+        pendingLtarOps.value.shift()
+      }
+    }
+
     const save = async (
       ltarState: Record<string, any> = {},
       // TODO: Hack. Remove this when kanban injection store issue is resolved
@@ -379,18 +419,34 @@ const [useProvideExpandedFormStore, useExpandedFormStore] = useInjectionState(
           oldRow: { ...data },
         })
       } else {
+        // Build the scalar update payload from changedColumns, excluding virtual/LTAR
+        // columns. Relation edits made inside the expanded form are deferred into
+        // pendingLtarOps and applied separately below — their row value is a rollup
+        // count / nested object, not a writable scalar, so they must never be sent as a
+        // column PATCH. See #14013.
         const updateOrInsertObj = [...changedColumns.value].reduce((obj, col) => {
+          const column = (meta.value.columns ?? []).find((c) => c.title === col)
+          if (column && isVirtualCol(column)) return obj
           obj[col] = row.value.row[col]
           return obj
         }, {} as Record<string, any>)
 
-        if (Object.keys(updateOrInsertObj).length) {
-          const id = extractPkFromRow(row.value.row, meta.value.columns as ColumnType[])
+        const hasScalarChanges = Object.keys(updateOrInsertObj).length > 0
+        const hasPendingLtarOps = pendingLtarOps.value.length > 0
 
-          if (!id) {
-            return message.info(t('msg.info.updateNotAllowedWithoutPK'))
-          }
+        if (!hasScalarChanges && !hasPendingLtarOps) {
+          // No columns to update
+          message.info(t('msg.info.noColumnsToUpdate'))
+          return
+        }
 
+        const id = extractPkFromRow(row.value.row, meta.value.columns as ColumnType[])
+
+        if (!id) {
+          return message.info(t('msg.info.updateNotAllowedWithoutPK'))
+        }
+
+        if (hasScalarChanges) {
           const updatedData = await $api.dbTableRow.update(
             NOCO,
             meta.value.base_id ?? (base.value.id as string),
@@ -403,14 +459,16 @@ const [useProvideExpandedFormStore, useExpandedFormStore] = useInjectionState(
           if (updatedData?.__nc_rls_hidden) {
             row.value.row.__nc_rls_hidden = true
           }
+        }
 
-          if (commentsDrawer.value) {
-            await Promise.all([loadComments()])
-          }
-        } else {
-          // No columns to update
-          message.info(t('msg.info.noColumnsToUpdate'))
-          return
+        // Replay deferred relation edits after the scalar update so single-target
+        // replaces resolve against fresh state.
+        if (hasPendingLtarOps) {
+          await applyPendingLtarOps()
+        }
+
+        if (commentsDrawer.value) {
+          await Promise.all([loadComments()])
         }
       }
 
@@ -434,6 +492,8 @@ const [useProvideExpandedFormStore, useExpandedFormStore] = useInjectionState(
 
     const clearColumns = () => {
       changedColumns.value = new Set()
+      // Drop deferred relation edits on discard — they were never written to the backend.
+      pendingLtarOps.value = []
     }
 
     const loadRow = async (rowId?: string, onlyVirtual = false, onlyNewColumns = false) => {

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -13,6 +13,12 @@ import {
   timeFormats,
 } from 'nocodb-sdk'
 import type { ComputedRef, Ref } from 'vue'
+import {
+  columnHasPendingLtarOps,
+  reconcilePendingLtarOp,
+  resolveDeferredLtarCount,
+  resolveDeferredSingleTargetValue,
+} from '~/utils/ltarDeferredOps'
 
 interface DataApiResponse {
   list: Record<string, any>[]
@@ -774,6 +780,68 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
     const addLTARRef = smartsheetRowStore?.addLTARRef
     const removeLTARRef = smartsheetRowStore?.removeLTARRef
     const rowStoreCurrentRow = smartsheetRowStore?.currentRow
+    const changedColumns = smartsheetRowStore?.changedColumns
+
+    // --- Expanded-form deferred relation edits (#14013) ---
+    // Inside the expanded form, link/unlink for an EXISTING record must not write to the
+    // backend immediately. Instead we queue the op on the row store (alongside changedColumns),
+    // mark the column dirty and update the cell optimistically, so relation edits join the
+    // standard Save/Discard workflow. Grid, new-row, shared/public form and read-only
+    // (page-designer) contexts are all excluded and keep their current immediate-commit behaviour.
+    const isExpandedFormOpen = inject(IsExpandedFormOpenInj, ref(false))
+    const pendingLtarOps = smartsheetRowStore?.pendingLtarOps
+
+    const shouldDeferLtarEdit = computed(
+      () => isExpandedFormOpen.value && !!pendingLtarOps && !isNewRow?.value && !isPublic.value && !isForm.value && !!rowId.value,
+    )
+
+    /** Re-derive the cell's optimistic value from the original server value + queued ops. */
+    const refreshDeferredDisplay = () => {
+      if (!rowStoreCurrentRow || !pendingLtarOps) return
+
+      const cur = rowStoreCurrentRow.value
+      const colTitle = column.value.title!
+      const colId = column.value.id as string
+      const queue = pendingLtarOps.value
+
+      if (isSingleTargetRelation.value) {
+        cur.row[colTitle] = resolveDeferredSingleTargetValue(queue, colId, cur.oldRow?.[colTitle] ?? null)
+      } else {
+        const next = resolveDeferredLtarCount(queue, colId, +(cur.oldRow?.[colTitle] ?? 0) || 0)
+        cur.row[colTitle] = next
+        childrenListCount.value = next
+      }
+
+      triggerRef(rowStoreCurrentRow as Ref)
+    }
+
+    const enqueueLtarOp = (op: 'link' | 'unlink', relatedRow: Record<string, any>) => {
+      if (!pendingLtarOps) return
+
+      const queue = pendingLtarOps.value
+      const colTitle = column.value.title!
+      const colId = column.value.id as string
+
+      reconcilePendingLtarOp(queue, {
+        op,
+        columnId: colId,
+        baseId: (meta.value?.base_id ?? base.value.id) as string,
+        tableId: meta.value!.id as string,
+        rowId: rowId.value as string,
+        type: type.value as RelationTypes,
+        relatedRowId: `${getRelatedTableRowId(relatedRow)}`,
+        record: relatedRow,
+      })
+
+      // Mirror dirty-state to the queue: dirty iff this column still has queued ops.
+      if (columnHasPendingLtarOps(queue, colId)) {
+        changedColumns?.value.add(colTitle)
+      } else {
+        changedColumns?.value.delete(colTitle)
+      }
+
+      refreshDeferredDisplay()
+    }
 
     const unlink = async (
       row: Record<string, any>,
@@ -803,6 +871,18 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         childrenCachedLinkedState.value.set(index, false)
         return
       }
+
+      // Expanded-form deferred edit (#14013): queue the unlink + update UI optimistically,
+      // skip the immediate API call. The op is replayed on Save.
+      if (shouldDeferLtarEdit.value) {
+        enqueueLtarOp('unlink', row)
+        isChildrenExcludedListLinked.value[index] = false
+        isChildrenListLinked.value[index] = false
+        excludedLinkedState.value.set(index, false)
+        childrenCachedLinkedState.value.set(index, false)
+        return
+      }
+
       try {
         // todo: audit
 
@@ -883,6 +963,18 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         childrenCachedLinkedState.value.set(index, true)
         return
       }
+
+      // Expanded-form deferred edit (#14013): queue the link + update UI optimistically,
+      // skip the immediate API call. The op is replayed on Save.
+      if (shouldDeferLtarEdit.value) {
+        enqueueLtarOp('link', row)
+        isChildrenExcludedListLinked.value[index] = true
+        isChildrenListLinked.value[index] = true
+        excludedLinkedState.value.set(index, true)
+        childrenCachedLinkedState.value.set(index, true)
+        return
+      }
+
       try {
         isChildrenExcludedListLoading.value[index] = true
         isChildrenListLoading.value[index] = true

--- a/packages/nc-gui/composables/useSmartsheetRowStore.ts
+++ b/packages/nc-gui/composables/useSmartsheetRowStore.ts
@@ -1,8 +1,14 @@
 import type { MaybeRef } from '@vueuse/core'
+import type { PendingLtarOp } from '~/utils/ltarDeferredOps'
 
 const [useProvideSmartsheetRowStore, useSmartsheetRowStore] = useInjectionState(
   (row: MaybeRef<Row>, changedColumns: Ref<Set<string>> = ref(new Set<string>())) => {
     const currentRow = ref(row)
+
+    // Existing-row relation edits deferred by the expanded form until Save (#14013). Shares a
+    // home with changedColumns + addLTARRef/removeLTARRef so all relation-deferral state lives
+    // in one place. Empty (and unused) in grid / new-row / public contexts.
+    const pendingLtarOps = ref<PendingLtarOp[]>([])
 
     // state
     const state = computed({
@@ -38,6 +44,7 @@ const [useProvideSmartsheetRowStore, useSmartsheetRowStore] = useInjectionState(
       pk,
       row,
       changedColumns,
+      pendingLtarOps,
       state,
       isNew,
       displayValue,

--- a/packages/nc-gui/test/ltar-deferred-ops.test.ts
+++ b/packages/nc-gui/test/ltar-deferred-ops.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for the pure deferred-LTAR queue logic used by the expanded form to keep
+ * relation edits inside the Save/Discard workflow (#14013).
+ *
+ * Imports the actual pure functions from utils/ltarDeferredOps.ts — no mocks.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { RelationTypes } from 'nocodb-sdk'
+import {
+  type PendingLtarOp,
+  columnHasPendingLtarOps,
+  reconcilePendingLtarOp,
+  resolveDeferredLtarCount,
+  resolveDeferredSingleTargetValue,
+} from '~/utils/ltarDeferredOps'
+
+// ---- Helpers ----
+
+function makeOp(
+  op: 'link' | 'unlink',
+  relatedRowId: string,
+  { columnId = 'col_links', type = RelationTypes.HAS_MANY }: { columnId?: string; type?: RelationTypes } = {},
+): PendingLtarOp {
+  return {
+    op,
+    columnId,
+    baseId: 'base1',
+    tableId: 'tbl1',
+    rowId: 'rec1',
+    type,
+    relatedRowId,
+    record: { Id: relatedRowId, Title: `Row ${relatedRowId}` },
+  }
+}
+
+function queueWith(...ops: PendingLtarOp[]): PendingLtarOp[] {
+  const q: PendingLtarOp[] = []
+  for (const op of ops) reconcilePendingLtarOp(q, op)
+  return q
+}
+
+// ---- reconcilePendingLtarOp ----
+
+describe('reconcilePendingLtarOp', () => {
+  it('appends a new op and preserves insertion order', () => {
+    const q = queueWith(makeOp('unlink', '1'), makeOp('link', '2'))
+    expect(q.map((o) => [o.op, o.relatedRowId])).toEqual([
+      ['unlink', '1'],
+      ['link', '2'],
+    ])
+  })
+
+  it('ignores a duplicate of the same op on the same record', () => {
+    const q = queueWith(makeOp('unlink', '1'), makeOp('unlink', '1'))
+    expect(q).toHaveLength(1)
+  })
+
+  it('cancels a queued op when its inverse on the same record is applied (link → unlink)', () => {
+    const q = queueWith(makeOp('link', '5'), makeOp('unlink', '5'))
+    expect(q).toHaveLength(0)
+  })
+
+  it('cancels a queued unlink when the record is re-linked (unlink → re-link = back to original)', () => {
+    const q = queueWith(makeOp('unlink', '7'), makeOp('link', '7'))
+    expect(q).toHaveLength(0)
+  })
+
+  it('keeps ops for different records independent', () => {
+    const q = queueWith(makeOp('unlink', '1'), makeOp('unlink', '2'), makeOp('link', '1'))
+    // unlink 1 cancelled by link 1; unlink 2 remains
+    expect(q.map((o) => [o.op, o.relatedRowId])).toEqual([['unlink', '2']])
+  })
+
+  it('keeps same record on different columns independent', () => {
+    const q = queueWith(makeOp('unlink', '1', { columnId: 'colA' }), makeOp('link', '1', { columnId: 'colB' }))
+    expect(q).toHaveLength(2)
+  })
+})
+
+// ---- columnHasPendingLtarOps ----
+
+describe('columnHasPendingLtarOps', () => {
+  it('is true while the column has queued ops and false once they cancel out', () => {
+    const q = queueWith(makeOp('unlink', '1', { columnId: 'colA' }))
+    expect(columnHasPendingLtarOps(q, 'colA')).toBe(true)
+    expect(columnHasPendingLtarOps(q, 'colB')).toBe(false)
+
+    reconcilePendingLtarOp(q, makeOp('link', '1', { columnId: 'colA' }))
+    expect(columnHasPendingLtarOps(q, 'colA')).toBe(false)
+  })
+})
+
+// ---- resolveDeferredLtarCount (HM / MM) ----
+
+describe('resolveDeferredLtarCount', () => {
+  it('subtracts unlinks and adds links against the original count', () => {
+    const q = queueWith(makeOp('unlink', '1'), makeOp('unlink', '2'), makeOp('link', '9'))
+    expect(resolveDeferredLtarCount(q, 'col_links', 3)).toBe(2) // 3 - 2 + 1
+  })
+
+  it('never goes below zero', () => {
+    const q = queueWith(makeOp('unlink', '1'), makeOp('unlink', '2'))
+    expect(resolveDeferredLtarCount(q, 'col_links', 1)).toBe(0)
+  })
+
+  it('coerces a non-numeric original count to 0', () => {
+    const q = queueWith(makeOp('link', '1'))
+    expect(resolveDeferredLtarCount(q, 'col_links', undefined as unknown as number)).toBe(1)
+  })
+
+  it('ignores ops belonging to other columns', () => {
+    const q = queueWith(makeOp('link', '1', { columnId: 'other' }))
+    expect(resolveDeferredLtarCount(q, 'col_links', 4)).toBe(4)
+  })
+})
+
+// ---- resolveDeferredSingleTargetValue (BT / OO / MO) ----
+
+describe('resolveDeferredSingleTargetValue', () => {
+  const original = { Id: '100', Title: 'Original' }
+
+  it('returns the original server value when no ops are queued', () => {
+    expect(resolveDeferredSingleTargetValue([], 'col_bt', original)).toBe(original)
+  })
+
+  it('returns null after an unlink', () => {
+    const q = queueWith(makeOp('unlink', '100', { columnId: 'col_bt', type: RelationTypes.BELONGS_TO }))
+    expect(resolveDeferredSingleTargetValue(q, 'col_bt', original)).toBeNull()
+  })
+
+  it('returns the latest linked record on replace', () => {
+    const q = queueWith(
+      makeOp('link', '200', { columnId: 'col_bt', type: RelationTypes.BELONGS_TO }),
+      makeOp('link', '300', { columnId: 'col_bt', type: RelationTypes.BELONGS_TO }),
+    )
+    expect(resolveDeferredSingleTargetValue(q, 'col_bt', original)?.Id).toBe('300')
+  })
+
+  it('falls back to original when a link is then cancelled', () => {
+    const q = queueWith(
+      makeOp('link', '200', { columnId: 'col_bt', type: RelationTypes.BELONGS_TO }),
+      makeOp('unlink', '200', { columnId: 'col_bt', type: RelationTypes.BELONGS_TO }),
+    )
+    expect(resolveDeferredSingleTargetValue(q, 'col_bt', original)).toBe(original)
+  })
+})
+
+// ---- end-to-end queue scenarios (regression coverage) ----
+
+describe('queue scenarios', () => {
+  it('multiple edits before save collapse to the minimal API set', () => {
+    // link A, unlink B, unlink A (cancels link A), link C
+    const q = queueWith(makeOp('link', 'A'), makeOp('unlink', 'B'), makeOp('unlink', 'A'), makeOp('link', 'C'))
+    expect(q.map((o) => [o.op, o.relatedRowId])).toEqual([
+      ['unlink', 'B'],
+      ['link', 'C'],
+    ])
+  })
+
+  it('add-then-remove of the same record is a no-op (no API call, not dirty)', () => {
+    const q = queueWith(makeOp('link', 'X'), makeOp('unlink', 'X'))
+    expect(q).toHaveLength(0)
+    expect(columnHasPendingLtarOps(q, 'col_links')).toBe(false)
+  })
+})

--- a/packages/nc-gui/utils/ltarDeferredOps.ts
+++ b/packages/nc-gui/utils/ltarDeferredOps.ts
@@ -1,0 +1,86 @@
+import type { RelationTypes } from 'nocodb-sdk'
+
+/**
+ * A single link/unlink operation queued by the expanded form while editing an
+ * existing record. Instead of writing to the backend immediately, relation edits
+ * are buffered as these ops and replayed on Save — see #14013 and
+ * `useExpandedFormStore.save()` / `useLTARStore.link()/unlink()`.
+ *
+ * Every field needed to replay the nested API call is captured at enqueue time so
+ * the op is self-contained (no dependency on live store state at Save time).
+ */
+export interface PendingLtarOp {
+  op: 'link' | 'unlink'
+  columnId: string
+  baseId: string
+  tableId: string
+  rowId: string
+  type: RelationTypes
+  relatedRowId: string
+  /** Related record object — used only to re-render single-target chips optimistically. */
+  record: Record<string, any>
+}
+
+/**
+ * Merge a new link/unlink operation into the pending queue (mutates `queue`).
+ *
+ * Reconciliation rules, so that multiple edits before Save collapse to the
+ * minimal, correct set of API calls:
+ *  - Applying the inverse op on the same record cancels the queued op (net no-op,
+ *    e.g. unlink → re-link of the same record, or link → unlink before saving).
+ *  - A duplicate of an already-queued op is ignored.
+ *  - Otherwise the op is appended. Insertion order is preserved so that on replay
+ *    removals run before additions of later picks.
+ *
+ * Returns the same `queue` reference for convenience.
+ */
+export function reconcilePendingLtarOp(queue: PendingLtarOp[], next: PendingLtarOp): PendingLtarOp[] {
+  const inverse = next.op === 'link' ? 'unlink' : 'link'
+
+  const inverseIdx = queue.findIndex(
+    (o) => o.op === inverse && o.columnId === next.columnId && o.relatedRowId === next.relatedRowId,
+  )
+  if (inverseIdx !== -1) {
+    queue.splice(inverseIdx, 1)
+    return queue
+  }
+
+  const isDuplicate = queue.some((o) => o.op === next.op && o.columnId === next.columnId && o.relatedRowId === next.relatedRowId)
+  if (!isDuplicate) queue.push(next)
+
+  return queue
+}
+
+/** Whether the given column still has any queued operation (drives dirty-state). */
+export function columnHasPendingLtarOps(queue: PendingLtarOp[], columnId: string): boolean {
+  return queue.some((o) => o.columnId === columnId)
+}
+
+/**
+ * Optimistic rollup count for a multi-target (HM/MM) column:
+ * original linked count − queued unlinks + queued links (never below 0).
+ */
+export function resolveDeferredLtarCount(queue: PendingLtarOp[], columnId: string, originalCount: number): number {
+  const ops = queue.filter((o) => o.columnId === columnId)
+  const links = ops.filter((o) => o.op === 'link').length
+  const unlinks = ops.filter((o) => o.op === 'unlink').length
+  return Math.max(0, (Number(originalCount) || 0) - unlinks + links)
+}
+
+/**
+ * Optimistic value for a single-target (BT/OO/MO) column:
+ *  - the latest queued link wins (a replace),
+ *  - else a queued unlink clears it,
+ *  - else fall back to the original server value.
+ */
+export function resolveDeferredSingleTargetValue(
+  queue: PendingLtarOp[],
+  columnId: string,
+  originalValue: Record<string, any> | null,
+): Record<string, any> | null {
+  const ops = queue.filter((o) => o.columnId === columnId)
+  const lastLink = ops.findLast((o) => o.op === 'link')
+  if (lastLink) return lastLink.record
+  if (ops.some((o) => o.op === 'unlink')) return null
+  return originalValue ?? null
+}


### PR DESCRIPTION
## Change Summary

Fixes #14013

Relation field updates in the expanded form were being committed immediately, bypassing the existing Save/Discard workflow. This change defers relation add/remove operations until the user explicitly clicks **Save Changes**, making relation fields behave consistently with other editable fields.

### Changes

* Added deferred LTAR operation handling for expanded-form editing.
* Integrated relation changes with existing dirty-state tracking.
* Ensured Save applies queued relation operations.
* Ensured Discard removes pending relation operations.
* Added regression tests covering relation add/remove and save/discard flows.

## Change type

* [x] fix: (bug fix for the user, not a fix to a build script)

## Test / Verification

### Manual Verification

* Reproduced issue locally.
* Verified relation removal shows **Save Changes** instead of immediately persisting.
* Verified relation addition shows **Save Changes**.
* Verified **Discard Changes** restores original relation state.
* Verified **Save Changes** persists relation updates.
* Verified text-field save behavior remains unchanged.

### Automated Tests

* Added regression tests for deferred LTAR operations.
* Verified relation add/remove flows.
* Verified operation reconciliation and save/discard behavior.

## Additional information / screenshots (optional)
<img width="1463" height="808" alt="Screenshot 2026-06-13 at 3 19 59 PM" src="https://github.com/user-attachments/assets/2bb939ce-13a2-43c1-8a77-5feac9f2018e" />



This fix only affects relation editing within the expanded form workflow.

The following flows remain unchanged:

* Grid editing
* New record creation
* Public forms

The implementation reuses the existing dirty-state workflow and avoids introducing a separate save mechanism.
