### PR TITLE
feat(formula): add MD5 and SHA256 hash functions

### DIFF
--- a/packages/nocodb-sdk/src/lib/formula/formulas.ts
+++ b/packages/nocodb-sdk/src/lib/formula/formulas.ts
@@ -1192,6 +1192,43 @@ export const formulas: Record<string, FormulaMeta> = {
     ],
     returnType: FormulaDataTypes.STRING,
   },
+
+  MD5: {
+    docsUrl: `${API_DOC_PREFIX}/field-types/formula/string-functions#md5`,
+
+    validation: {
+      args: {
+        rqd: 1
+      },
+    },
+    description: 'Returns the MD5 hash of the input string.',
+    syntax: 'MD5(str)',
+    examples: [
+      'MD5("hello") => "5d41402abc4b2a76b9719d911017c592"',
+      'MD5({column1})',
+      'IF(MD5({column1}) = "expected", TRUE(), FALSE())',
+    ],
+    returnType: FormulaDataTypes.STRING,
+  },
+
+  SHA256: {
+    docsUrl: `${API_DOC_PREFIX}/field-types/formula/string-functions#sha256`,
+
+    validation: {
+      args: {
+        rqd: 1
+      },
+    },
+    description: 'Returns the SHA-256 hash of the input string as a lowercase hexadecimal string',
+    syntax: 'SHA256(str)',
+    examples: [
+      'SHA256("hello") => "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"',
+      'SHA256({column1})',
+      'IF(SHA256({column1}) = "expected", TRUE(), FALSE())',
+    ],
+    returnType: FormulaDataTypes.STRING,
+  },
+
   // Disabling these functions for now; these act as alias for CreatedAt & UpdatedAt fields;
   // Issue: Error noticed if CreatedAt & UpdatedAt fields are removed from the table after creating these formulas
   //

--- a/packages/nocodb-sdk/src/lib/formula/validate-extract-tree.spec.ts
+++ b/packages/nocodb-sdk/src/lib/formula/validate-extract-tree.spec.ts
@@ -5,6 +5,7 @@ import UITypes from '../UITypes';
 import { SqlUiFactory } from '~/lib/sqlUi';
 import { UnifiedMetaType } from '~/lib/types';
 import { SeparatorType } from '~/lib/columnHelper/utils/common';
+import { CallExpressionNode, IdentifierNode } from './types';
 
 // Mock dependencies
 const mockColumns: UnifiedMetaType.IColumn[] = [
@@ -968,4 +969,65 @@ describe('validateFormulaAndExtractTreeWithType', () => {
     });
     expect(result.referencedColumn.uidt).toBe('SingleLineText');
   });
+  
+
+  describe('MD5 and SHA256 hash functions', () => {
+    const validate = (formula: string, client?: any) =>
+      validateFormulaAndExtractTreeWithType({
+        formula,
+        columns: mockColumns,
+        clientOrSqlUi: client || mockClientOrSqlUi,
+        getMeta: mockGetMeta,
+      });
+    it('should validate MD5 with string literal and return STRING', async () => {
+      const result = (await validate('MD5("hello")')) as CallExpressionNode;
+      expect(result.type).toBe(JSEPNode.CALL_EXP);
+      expect((result.callee as IdentifierNode).name).toBe('MD5');
+      expect(result.dataType).toBe(FormulaDataTypes.STRING);
+    });
+    it('should validate SHA256 with string literal and return STRING', async () => {
+      const result = (await validate('SHA256("hello")')) as CallExpressionNode;
+      expect(result.type).toBe(JSEPNode.CALL_EXP);
+      expect((result.callee as IdentifierNode).name).toBe('SHA256');
+      expect(result.dataType).toBe(FormulaDataTypes.STRING);
+    });
+    it('should validate MD5 with column reference', async () => {
+      const result = (await validate('MD5({Column1})')) as CallExpressionNode;
+      expect(result.type).toBe(JSEPNode.CALL_EXP);
+      expect((result.callee as IdentifierNode).name).toBe('MD5');
+      expect((result.arguments[0] as IdentifierNode).name).toBe('col1');
+      expect(result.dataType).toBe(FormulaDataTypes.STRING);
+    });
+    it('should validate SHA256 with column reference', async () => {
+      const result = (await validate('SHA256({Column1})')) as CallExpressionNode;
+      expect(result.type).toBe(JSEPNode.CALL_EXP);
+      expect((result.callee as IdentifierNode).name).toBe('SHA256');
+      expect((result.arguments[0] as IdentifierNode).name).toBe('col1');
+      expect(result.dataType).toBe(FormulaDataTypes.STRING);
+    });
+    it('should throw INVALID_ARG when MD5 is missing required argument', async () => {
+      await expect(validate('MD5()')).rejects.toMatchObject({
+        type: FormulaErrorType.INVALID_ARG,
+      });
+    });
+    it('should throw INVALID_ARG when SHA256 has too many arguments', async () => {
+      await expect(validate('SHA256("hello", "extra")')).rejects.toMatchObject({
+        type: FormulaErrorType.INVALID_ARG,
+      });
+    });
+    it('should throw INVALID_FUNCTION_NAME for MD5 on SQLite', async () => {
+      const sqliteClient = SqlUiFactory.create({ client: 'sqlite3' });
+      await expect(validate('MD5({Column1})', sqliteClient)).rejects.toMatchObject({
+        type: FormulaErrorType.INVALID_FUNCTION_NAME,
+      });
+    });
+    it('should throw INVALID_FUNCTION_NAME for SHA256 on SQLite', async () => {
+      const sqliteClient = SqlUiFactory.create({ client: 'sqlite3' });
+      await expect(validate('SHA256({Column1})', sqliteClient)).rejects.toMatchObject({
+        type: FormulaErrorType.INVALID_FUNCTION_NAME,
+      });
+    });
+  });
 });
