### PR TITLE
fix(attachments): stop treating videos as images in grid/carousel thumbnails, guard reload-on-error crash

### DIFF
--- a/packages/nc-gui/components/cell/attachment/Carousel.vue
+++ b/packages/nc-gui/components/cell/attachment/Carousel.vue
@@ -87,7 +87,14 @@ const { loadRow } = useSmartsheetRowStoreOrThrow()
 const isUpdated = ref(1)
 
 const triggerReload = async () => {
-  await loadRow()
+  // Defensive: this runs off a media (img/video) `error` event, so a failure here must never
+  // escape as an uncaught rejection and crash the whole page via the top-level ErrorBoundary.
+  try {
+    await loadRow()
+  } catch (e) {
+    console.error('Failed to reload row after attachment load error:', e)
+    return
+  }
   isUpdated.value = isUpdated.value + 1
 }
 

--- a/packages/nc-gui/components/cell/attachment/Carousel.vue
+++ b/packages/nc-gui/components/cell/attachment/Carousel.vue
@@ -86,11 +86,27 @@ const { loadRow } = useSmartsheetRowStoreOrThrow()
 
 const isUpdated = ref(1)
 
+// Tracks which attachment (by url/path/title) has already triggered a self-heal reload, so a
+// single flaky attachment can't re-trigger `loadRow` on every subsequent media `error` event
+// (previously this reset on every error, and since the reload re-signs every URL in the row and
+// remounts all media in the carousel, a single bad attachment could cascade into repeated
+// full-row refetches + full carousel re-downloads). Switching to a different attachment allows
+// one reload attempt again, so a genuinely stale URL for that attachment can still self-heal.
+const reloadedAttachmentKeys = new Set<string>()
+
+const getAttachmentKey = (item: Record<string, any> | false) => (item ? item.url || item.path || item.title || '' : '')
+
 const triggerReload = async () => {
+  const key = getAttachmentKey(selectedFile.value)
+  if (key && reloadedAttachmentKeys.has(key)) return
+  if (key) reloadedAttachmentKeys.add(key)
+
   // Defensive: this runs off a media (img/video) `error` event, so a failure here must never
   // escape as an uncaught rejection and crash the whole page via the top-level ErrorBoundary.
+  // `silent: true` — this is a background self-heal attempt, not a user-initiated action, so a
+  // failure (e.g. transient 404) should log rather than pop a toast (see useSmartsheetLtarHelpers).
   try {
-    await loadRow()
+    await loadRow({ silent: true })
   } catch (e) {
     console.error('Failed to reload row after attachment load error:', e)
     return

--- a/packages/nc-gui/components/cell/attachment/Preview/Thumbnail.vue
+++ b/packages/nc-gui/components/cell/attachment/Preview/Thumbnail.vue
@@ -43,6 +43,13 @@ const FileIcon = (icon: string) => {
 }
 
 const srcs = computed(() => {
+  // Non-image attachments (video/pdf/etc.) never have a real `thumbnails.*` entry (only images
+  // get one — see prepareAttachmentForSigning on the backend), so `getPossibleAttachmentSrc`
+  // would fall back to the raw file URL here. Loading a multi-MB video through an `<img>` tag
+  // always fails, but not before the browser downloads some/all of it — wasted bandwidth and a
+  // guaranteed error event on every render (carousel filmstrip, list previews, audit views,
+  // etc.). Skip straight to the icon fallback below instead.
+  if (!isImage(props.attachment?.title, props.attachment?.mimetype)) return []
   return getPossibleAttachmentSrc(props.attachment, props.thumbnail)
 })
 

--- a/packages/nc-gui/components/cell/attachment/Preview/Video.vue
+++ b/packages/nc-gui/components/cell/attachment/Preview/Video.vue
@@ -39,8 +39,12 @@ onBeforeUnmount(() => {
 })
 
 const handleError = async () => {
-  const isURLExp = await isURLExpired(props.src?.[0])
-  if (isURLExp.isExpired) {
+  // `props.src` is an ordered list of candidate URLs for the same file (e.g. presigned first,
+  // public/direct URL as fallback). A load failure on the first source doesn't mean the
+  // attachment itself is gone — only bubble up to the carousel's reload-on-error flow (which
+  // re-fetches the whole row) once every candidate has been confirmed expired/unavailable.
+  const results = await Promise.all((props.src ?? []).map((src) => isURLExpired(src)))
+  if (results.length > 0 && results.every((r) => r.isExpired)) {
     emit('error')
   }
 }

--- a/packages/nc-gui/components/smartsheet/grid/canvas/cells/Attachment.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/cells/Attachment.ts
@@ -205,7 +205,14 @@ export const AttachmentCellRenderer: CellRenderer = {
       const itemY = y + verticalPadding + row * (itemSize + gap)
 
       const size = getAttachmentSize(rowHeight!)
-      const thumbnailUrls = getPossibleAttachmentSrc(item, size)
+      // Only images have real thumbnails (see prepareAttachmentForSigning on the backend,
+      // which only populates `item.thumbnails` for image mimetypes). Attempting to load a
+      // video/pdf/etc. through an `<img>` element (loadOrGetImage) always fails, but not
+      // before the browser downloads part or all of the file — on every canvas repaint
+      // (scroll/hover/selection), this saturates the per-origin connection limit and starves
+      // real image loads, causing widespread slow/failed loading across the grid. See
+      // handleHover/handleClick below, which already gate this the same way.
+      const thumbnailUrls = isImage(item.title, item.mimetype || item.type) ? getPossibleAttachmentSrc(item, size) : undefined
 
       let thumbnailLoaded = false
 

--- a/packages/nc-gui/composables/useSmartsheetLtarHelpers.ts
+++ b/packages/nc-gui/composables/useSmartsheetLtarHelpers.ts
@@ -118,12 +118,27 @@ const [useProvideSmartsheetLtarHelpers, useSmartsheetLtarHelpers] = useInjection
     }
 
     const loadRow = async (row: Row) => {
-      const record = await $api.dbTableRow.read(
-        NOCO,
-        meta.value?.base_id ?? (base.value?.id as string),
-        meta.value?.title as string,
-        encodeURIComponent(extractPkFromRow(row.row, meta.value?.columns as ColumnType[])),
-      )
+      // Callers (e.g. the attachment Carousel's reload-on-media-error flow) must not let a
+      // failed refetch (404 if the row was deleted meanwhile, a transient network error, etc.)
+      // escape as an uncaught rejection — that would bubble past this composable's callers,
+      // get caught by the top-level ErrorBoundary, and crash the whole page instead of just
+      // failing the reload. Mirrors the error handling in useExpandedFormStore's loadRow.
+      let record: Record<string, any>
+      try {
+        record = await $api.dbTableRow.read(
+          NOCO,
+          meta.value?.base_id ?? (base.value?.id as string),
+          meta.value?.title as string,
+          encodeURIComponent(extractPkFromRow(row.row, meta.value?.columns as ColumnType[])),
+        )
+      } catch (e: any) {
+        if (e?.response?.status === 404) {
+          message.error(t('msg.noRecordFound'))
+        } else {
+          message.error(await extractSdkResponseErrorMsg(e))
+        }
+        return
+      }
       Object.assign(unref(row), {
         row: record,
         oldRow: { ...record },

--- a/packages/nc-gui/composables/useSmartsheetLtarHelpers.ts
+++ b/packages/nc-gui/composables/useSmartsheetLtarHelpers.ts
@@ -117,12 +117,16 @@ const [useProvideSmartsheetLtarHelpers, useSmartsheetLtarHelpers] = useInjection
       }
     }
 
-    const loadRow = async (row: Row) => {
+    const loadRow = async (row: Row, { silent = false }: { silent?: boolean } = {}) => {
       // Callers (e.g. the attachment Carousel's reload-on-media-error flow) must not let a
       // failed refetch (404 if the row was deleted meanwhile, a transient network error, etc.)
       // escape as an uncaught rejection — that would bubble past this composable's callers,
       // get caught by the top-level ErrorBoundary, and crash the whole page instead of just
       // failing the reload. Mirrors the error handling in useExpandedFormStore's loadRow.
+      //
+      // `silent` is for background self-heal callers (e.g. Carousel's media-error reload):
+      // a failure there is not something the user asked for, so surface it in the console only
+      // instead of a toast — otherwise a benign transient failure looks like a data-loss bug.
       let record: Record<string, any>
       try {
         record = await $api.dbTableRow.read(
@@ -132,7 +136,9 @@ const [useProvideSmartsheetLtarHelpers, useSmartsheetLtarHelpers] = useInjection
           encodeURIComponent(extractPkFromRow(row.row, meta.value?.columns as ColumnType[])),
         )
       } catch (e: any) {
-        if (e?.response?.status === 404) {
+        if (silent) {
+          console.error('loadRow: silent background refetch failed', e)
+        } else if (e?.response?.status === 404) {
           message.error(t('msg.noRecordFound'))
         } else {
           message.error(await extractSdkResponseErrorMsg(e))

--- a/packages/nc-gui/utils/attachmentUtils.ts
+++ b/packages/nc-gui/utils/attachmentUtils.ts
@@ -85,8 +85,13 @@ export async function isURLExpired(url?: string) {
       status: response.status,
     }
   } catch (error) {
+    // A thrown fetch (CORS block, DNS hiccup, offline, aborted, etc.) tells us nothing about
+    // whether the URL itself is expired — it's "unknown", not "expired". Treating it as expired
+    // caused callers (e.g. Video.vue's handleError) to trigger a row reload for transient/CORS
+    // errors that had nothing to do with the attachment URL being stale, contributing to
+    // spurious reload loops and false "record not found" toasts.
     return {
-      isExpired: true,
+      isExpired: false,
       status: 0,
       error: error.message,
     }


### PR DESCRIPTION
## Summary

- The canvas grid cell renderer (`Attachment.ts`) unconditionally tried to load *every* attachment through an `<img>` element to render a thumbnail, without checking `isImage()` first (unlike `handleHover`/`handleClick` in the same file, which already gate this correctly). For video/pdf/etc. attachments — which never have a real `thumbnails.*` entry — this means every canvas repaint (scroll, hover, selection change) re-attempts a full image-decode of the raw file. It always fails, but not before the browser downloads part or all of it, wasting bandwidth and starving real image loads competing for the same origin's connection limit. With several video rows in a table this made the whole grid feel like it "loads forever" and some attachments "never load". This turned out to be the dominant root cause behind the crash/reload issue this PR originally targeted.
- The same bug exists in the attachment carousel's filmstrip thumbnail (`Preview/Thumbnail.vue`), which is also used by list/audit views.
- `isURLExpired` treated *any* thrown `fetch` (CORS block, transient network error, offline, aborted) as "the URL is expired", which could misfire `Video.vue`'s reload-on-error flow for reasons that have nothing to do with the attachment being stale.
- `Video.vue`'s `handleError` only checked the *first* candidate source before declaring an error, ignoring any fallback URLs.
- The carousel's `triggerReload` had no per-attachment de-duplication, so a single flaky attachment could keep re-triggering a full row refetch on every repeated media error, and that background refetch could show a "record not found" toast for what is actually just a self-heal attempt.

## Changes

- `components/smartsheet/grid/canvas/cells/Attachment.ts`: gate the grid thumbnail-load attempt on `isImage()`, matching the existing `handleHover`/`handleClick` behavior.
- `components/cell/attachment/Preview/Thumbnail.vue`: same `isImage()` gate before attempting `<img>` load; go straight to the icon fallback for non-images.
- `utils/attachmentUtils.ts`: `isURLExpired` only reports "expired" on an explicit HTTP 403; a thrown fetch is now treated as "unknown", not "expired".
- `components/cell/attachment/Preview/Video.vue`: `handleError` now checks *all* candidate sources before emitting `error`, not just the first one.
- `components/cell/attachment/Carousel.vue`: `triggerReload` now dedupes per attachment identity (url/path/title) so a single broken attachment reloads at most once, and passes `silent: true` to `loadRow`.
- `composables/useSmartsheetLtarHelpers.ts`: `loadRow` catches the reload failure so it can't crash the page via the top-level ErrorBoundary, and accepts a `{ silent }` option to suppress the "record not found" toast for background self-heal callers, logging to console instead.

## Test plan

- [x] Verified in a live deployment: before the fix, opening a table with several video attachments showed `media-error` events with `tag: "IMG"` firing against `.mp4` URLs purely from the grid being visible (no user interaction), and the grid took a very long time to finish loading with some attachments never rendering.
- [x] After the fix: zero `media-error` events after the grid idles, all attachment cells render immediately (image thumbnail or file-type icon), and the existing carousel/video playback flow (click cell -> expand -> play) still works with no regressions.
- [ ] Would appreciate a maintainer sanity-check on `Thumbnail.vue`'s other call sites (list view items, audit views) to confirm none of them relied on the old fallback-to-raw-file behavior for non-image types.