### PR TITLE
fix(nocodb): disambiguate paired link column on V2 upgrade by fk_index_name

### DIFF
--- a/packages/nocodb/src/helpers/ltarPairing.ts
+++ b/packages/nocodb/src/helpers/ltarPairing.ts
@@ -1,0 +1,84 @@
+/**
+ * Helpers for identifying the counterpart column of a Link-to-another-record
+ * (LTAR) relation while upgrading V1 links to V2.
+ *
+ * Background (nocodb/nocodb#13781):
+ * When a link is converted to V2 we have to locate the column on the related
+ * table that forms the other half of the relation (the BT for an HM, or the HM
+ * for a BT). Historically this match keyed only on
+ * `(fk_parent_column_id, fk_child_column_id, type)` and returned the first hit.
+ * Those keys are NOT unique when an external source has multiple foreign-key
+ * constraints over the same column pair: NocoDB then creates two links that
+ * share both column ids and differ only by `fk_index_name`, so the first match
+ * could pick the wrong counterpart and the two links' identities ended up
+ * swapped after the (irreversible) upgrade.
+ *
+ * A genuine HM/BT pair is always created with the same FK constraint name in
+ * `fk_index_name` (see `createHmAndBtColumn`), and distinct relations get
+ * distinct constraint names. So when the base match is ambiguous we
+ * disambiguate by `fk_index_name`.
+ */
+
+/** Minimal subset of LTAR relation metadata needed to pair columns. */
+export interface LtarPairColOptions {
+  fk_parent_column_id?: string;
+  fk_child_column_id?: string;
+  fk_index_name?: string;
+  type?: string;
+}
+
+export interface LtarPairCandidate<
+  TColumn = unknown,
+  TColOptions extends LtarPairColOptions = LtarPairColOptions,
+> {
+  column: TColumn;
+  colOptions: TColOptions;
+}
+
+/**
+ * Pick the column that is the true counterpart of the link being converted.
+ *
+ * Behaviour is intentionally unchanged when the base match yields 0 or 1
+ * candidate, or when the source column has no `fk_index_name` (legacy rows) — in
+ * those cases the first base match is returned exactly as before, so existing
+ * conversions cannot regress. Only the previously-broken ambiguous case
+ * (an external source with multiple FK constraints over the same column pair)
+ * now resolves deterministically.
+ */
+export function pickPairedLtarColumn<
+  TColumn,
+  TColOptions extends LtarPairColOptions,
+>(
+  candidates: LtarPairCandidate<TColumn, TColOptions>[],
+  source: LtarPairColOptions,
+  pairedRelType: string,
+): LtarPairCandidate<TColumn, TColOptions> | undefined {
+  const baseMatches = candidates.filter(
+    (c) =>
+      c.colOptions.fk_parent_column_id === source.fk_parent_column_id &&
+      c.colOptions.fk_child_column_id === source.fk_child_column_id &&
+      c.colOptions.type === pairedRelType,
+  );
+
+  // 0 or 1 match → unambiguous, keep the historic result.
+  if (baseMatches.length <= 1) {
+    return baseMatches[0];
+  }
+
+  // Ambiguous: several links share the same (parent, child, type) — e.g. an
+  // external source with multiple FK constraints over the same column pair. The
+  // correct counterpart shares this link's FK constraint name, which uniquely
+  // identifies the pair.
+  if (source.fk_index_name) {
+    const exact = baseMatches.find(
+      (c) => c.colOptions.fk_index_name === source.fk_index_name,
+    );
+    if (exact) {
+      return exact;
+    }
+  }
+
+  // Could not disambiguate (e.g. legacy rows without `fk_index_name`); fall back
+  // to the previous behaviour so we never break a conversion that worked before.
+  return baseMatches[0];
+}

--- a/packages/nocodb/src/services/columns.service.ts
+++ b/packages/nocodb/src/services/columns.service.ts
@@ -127,6 +127,7 @@ import { DuplicateDetectionService } from '~/services/duplicate-detection.servic
 import { LinkPlaceholderService } from '~/services/link-placeholder.service';
 import NcConnectionMgrv2 from '~/utils/common/NcConnectionMgrv2';
 import { ltarColumnConversion } from '~/helpers/ltarColumnConversion';
