### PR TITLE
fix: convert Excel serial dates on xlsx import for date-typed columns

### DIFF
--- a/packages/nocodb/src/modules/jobs/jobs/data-import/handlers/excel-import.handler.spec.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/data-import/handlers/excel-import.handler.spec.ts
@@ -1,0 +1,73 @@
+import ExcelJS from 'exceljs';
+import { Readable } from 'stream';
+import { UITypes } from 'nocodb-sdk';
+import { ExcelImportHandler } from './excel-import.handler';
+import type { FileImportColumn } from 'nocodb-sdk';
+
+async function buildWorkbookBuffer(
+  cellValue: Date,
+  numFmt = 'dd/mm/yyyy',
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet('Sheet1');
+  sheet.addRow(['Beleg-Dat']);
+  const dataRow = sheet.addRow([cellValue]);
+  dataRow.getCell(1).numFmt = numFmt;
+  return (await workbook.xlsx.writeBuffer()) as unknown as Buffer;
+}
+
+async function collectRows(
+  buffer: Buffer,
+  columns: FileImportColumn[],
+): Promise<Record<string, any>[]> {
+  const handler = new ExcelImportHandler();
+  const rows: Record<string, any>[] = [];
+  for await (const row of handler.streamRows(
+    Readable.from(buffer),
+    { firstRowAsHeaders: true },
+    columns,
+  )) {
+    rows.push(row);
+  }
+  return rows;
+}
+
+describe('ExcelImportHandler', () => {
+  it('imports a date-formatted xlsx cell into a Date column as an ISO date, not a raw serial number', async () => {
+    const cellDate = new Date(Date.UTC(2026, 5, 15));
+    const buffer = await buildWorkbookBuffer(cellDate);
+
+    const columns: FileImportColumn[] = [
+      { key: 0, title: 'Beleg-Dat', column_name: 'Beleg-Dat', uidt: UITypes.Date },
+    ];
+
+    const rows = await collectRows(buffer, columns);
+
+    expect(rows).toHaveLength(1);
+    const value = rows[0]['Beleg-Dat'];
+
+    // Regression guard for nocodb/nocodb#14275: with `styles: 'ignore'` on the
+    // workbook reader, exceljs never applies numFmt-based date detection, so
+    // without the fix this cell surfaces as the raw Excel serial number
+    // (e.g. 46188) instead of a date, which fails the DB insert.
+    expect(typeof value).toBe('string');
+    expect(Number.isNaN(Date.parse(value))).toBe(false);
+    expect(new Date(value).toISOString().slice(0, 10)).toBe('2026-06-15');
+  });
+
+  it('leaves a plain numeric cell alone when the destination column is a Number', async () => {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet('Sheet1');
+    sheet.addRow(['Quantity']);
+    sheet.addRow([42]);
+    const buffer = (await workbook.xlsx.writeBuffer()) as unknown as Buffer;
+
+    const columns: FileImportColumn[] = [
+      { key: 0, title: 'Quantity', column_name: 'Quantity', uidt: UITypes.Number },
+    ];
+
+    const rows = await collectRows(buffer, columns);
+
+    expect(rows[0]['Quantity']).toBe(42);
+  });
+});

--- a/packages/nocodb/src/modules/jobs/jobs/data-import/handlers/excel-import.handler.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/data-import/handlers/excel-import.handler.ts
@@ -1,4 +1,5 @@
 import ExcelJS from 'exceljs';
+import { UITypes } from 'nocodb-sdk';
 import type { Readable } from 'stream';
 import type {
   FileImportColumn,
@@ -23,7 +24,28 @@ type NamedWorksheetReader = ExcelJS.stream.xlsx.WorksheetReader & {
   name?: string;
 };
 
-function resolveCellValue(cell: ExcelJS.Cell): any {
+const DATE_LIKE_UIDTS: ReadonlySet<string> = new Set([
+  UITypes.Date,
+  UITypes.DateTime,
+  UITypes.Time,
+  UITypes.CreatedTime,
+  UITypes.LastModifiedTime,
+]);
+
+/**
+ * Excel serial date -> ISO string, mirroring exceljs's own `utils.excelToDate`
+ * (days since 1899-12-30). We can't rely on exceljs to do this for us because
+ * `styles: 'ignore'` above skips parsing styles.xml, so numFmt-based date
+ * detection never fires and date-formatted cells surface as plain numbers.
+ * Assumes the 1900 date system (date1904 = false), which covers the vast
+ * majority of real-world workbooks.
+ */
+function excelSerialToIsoDate(serial: number): string {
+  const millisecondSinceEpoch = Math.round((serial - 25569) * 24 * 3600 * 1000);
+  return new Date(millisecondSinceEpoch).toISOString();
+}
+
+function resolveCellValue(cell: ExcelJS.Cell, uidt?: string): any {
   const value = cell.value;
   if (value === null || value === undefined) return null;
 
@@ -43,6 +65,9 @@ function resolveCellValue(cell: ExcelJS.Cell): any {
   }
   if (value instanceof Date) {
     return value.toISOString();
+  }
+  if (typeof value === 'number' && uidt && DATE_LIKE_UIDTS.has(uidt)) {
+    return excelSerialToIsoDate(value);
   }
   return value;
 }
@@ -141,9 +166,9 @@ export class ExcelImportHandler implements DataImportHandler {
   ): AsyncGenerator<ImportRow, void, undefined> {
     const firstRowAsHeaders = parserConfig.firstRowAsHeaders !== false;
 
-    const colNameByIndex: Record<number, string> = {};
+    const colByIndex: Record<number, FileImportColumn> = {};
     for (const col of columns) {
-      colNameByIndex[col.key] = col.column_name;
+      colByIndex[col.key] = col;
     }
 
     const workbookReader = new ExcelJS.stream.xlsx.WorkbookReader(
@@ -169,8 +194,8 @@ export class ExcelImportHandler implements DataImportHandler {
 
         const record: ImportRow = {};
         row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
-          const colName = colNameByIndex[colNumber - 1];
-          if (colName) record[colName] = resolveCellValue(cell);
+          const col = colByIndex[colNumber - 1];
+          if (col) record[col.column_name] = resolveCellValue(cell, col.uidt);
         });
         yield record;
       }


### PR DESCRIPTION
## Change Summary

Fixes #14275 — xlsx import fails with "column ... is of type date but
expression is of type integer" when importing a date-formatted Excel
column into a Date-typed NocoDB field.

Root cause: Excel stores dates as plain numbers with the "this is a
date" formatting info living separately in styles.xml. ExcelImportHandler
reads workbooks with `styles: 'ignore'` for performance, so that
formatting info (and therefore ExcelJS's own date detection) is never
parsed — date cells surface as raw serial numbers and get inserted
as-is into the DB.

Fix: convert the raw serial number to an ISO date whenever the
*destination* column's type (already known from the column mapping) is
Date/DateTime/Time/CreatedTime/LastModifiedTime — no change to the
existing `styles: 'ignore'` performance behavior for other column types.

Testing:
- Added a unit test that builds a real xlsx via ExcelJS with a
  date-formatted cell and confirms it round-trips correctly.
- Manually reproduced the original bug end-to-end against a real
  Postgres instance (via ExcelImportHandler + knex), confirmed the
  exact failure without the fix, and confirmed a clean insert with it.

closes: #14275

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [x] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)
