### PR TITLE
fix(nocodb): accept MSSQL MAX length sentinel in dtxp sanitiser

### DIFF
--- a/packages/nocodb/src/helpers/sqlSanitize.ts
+++ b/packages/nocodb/src/helpers/sqlSanitize.ts
@@ -29,6 +29,46 @@ export function pgQuoteLiteral(value: string): string {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
+/**
+ * Validate a column precision/length value (`dtxp`) before it is interpolated
+ * into DDL. Unlike the data type (`dt`, guarded by `KnexClient.sanitiseDataType`),
+ * `dtxp` is not run through an allowlist anywhere in the column pipeline, so a
+ * crafted value such as `1) CHECK(1=0` would otherwise inject a persistent
+ * constraint — or, on SQLite, an arbitrary `;`-delimited statement — into the
+ * live table schema.
+ *
+ * Accepts only the shapes NocoDB ever legitimately produces for `dtxp`:
+ *   - numeric precision, optionally `precision,scale` — e.g. `255`, `10,2`
+ *   - the `MAX` length sentinel for SQL Server large-value types — e.g.
+ *     `nvarchar(MAX)`, stored verbatim as `dtxp: 'MAX'` for text columns (see
+ *     `MssqlUi`). A bare keyword with no injection surface.
+ *   - enum/set value lists of single-quoted SQL string literals (with `''`
+ *     escaping) — e.g. `'a','b'`, built by `columns.service` for Single/MultiSelect
+ *
+ * Returns the validated value (trimmed; enum lists kept verbatim) so it can be
+ * interpolated as-is. Throws on anything else — mirroring `sanitiseDataType`.
+ */
+export function sanitiseDataTypePrecision(
+  dtxp: string | number | null | undefined,
+): string {
+  if (dtxp === null || dtxp === undefined) return '';
+
+  const value = String(dtxp).trim();
+  if (value === '') return '';
+
+  // numeric precision, optionally precision,scale: `255` | `10,2`
+  if (/^\d+(?:\s*,\s*\d+)?$/.test(value)) return value;
+
+  // SQL Server large-value sentinel: `nvarchar(MAX)`, `varbinary(MAX)`, …
+  // Normalise to upper-case `MAX` regardless of stored casing.
+  if (/^max$/i.test(value)) return 'MAX';
+
+  // enum/set value list: `'a','b',…` — each a quoted literal with `''` escaping
+  if (/^'(?:[^']|'')*'(?:\s*,\s*'(?:[^']|'')*')*$/.test(value)) return value;
+
+  throw new Error(`Invalid data type precision: ${dtxp}`);
+}
+
 export function sanitizeAndEscapeDots(alias: string, knex: XKnex) {
   const sanitizedAlias = sanitize(alias);
   // if alias does not contain any dot then return as it is


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
