### PR TITLE
ci: pin tim-actions steps in DCO check to full commit SHAs

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
       - name: Get PR Commits
         id: "get-pr-commits"
-        uses: tim-actions/get-pr-commits@master
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d # master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@master
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # master
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
### What
Pin the two `tim-actions/*` steps in `.github/workflows/dco-check.yml` from the mutable
`@master` tag to the exact `master` commit SHA (the tag is preserved in a trailing comment):

- `tim-actions/get-pr-commits@master` → `@198af0356…` — this step is passed `secrets.GITHUB_TOKEN`
- `tim-actions/dco@master` → `@f2279e6e6…`

### Why
`@master` is a moving reference: whatever that branch points to at run time is what executes in
the job. If a third-party action's `master` is moved (compromise or an unintended change), the new
code runs here with the workflow's token — the same class of issue behind the 2025 `tj-actions`
incident. Pinning to a full commit SHA is GitHub's documented hardening guidance
(“Using third-party actions” → *pin actions to a full-length commit SHA*), and it's the standard
several of nocodb's other workflows already follow.

### Scope / safety
- Behaviour is unchanged — the pinned SHAs are the current tip of each action's `master`.
- Renovate/Dependabot can still bump a SHA pin (with the tag comment for readability).
- Only `dco-check.yml` is touched.

Happy to adjust the pin style (e.g. to a released tag) if you prefer. Commit is DCO signed-off.

<sub>AI-assisted; I verified the workflow and the pinned SHAs myself against `master`.</sub>
