### PR TITLE
fix(db-error): handle EACCES from SSRF protection in error extractors

### DIFF
--- a/packages/nocodb/src/helpers/db-error/default.extractor.ts
+++ b/packages/nocodb/src/helpers/db-error/default.extractor.ts
@@ -12,6 +12,15 @@ export class DefaultDBErrorExtractor implements IClientDbErrorExtractor {
   extract(error: any): DBErrorExtractResult {
     if (!error.code) return;
 
+    if (error.code === 'EACCES') {
+      return {
+        error: NcErrorType.ERR_DATABASE_OP_FAILED,
+        message: 'Connection to internal hosts is not allowed',
+        code: 'EACCES',
+        httpStatus: 403,
+      };
+    }
+
     let message: string | undefined;
     const httpStatus = 422;
 

--- a/packages/nocodb/src/helpers/db-error/mysql.extractor.ts
+++ b/packages/nocodb/src/helpers/db-error/mysql.extractor.ts
@@ -172,6 +172,10 @@ export class MysqlDBErrorExtractor implements IClientDbErrorExtractor {
       case 'ER_TOO_MANY_ROWS':
         message = 'Query returned too many rows.';
         break;
+      case 'EACCES':
+        message = 'Connection to internal hosts is not allowed';
+        httpStatus = 403;
+        break;
       default:
         this.option.dbErrorLogger.error(
           `${error.code} is not handled on database mysql`,

--- a/packages/nocodb/src/helpers/db-error/pg.extractor.ts
+++ b/packages/nocodb/src/helpers/db-error/pg.extractor.ts
@@ -345,6 +345,11 @@ export class PgDBErrorExtractor implements IClientDbErrorExtractor {
         httpStatus = 409;
         break;
 
+      case 'EACCES': // SSRF protection blocked connection
+        message = 'Connection to internal hosts is not allowed';
+        httpStatus = 403;
+        break;
+
       case '53300': // too_many_connections
         message = 'Too many database connections.';
         httpStatus = 503;

--- a/packages/nocodb/src/helpers/db-error/sqlite.extractor.ts
+++ b/packages/nocodb/src/helpers/db-error/sqlite.extractor.ts
@@ -122,6 +122,11 @@ export class SqliteDBErrorExtractor implements IClientDbErrorExtractor {
         message = 'The database schema has changed.';
         break;
 
+      case 'EACCES':
+        message = 'Connection to internal hosts is not allowed';
+        httpStatus = 403;
+        break;
+
       default:
         this.option.dbErrorLogger.error(
           `${error.code} is not handled on database sqlite`,


### PR DESCRIPTION
## Change Summary

Root cause: The SSRF protection  blocks connections to internal hosts by throwing an EACCES error. However, none of the database error extractors recognized this error code, so they all fell through to their default handlers - logging the unhandled error and returning a generic 500. fix #14072 

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

No existing tests for db-error extractors in the codebase.
Verified manually: EACCES now returns { error: ERR_DATABASE_OP_FAILED, message: "Connection to internal hosts is not allowed", code: "EACCES", httpStatus: 403 } instead of generic 500.
Self-hosted users can still bypass SSRF with NC_ALLOW_LOCAL_EXTERNAL_DBS=true or NC_DISABLE_SSRF_PROTECTION=true

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
