### PR TITLE
Nc/fix: OM LinkToAnotherRecord sorting by COUNT of linked records

### DIFF
--- a/packages/nocodb/src/db/field-handler/handlers/ltar/ltar.general.handler.ts
+++ b/packages/nocodb/src/db/field-handler/handlers/ltar/ltar.general.handler.ts
@@ -1,13 +1,13 @@
 import { isMMOrMMLike, RelationTypes } from 'nocodb-sdk';
 import { LookupGeneralHandler } from '../lookup/lookup.general.handler';
 import type CustomKnex from '~/db/CustomKnex';
-import type { Column, LinkToAnotherRecordColumn } from '~/models';
+import type { Column, LinkToAnotherRecordColumn, RollupColumn } from '~/models';
 import type {
   FilterOptions,
   SortOptions,
 } from '~/db/field-handler/field-handler.interface';
 import type { Knex } from '~/db/CustomKnex';
-import { Filter, Model } from '~/models';
+import { Filter, LinksColumn, Model } from '~/models';
 import {
   getAlias,
   negatedMapping,
@@ -15,12 +15,17 @@ import {
 import { GenericFieldHandler } from '~/db/field-handler/handlers/generic';
 import { getAliasedSoftDeleteFilter } from '~/helpers/dbHelpers';
 import { getDisplayValueOfRefTable } from '~/db/generateLookupSelectQuery';
+import genRollupSelectv2 from '~/db/genRollupSelectv2';
 
 export class LtarGeneralHandler extends GenericFieldHandler {
   /**
-   * Sort by the linked record's display value — delegates to
-   * `LookupGeneralHandler.applySort` since both produce SQL via
-   * `generateLookupSelectQuery`. Keeps the lookup-chain logic in one place.
+   * V2 one-to-many (OM) links hold multiple linked records. Sorting them by
+   * the stringified display-value list (the lookup path) is meaningless —
+   * order by the COUNT of linked records instead, the same as the Links
+   * column does via the rollup builder. Every other relation type (and nested
+   * lookups) keeps sorting by the linked record's display value, delegated to
+   * `LookupGeneralHandler.applySort` (both produce SQL via
+   * `generateLookupSelectQuery`).
    */
   override async applySort(
     qb: Knex.QueryBuilder,
@@ -28,6 +33,30 @@ export class LtarGeneralHandler extends GenericFieldHandler {
     direction: 'asc' | 'desc',
     options: SortOptions,
   ): Promise<void> {
+    const { alias, nulls, baseModel: baseModelSqlv2, context } = options;
+    const colOptions = await column.getColOptions<LinkToAnotherRecordColumn>(
+      context,
+    );
+
+    // `om` is a V2-only relation type, so the type check alone detects it.
+    if (colOptions?.type === RelationTypes.ONE_TO_MANY) {
+      const builder = (
+        await genRollupSelectv2({
+          baseModelSqlv2,
+          knex: options.knex as CustomKnex,
+          // Read the column as a LinksColumn to get count-rollup semantics
+          // (rollup_function = 'count') for the COUNT(*) over the junction.
+          columnOptions: (await LinksColumn.read(
+            context,
+            column.id,
+          )) as RollupColumn,
+          alias,
+        })
+      ).builder;
+      qb.orderBy(builder, direction, nulls);
+      return;
+    }
+
     return new LookupGeneralHandler().applySort(qb, column, direction, options);
   }
 


### PR DESCRIPTION
## Change Summary

Fixes incorrect sorting for V2 one-to-many (OM) LinkToAnotherRecord columns.

Previously, sorting an OM LinkToAnotherRecord column ordered rows by a stringified `json_agg` of linked record display values rather than by the number of linked records. This produced incorrect ordering based on lexicographical comparison of aggregated display values.

This change routes OM LinkToAnotherRecord sorting through the existing COUNT-based rollup path, ensuring rows are ordered by linked record count.

Closes #13811

---

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

---

## Test / Verification

- Reproduced the issue using a V2 OM LinkToAnotherRecord column.
- Verified sorting with the following data:
  - A → 2 linked records
  - B → 1 linked record
  - C → 0 linked records
- Confirmed correct ordering:
  - DESC → A(2), B(1), C(0)
  - ASC → C(0), B(1), A(2)
- Verified the fix against a running instance using API-based sorting.
- Ran type checking successfully.
- Ran lint successfully.

---

## Additional information / screenshots (optional)

### What changed
- Detect OM (`ONE_TO_MANY`) LinkToAnotherRecord relations during sort generation.
- Route OM sorting through the existing COUNT rollup logic (`genRollupSelectv2`).
- Preserve existing sorting behavior for all other relation and lookup types.

### Scope
- Backend sorting logic only.
- No UI changes included in this PR.
- No changes to HM/MM/MO/OO/BT relation sorting behavior.
- No changes to lookup sorting behavior.

### Notes
OM relation columns are currently not exposed in the Sort picker UI. This PR only fixes the backend sorting behavior and does not modify UI availability.