### PR TITLE
feat: add opt-in Gateway API HTTPRoute support to the nocodb chart

### DIFF
--- a/charts/nocodb/Chart.yaml
+++ b/charts/nocodb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nocodb
 description: NocoDB — A Free & Self-hostable Airtable Alternative. Production-ready chart for external Postgres and Redis.
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "2026.06.1"
 home: https://nocodb.com
 icon: https://github.com/nocodb/nocodb/raw/develop/packages/nc-gui/assets/img/icons/512x512.png

--- a/charts/nocodb/README.md
+++ b/charts/nocodb/README.md
@@ -210,6 +210,11 @@ Create one Secret and reference it from each `*.existingSecret`:
 | `ingress.annotations` | Ingress annotations (cert-manager cluster-issuer here) | `{}` |
 | `ingress.hosts` | Ingress hosts | See values.yaml |
 | `ingress.tls` | Ingress TLS entries | `[]` |
+| `httproute.enabled` | Create a Gateway API HTTPRoute (alternative to Ingress; needs the Gateway API CRDs and a Gateway) | `false` |
+| `httproute.annotations` | HTTPRoute annotations | `{}` |
+| `httproute.parentRefs` | Gateways this route attaches to (each entry: name, and optional namespace/sectionName/port) | `[]` |
+| `httproute.hostnames` | Hostnames matched by this route | `[]` |
+| `httproute.rules` | Custom routing rules; when set, replaces the default "/ -> service" rule (tpl-rendered) | `[]` |
 | `networkPolicy.enabled` | Create a NetworkPolicy | `false` |
 | `networkPolicy.allowExternal` | Allow ingress from anywhere | `true` |
 | `networkPolicy.extraIngress` | Extra ingress rules | `[]` |

--- a/charts/nocodb/templates/httproute.yaml
+++ b/charts/nocodb/templates/httproute.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.httproute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "nocodb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nocodb.labels" . | nindent 4 }}
+  {{- with include "nocodb.annotations" (dict "context" . "extraAnnotations" .Values.httproute.annotations) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.httproute.rules }}
+    {{- include "nocodb.tplvalues.render" (dict "value" .Values.httproute.rules "context" $) | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "nocodb.fullname" . }}
+          port: {{ .Values.service.port }}
+    {{- end }}
+{{- end }}

--- a/charts/nocodb/values.yaml
+++ b/charts/nocodb/values.yaml
@@ -302,6 +302,21 @@ ingress:
           pathType: Prefix
   ## @param ingress.tls Ingress TLS entries
   tls: []
+## @param httproute.enabled Create a Gateway API HTTPRoute (alternative to Ingress; needs the Gateway API CRDs and a Gateway)
+## @param httproute.annotations HTTPRoute annotations
+## @param httproute.parentRefs Gateways this route attaches to (each entry: name, and optional namespace/sectionName/port)
+## @param httproute.hostnames Hostnames matched by this route
+## @param httproute.rules Custom routing rules; when set, replaces the default "/ -> service" rule (tpl-rendered)
+httproute:
+  enabled: false
+  annotations: {}
+  parentRefs: []
+  #  - name: my-gateway
+  #    namespace: gateway-system
+  #    sectionName: https
+  hostnames: []
+  #  - nocodb.example.com
+  rules: []
 networkPolicy:
   ## @param networkPolicy.enabled Create a NetworkPolicy
   enabled: false


### PR DESCRIPTION
## Change Summary

Adds an opt-in Gateway API HTTPRoute to the nocodb chart as an alternative to Ingress for clusters running a Gateway API implementation (Envoy Gateway, Istio, Cilium, etc.). Disabled by default (`httproute.enabled: false`), so existing installs are unaffected. It mirrors the ingress values shape: `parentRefs`, `hostnames`, `annotations`, and a `rules` escape hatch that overrides the default "/ -> service" rule when set.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] feat: opt-in Gateway API HTTPRoute template + values

## Test/ Verification

- `helm lint charts/nocodb`: passes
- `helm template` (default): no HTTPRoute rendered
- `helm template` (enabled with parentRefs + hostnames): valid HTTPRoute, default `/ -> service:8080` rule
- `helm template` (custom `rules`): override renders with filters

Chart version bumped 1.0.0 -> 1.1.0 (MINOR, backward-compatible opt-in feature).

## Additional information / screenshots (optional)

The HTTPRoute reuses the chart's existing helpers (`nocodb.fullname`, `nocodb.labels`, `nocodb.annotations`, `nocodb.tplvalues.render`) and follows the same structure as `templates/ingress.yaml`.
