### PR TITLE
fix(attachments): backfill generic/missing mimetype from file extension

### DIFF
--- a/packages/nocodb/src/services/attachments.service.ts
+++ b/packages/nocodb/src/services/attachments.service.ts
@@ -119,6 +119,23 @@ export class AttachmentsService {
             : _destPath;
 
           const originalName = utf8ify(file.originalname);
+
+          // Some clients (e.g. server-to-server / batch upload pipelines) send a
+          // generic or missing Content-Type, which we would otherwise persist
+          // verbatim and also set as the storage object's Content-Type. That makes
+          // browsers refuse to play videos (a <video> source is matched strictly by
+          // MIME, unlike <img> which sniffs bytes). Fall back to the extension-derived
+          // type so previews, thumbnails and the stored mimetype stay correct.
+          const genericMimetypes = ['text/plain', 'application/octet-stream'];
+          if (!file.mimetype || genericMimetypes.includes(file.mimetype)) {
+            const guessedMimetype = mime.getType(
+              path.extname(originalName).slice(1),
+            );
+            if (guessedMimetype) {
+              file.mimetype = guessedMimetype;
+            }
+          }
+
           const fileName = param.scope
             ? `${normalizeFilename(
                 path.parse(originalName).name,


### PR DESCRIPTION
## Problem

When a client uploads an attachment with a **generic or missing `Content-Type`** (for example a server-to-server / batch upload pipeline that sends `text/plain`), `AttachmentsService.upload` persists that value verbatim as the attachment's `mimetype` and also uses it as the storage object's `Content-Type`.

Browsers then refuse to play such files. A `<video>`/`<source>` element is matched **strictly by MIME type**, unlike `<img>` which sniffs the bytes — so a video uploaded as `text/plain` fails to load while images uploaded the same way still render. In nc-gui this surfaces to the user as a **"Page Loading Error / Something went wrong while loading page!"** popup when opening the video, while images merely load.

### Reproduction

1. Upload a `.mp4` via the storage upload API with `Content-Type: text/plain` (e.g. `curl -F "file=@clip.mp4;type=text/plain"`).
2. The stored attachment has `"mimetype":"text/plain"`, and on S3-compatible storage the object's `Content-Type` is `text/plain`.
3. Open the attachment in the UI → the video will not play and a "Page Loading Error" popup appears. The same upload as an image only loads slowly (byte sniffing), no error.

## Fix

In the multipart upload path, when `file.mimetype` is missing or generic (`text/plain` / `application/octet-stream`), fall back to the **extension-derived type** via `mime.getType(...)` before sharp metadata extraction and storage. This keeps image dimensions/thumbnails, the stored `mimetype`, and the storage object's `Content-Type` correct.

The change is placed before the `sharp` image-metadata block so that an image mistakenly sent as `text/plain` still gets its width/height extracted.

## Scope / notes

- Touches only `AttachmentsService.upload` (the multipart path). The URL-import path already falls back to the extension when no type is provided.
- No new dependencies; `mime/lite` and `path` are already imported.

Made with [Cursor](https://cursor.com)