### PR TITLE
fix(nc-gui): ignore IME composition Enter in sidebar rename inputs

### DIFF
--- a/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/ProjectNode.vue
@@ -150,6 +150,12 @@ const updateProjectTitle = async () => {
   }
 }
 
+/** Ignore the Enter that confirms an IME candidate; only commit once composition is done */
+const onTitleKeyEnter = (event: KeyboardEvent) => {
+  if (isComposingKeyEvent(event)) return
+  updateProjectTitle()
+}
+
 const { copy } = useCopy(true)
 
 const copyProjectInfo = async () => {
@@ -589,7 +595,7 @@ defineExpose({
                 fontWeight: 'inherit',
               }"
               @click.stop
-              @keyup.enter="updateProjectTitle"
+              @keydown.enter.stop.prevent="onTitleKeyEnter"
               @keyup.esc="updateProjectTitle"
               @blur="updateProjectTitle"
               @keydown.stop

--- a/packages/nc-gui/components/dashboard/TreeView/Table/Node.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Table/Node.vue
@@ -337,6 +337,10 @@ function onKeyDown(event: KeyboardEvent) {
 
 /** Rename view when enter is pressed */
 function onKeyEnter(event: KeyboardEvent) {
+  // Ignore the Enter that confirms an IME (Chinese/Japanese/Korean etc.) candidate --
+  // it must not be treated as "confirm rename" while the user is still composing input.
+  if (isComposingKeyEvent(event)) return
+
   event.stopImmediatePropagation()
   event.preventDefault()
 

--- a/packages/nc-gui/components/dashboard/TreeView/Table/index.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Table/index.vue
@@ -124,6 +124,12 @@ const updateSourceTitle = async (sourceId: string) => {
   }
 }
 
+/** Ignore the Enter that confirms an IME candidate; only commit once composition is done */
+const onSourceTitleKeyEnter = (event: KeyboardEvent, sourceId: string) => {
+  if (isComposingKeyEvent(event)) return
+  updateSourceTitle(sourceId)
+}
+
 /**
  * Opens a dialog to create a new table.
  *
@@ -360,8 +366,7 @@ onKeyStroke('Escape', () => {
                             }"
                             :data-source-rename-input-id="source.id"
                             @click.stop
-                            @keydown.enter.stop.prevent
-                            @keyup.enter="updateSourceTitle(source.id!)"
+                            @keydown.enter.stop.prevent="onSourceTitleKeyEnter($event, source.id!)"
                             @keyup.esc="updateSourceTitle(source.id!)"
                             @blur="updateSourceTitle(source.id!)"
                             @keydown.stop

--- a/packages/nc-gui/components/dashboard/TreeView/Views/Node.vue
+++ b/packages/nc-gui/components/dashboard/TreeView/Views/Node.vue
@@ -150,6 +150,10 @@ function onKeyDown(event: KeyboardEvent) {
 
 /** Rename view when enter is pressed */
 function onKeyEnter(event: KeyboardEvent) {
+  // Ignore the Enter that confirms an IME (Chinese/Japanese/Korean etc.) candidate --
+  // it must not be treated as "confirm rename" while the user is still composing input.
+  if (isComposingKeyEvent(event)) return
+
   event.stopImmediatePropagation()
   event.preventDefault()
 

--- a/packages/nc-gui/components/extensions/Extension/Header.vue
+++ b/packages/nc-gui/components/extensions/Extension/Header.vue
@@ -53,6 +53,12 @@ const updateExtensionTitle = async () => {
   titleEditMode.value = false
 }
 
+/** Ignore the Enter that confirms an IME candidate; only commit once composition is done */
+const onTitleKeyEnter = (event: KeyboardEvent) => {
+  if (isComposingKeyEvent(event)) return
+  updateExtensionTitle()
+}
+
 const expandExtension = () => {
   if (!collapsed.value) return
 
@@ -128,7 +134,7 @@ const handleDuplicateExtension = async (id: string, open = false) => {
           '!text-lg !font-semibold max-w-[420px]': isFullscreen,
         }"
         @click.stop
-        @keyup.enter="updateExtensionTitle"
+        @keydown.enter.stop.prevent="onTitleKeyEnter"
         @keyup.esc="updateExtensionTitle"
         @blur="updateExtensionTitle"
       >

--- a/packages/nc-gui/components/workspace/BaseListModal/BaseNode.vue
+++ b/packages/nc-gui/components/workspace/BaseListModal/BaseNode.vue
@@ -68,6 +68,12 @@ const updateTitle = () => {
   tempTitle.value = ''
 }
 
+/** Ignore the Enter that confirms an IME candidate; only commit once composition is done */
+const onTitleKeyEnter = (event: KeyboardEvent) => {
+  if (isComposingKeyEvent(event)) return
+  updateTitle()
+}
+
 const handleDuplicate = () => {
   onDuplicate(props.base)
   isMenuOpen.value = false
@@ -138,7 +144,7 @@ const onMenuClick = (e: Event) => {
         v-model:value="tempTitle"
         class="!bg-transparent !text-sm !font-medium !rounded-md !px-1 !h-7 !-ml-1.2"
         @click.stop
-        @keyup.enter="updateTitle"
+        @keydown.enter.stop.prevent="onTitleKeyEnter"
         @keyup.esc="updateTitle"
         @blur="updateTitle"
         @keydown.stop

--- a/packages/nc-gui/utils/browserUtils.ts
+++ b/packages/nc-gui/utils/browserUtils.ts
@@ -102,6 +102,13 @@ export const isTiptapDropdownExistInsideEditor = () => {
 export const ncIsIframe = () => window.self !== window.top
 
 export const isSidebarNodeRenameActive = () => document.querySelector('input.animate-sidebar-node-input-padding')
+
+// True while an IME (Chinese/Japanese/Korean etc.) composition is active for this
+// key event. The Enter that confirms an IME candidate must NOT commit a rename.
+// isComposing covers Chromium; key==='Process' / keyCode===229 are cross-browser
+// fallbacks for the composing Enter.
+export const isComposingKeyEvent = (event: KeyboardEvent) =>
+  event.isComposing || event.key === 'Process' || (event as any).keyCode === 229
 export function hasAncestorWithClass(element: HTMLElement, className: string | Array<string>): boolean {
   const classNames = ncIsArray(className) ? className : [className]
 


### PR DESCRIPTION
## Problem
When renaming items in the left sidebar (tables, views, bases/projects, sources, extensions) while using an IME (Chinese/Japanese/Korean, etc.), pressing Enter to confirm an IME candidate is misinterpreted as "commit rename". This causes the rename input to exit and submit before the user has finished composing their intended text.

## Root cause
During IME composition, `keydown`'s `event.isComposing` is `true` (with `key === 'Process'` / `keyCode === 229` as cross-browser fallbacks in some browsers/IMEs), but by the time `keyup` fires, composition has typically ended and `isComposing` is `false`. Several sidebar rename inputs bound their commit logic to `@keyup.enter`, so they could never observe the composing state, and the ones already on `@keydown` didn't check it at all.

The repo already has a precedent for this check (`composables/useMultiSelect/index.ts` and `components/smartsheet/grid/Table.vue` both guard with `if (e.isComposing) return`).

## Fix
- Added a shared `isComposingKeyEvent(event)` helper in `utils/browserUtils.ts`: `event.isComposing || event.key === 'Process' || event.keyCode === 229`.
- `Table/Node.vue` and `Views/Node.vue`: added the guard as the first line of the existing `onKeyEnter` (already on keydown).
- `ProjectNode.vue`, `Table/index.vue`, `BaseListModal/BaseNode.vue`, `Extension/Header.vue`: moved the Enter handler from `@keyup.enter` to `@keydown.enter.stop.prevent` (composition state isn't reliably available on keyup), and added a small guarded wrapper method that calls the original commit function only when not composing.

`Escape` and `blur` behavior are intentionally left unchanged in this PR to keep the change focused.

## Test plan
- [x] Verified on a real deployment by dispatching `KeyboardEvent('keydown', {key:'Enter', isComposing:true})` on the live rename `<input>` (simulates the exact browser semantics of confirming an IME candidate): edit mode stayed open and `preventDefault()` was not called. Then dispatched the same event with `isComposing:false`: the rename committed and `preventDefault()` was called (table rename path, `Table/Node.vue`).
- [ ] Manual test with a real Chinese (Pinyin) IME across all 6 affected inputs (table/view/project-base/source/base-list-modal/extension) — the other 5 inputs share the exact same `isComposingKeyEvent` helper and pattern as the verified one, but have not each been independently re-verified with a live IME.
- [x] Manual test with plain ASCII input and no IME — Enter still commits immediately (guard is a no-op when not composing).