### PR TITLE
fix(nocodb): resolve reset-password page API calls under sub-path deployments

### DIFF
--- a/packages/nocodb/src/modules/auth/auth.controller.ts
+++ b/packages/nocodb/src/modules/auth/auth.controller.ts
@@ -284,7 +284,12 @@ export class AuthController {
           {
             ncPublicUrl: ncSiteUrl || '',
             token: tokenId,
-            baseUrl: `/`,
+            // Honor the configured site URL so the in-page API calls resolve
+            // correctly when NocoDB is served from a sub-path / behind a
+            // reverse proxy (e.g. https://example.com/noco). Falling back to
+            // `/` keeps root deployments working. Used as `<%= baseUrl %>api/..`
+            // so it must carry a single trailing slash.
+            baseUrl: ncSiteUrl ? `${ncSiteUrl.replace(/\/+$/, '')}/` : `/`,
           },
         ),
       );


### PR DESCRIPTION


## Change Summary

Fixes https://github.com/nocodb/nocodb/issues/12640

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
