### PR TITLE
fix: accept non-zero-padded dates in Date/DateTime cells and prevent paste data loss

### DIFF
--- a/packages/nc-gui/components/cell/Date/Editor.vue
+++ b/packages/nc-gui/components/cell/Date/Editor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import dayjs from 'dayjs'
-import { isDateMonthFormat, isSystemColumn } from 'nocodb-sdk'
+import { isDateMonthFormat, isSystemColumn, toLenientDateFormat } from 'nocodb-sdk'
 import { parseFlexibleDate } from '~/utils/datetimeUtils'
 
 interface Props {
@@ -44,6 +44,12 @@ const isDateInvalid = ref(false)
 const datePickerRef = ref<HTMLInputElement>()
 
 const dateFormat = computed(() => parseProp(columnMeta?.value?.meta)?.date_format ?? 'YYYY-MM-DD')
+
+// parse typed input, also accepting non-zero-padded values
+const parseDateInput = (input: string) => {
+  const value = dayjs(input, dateFormat.value)
+  return value.isValid() ? value : dayjs(input, toLenientDateFormat(dateFormat.value), true)
+}
 
 const picker = computed(() => (isDateMonthFormat(dateFormat.value) ? 'month' : ''))
 
@@ -128,7 +134,7 @@ const handleUpdateValue = (e: Event, save = false, valueToSave?: dayjs.Dayjs) =>
     tempDate.value = undefined
     return
   }
