### PR TITLE
fix: add missing @ai-sdk/devtools dependency

### DIFF
--- a/packages/noco-integrations/core/package.json
+++ b/packages/noco-integrations/core/package.json
@@ -11,6 +11,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@ai-sdk/devtools": "^0.0.19",
     "@ai-sdk/provider": "^3.0.0",
     "ai": "^6.0.3",
     "nocodb-sdk": "file:../../nocodb-sdk",

--- a/packages/noco-integrations/pnpm-lock.yaml
+++ b/packages/noco-integrations/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
 
   core:
     dependencies:
+      '@ai-sdk/devtools':
+        specifier: ^0.0.19
+        version: 0.0.19
       '@ai-sdk/provider':
         specifier: ^3.0.0
         version: 3.0.2
@@ -77,6 +80,11 @@ importers:
 
 packages:
 
+  '@ai-sdk/devtools@0.0.19':
+    resolution: {integrity: sha512-2NbKPNEvgjQ5eu9T5UBVJ9MM4SHTDqL5pKQICqwlBRXi3hbwvfPABIPTaQyLk2MsWy+toUX31x5XUio4Cg5/+Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@ai-sdk/gateway@3.0.10':
     resolution: {integrity: sha512-sRlPMKd38+fdp2y11USW44c0o8tsIsT6T/pgyY04VXC3URjIRnkxugxd9AkU2ogfpPDMz50cBAGPnMxj+6663Q==}
     engines: {node: '>=18'}
@@ -88,6 +96,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.2':
     resolution: {integrity: sha512-HrEmNt/BH/hkQ7zpi2o6N3k1ZR1QTb7z85WYhYygiTxOQuaml4CMtHCWRbric5WPU+RNsYI7r1EpyVQMKO1pYw==}
@@ -180,6 +192,12 @@ packages:
   '@eslint/plugin-kit@0.3.1':
     resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1096,6 +1114,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1997,6 +2019,12 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/devtools@0.0.19':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      hono: 4.12.27
+
   '@ai-sdk/gateway@3.0.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
@@ -2010,6 +2038,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.2':
     dependencies:
@@ -2116,6 +2148,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.14.0
       levn: 0.4.1
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@humanfs/core@0.19.1': {}
 
@@ -3155,6 +3191,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.12.27: {}
 
   html-escaper@2.0.2: {}
 

--- a/packages/nocodb/package.json
+++ b/packages/nocodb/package.json
@@ -39,6 +39,7 @@
     "@ai-sdk/anthropic": "^3.0.1",
     "@ai-sdk/azure": "^3.0.1",
     "@ai-sdk/deepseek": "^2.0.1",
+    "@ai-sdk/devtools": "^0.0.19",
     "@ai-sdk/google": "^3.0.1",
     "@ai-sdk/groq": "^3.0.1",
     "@ai-sdk/openai": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,6 +799,9 @@ importers:
       '@ai-sdk/deepseek':
         specifier: ^2.0.1
         version: 2.0.4(zod@3.25.76)
+      '@ai-sdk/devtools':
+        specifier: ^0.0.19
+        version: 0.0.19
       '@ai-sdk/google':
         specifier: ^3.0.1
         version: 3.0.6(zod@3.25.76)
@@ -1583,6 +1586,11 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/devtools@0.0.19':
+    resolution: {integrity: sha512-2NbKPNEvgjQ5eu9T5UBVJ9MM4SHTDqL5pKQICqwlBRXi3hbwvfPABIPTaQyLk2MsWy+toUX31x5XUio4Cg5/+Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@ai-sdk/gateway@3.0.10':
     resolution: {integrity: sha512-sRlPMKd38+fdp2y11USW44c0o8tsIsT6T/pgyY04VXC3URjIRnkxugxd9AkU2ogfpPDMz50cBAGPnMxj+6663Q==}
     engines: {node: '>=18'}
@@ -1627,6 +1635,10 @@ packages:
 
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.2':
@@ -19061,6 +19073,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/devtools@0.0.19':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@hono/node-server': 1.19.14(hono@4.12.19)
+      hono: 4.12.19
+
   '@ai-sdk/gateway@3.0.10(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.2
@@ -19107,6 +19125,10 @@ snapshots:
       zod: 3.25.76
 
   '@ai-sdk/provider@1.1.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
## Problem

`packages/noco-integrations/core/src/ai/types.ts:7` imports `@ai-sdk/devtools`:

```ts
import { devToolsMiddleware } from '@ai-sdk/devtools';
```

The import was synced from the enterprise repo (PR #14144 / `nc-chatbot-hardening`), but the matching `package.json` dependency was **not** — `package.json` is excluded from the EE→OSS sync, so dependency additions have to be made manually in this repo. As a result `@ai-sdk/devtools` is declared nowhere, and `pnpm bootstrap` fails while building `@noco-integrations/core`:

```
src/ai/types.ts(7,36): error TS2307: Cannot find module '@ai-sdk/devtools' or its corresponding type declarations.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @noco-integrations/core@1.0.0 build: `tsc`
```

The install step dies before any test runs, so the **NestJS Unit Test** workflow is currently red on `develop` and on every open OSS-sync PR.

## Fix

Add `@ai-sdk/devtools@^0.0.19` (the version used upstream) as a dependency of:

- `packages/noco-integrations/core` — where the import lives
- `packages/nocodb` — which bundles the built core

and regenerate both lockfiles (`packages/noco-integrations/pnpm-lock.yaml` and root `pnpm-lock.yaml`).

## Verification

- `@noco-integrations/core` `tsc` build now passes (built `nocodb-sdk` first to mirror `pnpm bootstrap` order)
- `pnpm install --frozen-lockfile` passes for both the root and `noco-integrations` workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)