### PR TITLE
fix(csv-import): prevent period in column name from breaking PostgreSQL insert

### DIFF
--- a/packages/nocodb/src/helpers/columnHelpers.ts
+++ b/packages/nocodb/src/helpers/columnHelpers.ts
@@ -635,6 +635,9 @@ export async function populateRollupForLTAR({
 }
 
 export const sanitizeColumnName = (name: string, sourceType?: DriverClient) => {
+  // Periods are always replaced — Knex treats '.' as a schema/table qualifier
+  // separator and produces broken SQL for any identifier containing a period.
+  name = name.replace(/\./g, '_');
   if (
     process.env.NC_DATABASE_COLUMN_NAME_SANITIZE_ENABLED === 'false' ||
     process.env.NC_SANITIZE_COLUMN_NAME === 'false'

--- a/packages/nocodb/src/helpers/db-error/pg.extractor.ts
+++ b/packages/nocodb/src/helpers/db-error/pg.extractor.ts
@@ -308,7 +308,7 @@ export class PgDBErrorExtractor implements IClientDbErrorExtractor {
           }
 
           const extractColumnNameMatch = error.message.match(
-            / column "(\w+)" does not exist/i,
+            / column "([^"]+)" does not exist/i,
           );
 
           if (extractColumnNameMatch && extractColumnNameMatch[1]) {
@@ -324,7 +324,7 @@ export class PgDBErrorExtractor implements IClientDbErrorExtractor {
         message = 'The column does not exist.';
         if (error.message) {
           const extractTableNameMatch = error.message.match(
-            / column "(\w+)" does not exist/i,
+            / column "([^"]+)" does not exist/i,
           );
           if (extractTableNameMatch && extractTableNameMatch[1]) {
             message = `The column '${extractTableNameMatch[1]}' does not exist.`;

--- a/packages/nocodb/src/modules/jobs/jobs/data-import/data-import.processor.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/data-import/data-import.processor.ts
@@ -865,7 +865,7 @@ export class DataImportProcessor {
       // Map source columns to dest columns + type coercion
       const dbRow: Record<string, any> = {};
       for (const [srcCol, mapping] of Object.entries(colMap)) {
-        dbRow[mapping.destCn] = coerceValue(sourceRow[srcCol], mapping);
+        dbRow[mapping.destCn.replace(/\./g, '_')] = coerceValue(sourceRow[srcCol], mapping);
       }
 
       // Extract link display values for the post-insert link phase.


### PR DESCRIPTION


## Change Summary

Fixes #14200  by always replacing periods (.) in database column names during sanitization, even when column name sanitization is disabled via environment variables.

Previously, when NC_DATABASE_COLUMN_NAME_SANITIZE_ENABLED=false (or NC_SANITIZE_COLUMN_NAME=false), column names containing periods (e.g. Ext. Beleg-Nr) were returned unchanged. This caused Knex to interpret the period as an identifier qualifier (table.column), resulting in invalid SQL during import.

This change always replaces . with _ before the environment variable check, ensuring period-containing column names are safe for SQL generation while preserving the existing behavior for other characters when sanitization is disabled.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)


## Changes

Fix 1-> (columnHelpers.ts): Always strip periods from column names, even when NC_DATABASE_COLUMN_NAME_SANITIZE_ENABLED=false. Periods are incompatible with Knex identifier handling.
Fix 2-> (data-import.processor.ts): Defense-in-depth  strip periods from dest column names in import data keys before passing to Knex.
Fix 3-> (pg.extractor.ts): Error display  change regex \w+ → [^"]+ so column names with special chars are fully captured in error messages ( as in issue Ext. Beleg-Nr instead of just Ext)


## Test/ Verification
Compiled clean with tsc --noEmit

## Additional information / screenshots (optional)

Periods in database column names are incompatible with Knex's identifier handling, as . is interpreted as a qualifier separator. Replacing periods before the sanitization bypass prevents invalid SQL generation while keeping the existing opt-out behavior for other column name sanitization rules.