-  const value = dayjs(targetValue, dateFormat.value)
+  const value = valueToSave ? dayjs(valueToSave) : parseDateInput(targetValue as string)
 
   if (value.isValid()) {
     tempDate.value = value
@@ -150,7 +156,7 @@ onClickOutside(datePickerRef, (e) => {
 
 const onBlur = (e) => {
   const value = (e?.target as HTMLInputElement)?.value
-  if (value && dayjs(value, dateFormat.value).isValid()) {
+  if (value && parseDateInput(value).isValid()) {
     handleUpdateValue(e, true)
   }
 

--- a/packages/nc-gui/components/cell/DateTime/Editor.vue
+++ b/packages/nc-gui/components/cell/DateTime/Editor.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 import dayjs from 'dayjs'
-import { dateFormats, isSystemColumn, timeFormats } from 'nocodb-sdk'
+import { dateFormats, isSystemColumn, timeFormats, toLenientDateFormat } from 'nocodb-sdk'
 import { timeCellMaxWidthMap, timeFormatsObj } from './utils'
 const { modelValue, isPk, isUpdatedFromCopyNPaste } = defineProps<Props>()
 
 const emit = defineEmits(['update:modelValue', 'currentDate'])
+
+// exact column format, or its non-zero-padded variant when that is what the input matches
+const resolveInputFormat = (input: string, format: string) =>
+  dayjs(input, format).isValid() || !dayjs(input, toLenientDateFormat(format), true).isValid()
+    ? format
+    : toLenientDateFormat(format)
 
 interface Props {
   modelValue?: string | null
@@ -199,8 +205,9 @@ const handleUpdateValue = (e: Event, _isDatePicker: boolean, save = false) => {
       return
     }
 
-    if (dayjs(targetValue, dateFormat.value).isValid()) {
-      const date = dayjsTz(targetValue, dateFormat.value)
+    const dFmt = resolveInputFormat(targetValue, dateFormat.value)
+    if (dayjs(targetValue, dFmt).isValid()) {
+      const date = dayjsTz(targetValue, dFmt)
 
       if (localState.value) {
         tempDate.value = dayjsTz(`${date.format('YYYY-MM-DD')} ${localState.value.format(timeFormat.value)}`)

--- a/packages/nc-gui/composables/useMultiSelect/convertCellData.ts
+++ b/packages/nc-gui/composables/useMultiSelect/convertCellData.ts
@@ -1,5 +1,5 @@
 import type { AttachmentType, ColumnType, SerializerOrParserFnProps } from 'nocodb-sdk'
-import { ColumnHelper, UITypes, populateUniqueFileName } from 'nocodb-sdk'
+import { ColumnHelper, TypeConversionError, UITypes, populateUniqueFileName } from 'nocodb-sdk'
 
 import type { AppInfo } from '~/composables/useGlobal/types'
 
@@ -65,7 +65,8 @@ export default function convertCellData(
 
   let serializedValue = value
 
-  /* eslint-disable no-useless-catch */
+  const isDateType = to === UITypes.Date || to === UITypes.DateTime
+
   try {
     /**
      * This method can throw errors. so it's important to use a try-catch block when calling it.
@@ -79,9 +80,13 @@ export default function convertCellData(
 
     serializedValue = handlePostSerialize(serializedValue, value)
   } catch (ex) {
+    // keep the existing value on an invalid date/datetime paste instead of nulling it
+    if (isDateType && ex instanceof TypeConversionError) return undefined
     throw ex
   }
-  /* eslint-enable no-useless-catch */
+
+  // multi-cell paste returns null instead of throwing for invalid date/datetime; skip it too
+  if (isDateType && serializedValue === null) return undefined
 
   function handlePostSerialize(serializedValue: any, value: any) {
     switch (to) {

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/date-time.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/date-time.ts
@@ -5,6 +5,7 @@ import {
   constructDateTimeFormat,
   getDateFormat,
   getDateTimeFormat,
+  toLenientDateFormat,
 } from '~/lib/dateTimeHelper';
 import { parseProp } from '~/lib/helperFunctions';
 import UITypes from '~/lib/UITypes';
@@ -115,6 +116,11 @@ export const serializeDateOrDateTimeValue = (
       : constructDateTimeFormat(params.col);
 
     parsedDateOrDateTime = dayjs(value, formatting);
+
+    // fall back to unpadded input; strict, so invalid dates stay null
+    if (!parsedDateOrDateTime.isValid()) {
+      parsedDateOrDateTime = dayjs(value, toLenientDateFormat(formatting), true);
+    }
   }
 
   if (!parsedDateOrDateTime.isValid()) {

--- a/packages/nocodb-sdk/src/lib/dateTimeHelper.ts
+++ b/packages/nocodb-sdk/src/lib/dateTimeHelper.ts
@@ -75,6 +75,17 @@ export function getDateFormat(v: string) {
   return 'YYYY/MM/DD';
 }
 
+// Unpadded variant of a date/time format, leaving month/weekday names intact
+export function toLenientDateFormat(format: string) {
+  return format
+    .replace(/M+/g, (m) => (m === 'MM' ? 'M' : m))
+    .replace(/D+/g, (d) => (d === 'DD' ? 'D' : d))
+    .replace(/H+/g, (h) => (h === 'HH' ? 'H' : h))
+    .replace(/h+/g, (h) => (h === 'hh' ? 'h' : h))
+    .replace(/m+/g, (m) => (m === 'mm' ? 'm' : m))
+    .replace(/s+/g, (s) => (s === 'ss' ? 's' : s));
+}
+
 export function getDateTimeFormat(v: string) {
   for (const format of dateFormats) {
     for (const timeFormat of timeFormats) {


### PR DESCRIPTION
Fixes #14194.

Date parsing rejected non-zero-padded month/day (e.g. `5/5/2026` for a `MM/DD/YYYY` column) even though the backend accepts it. Typing such a value was silently ignored, and pasting it serialized to `null` — which could silently overwrite an existing date.

Adds a lenient-format fallback (`toLenientDateFormat`) used by `serializeDateOrDateTimeValue` and the Date/DateTime cell editors, so unpadded values matching the column format are accepted while genuinely invalid ones (e.g. month 13) are still rejected. An invalid date/datetime paste now leaves the existing value intact instead of nulling it.
