### PR TITLE
perf(nc-gui): disable prefetch of lazy-loaded chunks

### DIFF
--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -398,5 +398,18 @@ export default defineNuxtConfig({
     ],
   },
 
+  hooks: {
+    'build:manifest'(manifest) {
+      // Drop prefetch of lazy-loaded chunks. Nuxt prefetches every async chunk
+      // referenced by the entry (incl. the multi-MB Monaco editor) on first load,
+      // which on high-latency / metered links wastes bandwidth, competes with the
+      // resources actually needed, and shows up as large "unused JS" in audits.
+      // Chunks still load on-demand via their import() when the feature is used.
+      for (const key in manifest) {
+        manifest[key].dynamicImports = []
+      }
+    },
+  },
+
   compatibilityDate: '2024-12-04',
 })


### PR DESCRIPTION
## Problem

Nuxt prefetches every async chunk referenced from the entry on first load, including the multi-MB Monaco editor and other feature-only chunks. On high-latency or metered connections (e.g. users far from the server) this:

- wastes bandwidth downloading code that may never be used in the session,
- competes with the resources the current route actually needs, and
- shows up as large "unused JavaScript" in Lighthouse audits.

Measured on the login route of a production build: **155** `<link rel="prefetch">` tags, ~130 `_nuxt` JS requests, with most JS fetched via prefetch before it is needed.

## Change

Clear `dynamicImports` in the `build:manifest` hook so lazy chunks are no longer prefetched. They still load on-demand through their existing `import()` calls when the relevant feature is opened — no functional change, only first-load bandwidth is reduced.

```ts
hooks: {
  'build:manifest'(manifest) {
    for (const key in manifest) {
      manifest[key].dynamicImports = []
    }
  },
},
```

## Results (same login route, production build)

| Metric | Before | After |
|---|---|---|
| `<link rel="prefetch">` | 155 | 2 |
| `_nuxt` JS requests | 130 | 61 |
| JS fetched via prefetch | 113 | 0 |
| `modulepreload` (route deps) | preserved | preserved |

## Verification

- Login page renders correctly, no failed `_nuxt` resources.
- Lazy features still load on demand (Monaco worker/editor and RichText chunks served with 200).
- `modulepreload` of the current route's real dependencies is untouched.

Made with [Cursor](https://cursor.com)