+
+

--- a/packages/nocodb-sdk/src/lib/sqlUi/SqliteUi.ts
+++ b/packages/nocodb-sdk/src/lib/sqlUi/SqliteUi.ts
@@ -1033,6 +1033,8 @@ export class SqliteUi implements SqlUi {
       'ARRAYUNIQUE',
       'ARRAYSLICE',
       'ARRAYCOMPACT',
+      'MD5',
+      'SHA256',
     ];
   }
 

--- a/packages/nocodb/src/db/functionMappings/mysql.ts
+++ b/packages/nocodb/src/db/functionMappings/mysql.ts
@@ -252,6 +252,20 @@ END)`,
       ),
     };
   },
+
+  SHA256: async ({fn, knex, pt}: MapFnArgs) => {
+    const source = (await fn(pt.arguments[0])).builder;
+    return {
+      builder: knex.raw('SHA2(?, 256)', [source])
+    };
+  },
+
+  MD5: async({fn, knex, pt}: MapFnArgs) => {
+    const source = (await fn(pt.arguments[0])).builder;
+    return {
+      builder: knex.raw('MD5(?)', [source])
+    };
+  },
 };
 
 export default mysql2;

--- a/packages/nocodb/src/db/functionMappings/pg.ts
+++ b/packages/nocodb/src/db/functionMappings/pg.ts
@@ -695,6 +695,20 @@ END`,
       ),
     };
   },
+
+  SHA256: async ({fn, knex, pt}: MapFnArgs) => {
+    const source = (await fn(pt.arguments[0])).builder;
+    return {
+      builder: knex.raw(`encode(sha256(convert_to(?::text, 'UTF8')), 'hex')`, [source])
+    }
+  },
+
+  MD5: async({fn, knex, pt}: MapFnArgs) => {
+    const source = (await fn(pt.arguments[0])).builder;
+    return {
+      builder: knex.raw(`md5(?::text)`, [source]),
+    };
+  },
 };
 
 export default pg;


### PR DESCRIPTION
Closes #9747

## Change Summary

Adds `MD5()` and `SHA256()` formula functions for checksum/hash use cases (#9747).

- Register `MD5` and `SHA256` in SDK `formulas.ts` (`rqd: 1`, return type `STRING`)
- PostgreSQL: `md5(?::text)`, `encode(sha256(convert_to(?::text, 'UTF8')), 'hex')`
- MySQL: `MD5(?)`, `SHA2(?, 256)`
- SQLite: marked unsupported in `SqliteUi.getUnsupportedFnList()`
- 8 unit tests in `validate-extract-tree.spec.ts`

SHA-1 omitted (would require PostgreSQL `pgcrypto`).

## Change type

- [x] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Unit tests: `validate-extract-tree.spec.ts` — 8 MD5/SHA256 cases, all pass
- PostgreSQL UI: `MD5("hello")`, `SHA256("hello")` with known test vectors
- MySQL UI: same test vectors (MySQL 8)
- SQLite: formula save rejected as unsupported

## Additional information / screenshots (optional)

- Checksum validation via existing `IF()`:  
  `IF(SHA256({col}) = "expected", TRUE(), FALSE())`
- MSSQL / Oracle / Databricks not included in this PR