+import { pickPairedLtarColumn } from '~/helpers/ltarPairing';
 import { validateUniqueConstraint } from '~/helpers/uniqueConstraintHelpers';
 import {
   convertAIRecordTypeToValue,
@@ -7793,6 +7794,10 @@ export class ColumnsService implements IColumnsService {
           ? RelationTypes.ONE_TO_ONE
           : RelationTypes.HAS_MANY;
 
+      const candidates: {
+        column: Column;
+        colOptions: LinkToAnotherRecordColumn;
+      }[] = [];
       for (const c of relatedColumns) {
         if (!isLinksOrLTAR(c.uidt)) continue;
         // Skip self (self-referencing OO: both sides have same type & FK columns)
@@ -7800,15 +7805,16 @@ export class ColumnsService implements IColumnsService {
         const opts = await c.getColOptions<LinkToAnotherRecordColumn>(
           refContext,
         );
-        if (
-          opts.fk_parent_column_id === colOptions.fk_parent_column_id &&
-          opts.fk_child_column_id === colOptions.fk_child_column_id &&
-          opts.type === pairedRelType
-        ) {
-          hmColumn = c;
-          hmColOptions = opts;
-          break;
-        }
+        candidates.push({ column: c, colOptions: opts });
+      }
+
+      // Disambiguate by fk_index_name when an external source has multiple FK
+      // constraints over the same column pair, otherwise the wrong counterpart
+      // is picked (#13781).
+      const paired = pickPairedLtarColumn(candidates, colOptions, pairedRelType);
+      if (paired) {
+        hmColumn = paired.column;
+        hmColOptions = paired.colOptions;
       }
 
       if (!hmColumn) {
@@ -7828,6 +7834,10 @@ export class ColumnsService implements IColumnsService {
           ? RelationTypes.ONE_TO_ONE
           : RelationTypes.BELONGS_TO;
 
+      const candidates: {
+        column: Column;
+        colOptions: LinkToAnotherRecordColumn;
+      }[] = [];
       for (const c of relatedColumns) {
         if (!isLinksOrLTAR(c.uidt)) continue;
         // Skip self (self-referencing OO: both sides have same type & FK columns)
@@ -7835,15 +7845,16 @@ export class ColumnsService implements IColumnsService {
         const opts = await c.getColOptions<LinkToAnotherRecordColumn>(
           refContext,
         );
-        if (
-          opts.fk_parent_column_id === colOptions.fk_parent_column_id &&
-          opts.fk_child_column_id === colOptions.fk_child_column_id &&
-          opts.type === pairedRelType
-        ) {
-          btColumn = c;
-          btColOptions = opts;
-          break;
-        }
+        candidates.push({ column: c, colOptions: opts });
+      }
+
+      // Disambiguate by fk_index_name when an external source has multiple FK
+      // constraints over the same column pair, otherwise the wrong counterpart
+      // is picked (#13781).
+      const paired = pickPairedLtarColumn(candidates, colOptions, pairedRelType);
+      if (paired) {
+        btColumn = paired.column;
+        btColOptions = paired.colOptions;
       }
 
       if (!btColumn) {


### PR DESCRIPTION
Fixes #13781.

`convertLinkToV2` matched the counterpart link column only by `(fk_parent_column_id, fk_child_column_id, type)` and took the first hit. When two relations share that key the wrong counterpart is picked, swapping the links' identities on the irreversible V1→V2 upgrade.

Trigger: an external source with multiple FK constraints over the same column pair (e.g. a Postgres schema with two FKs on `child.pid → parent.id`), which yields two links sharing both column ids and differing only by `fk_index_name`. It does not reproduce on an internal base, where each HM link mints its own FK column.

Fixed by resolving the counterpart via a shared `pickPairedLtarColumn` helper that disambiguates by `fk_index_name`; behaviour is unchanged for unambiguous or legacy (missing `fk_index_name`) cases, so existing conversions don't regress.
