### PR TITLE
fix(nocodb): reset-password page 404s under sub-path / reverse-proxy deployments

### DIFF
--- a/packages/nocodb/src/modules/auth/auth.controller.ts
+++ b/packages/nocodb/src/modules/auth/auth.controller.ts
@@ -284,7 +284,12 @@ export class AuthController {
           {
             ncPublicUrl: ncSiteUrl || '',
             token: tokenId,
-            baseUrl: `/`,
+            // Honor the configured site URL so the in-page API calls resolve
+            // correctly when NocoDB is served from a sub-path / behind a
+            // reverse proxy (e.g. https://example.com/noco). Falling back to
+            // `/` keeps root deployments working. Used as `<%= baseUrl %>api/..`
+            // so it must carry a single trailing slash.
+            baseUrl: ncSiteUrl ? `${ncSiteUrl.replace(/\/+$/, '')}/` : `/`,
           },
         ),
       );


### PR DESCRIPTION
## Fixes #12640

### Problem
On self-hosted deployments served from a **sub-path behind a reverse proxy** (e.g. `https://example.com/noco`), clicking **Reset Password** in the password-reset email opens a page that just shows **"Not a valid url"**. DevTools shows a `404` on `/api/v1/db/auth/token/validate/XXXXX` — note the missing `/noco` prefix.

### Root cause
The reset email link itself is correct (built from `NC_SITE_URL`). But the backend-served reset page is rendered with a **hardcoded `baseUrl: '/'`** in `auth.controller.ts`:

```ts
ejs.render(resetPasswordTemplate, {
  ncPublicUrl: ncSiteUrl || '',
  token: tokenId,
  baseUrl: `/`,   // ← always root, ignores the sub-path
})
```

The page then calls `axios.post('<%= baseUrl %>api/v1/db/auth/token/validate/' + token)` (and the same for the reset submit). With `baseUrl = '/'` those resolve against the **domain root**, dropping the `/noco` prefix → `404` → the page falls into its error branch and renders *"Not a valid url"*.

### Fix
Derive `baseUrl` from the configured `NC_SITE_URL` / `NC_PUBLIC_URL` — the same value the reset email link already uses — and fall back to `/` for root deployments (it's interpolated as `<%= baseUrl %>api/...`, so it carries exactly one trailing slash):

```ts
baseUrl: ncSiteUrl ? `${ncSiteUrl.replace(/\/+$/, '')}/` : `/`,
```

This makes the in-page validate/reset calls resolve to `https://example.com/noco/api/...` on sub-path deployments while leaving root deployments unchanged.

### Testing
- Backend builds clean on this branch (type-check: no errors) and `/api/v1/health` returns `200`.
- Root deployments are unaffected (fallback to `/`).
- Affects both the `token/validate` call and the `password/reset` submit call on the page.

> Draft: opened for review of the approach. A manual end-to-end check behind an actual sub-path reverse proxy would be the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)