### PR TITLE
fix: widen nc_operation_logs.entity_id to text

### DIFF
--- a/packages/nocodb/src/meta/migrations/XcMigrationSourcev0.ts
+++ b/packages/nocodb/src/meta/migrations/XcMigrationSourcev0.ts
@@ -86,6 +86,7 @@ import * as nc_202607030001_ltar_order_columns from './v0/nc_202607030001_ltar_o
 import * as nc_202607071200_comment_attachments from './v0/nc_202607071200_comment_attachments';
 import * as nc_202607090505_snapshot_schedule from './v0/nc_202607090505_snapshot_schedule';
 import * as nc_202607091000_comments_meta from './v0/nc_202607091000_comments_meta';
+import * as nc_202607180000_widen_operation_logs_entity_id from './v0/nc_202607180000_widen_operation_logs_entity_id';
 
 // Create a custom migration source class
 export default class XcMigrationSourcev0 {
@@ -183,6 +184,7 @@ export default class XcMigrationSourcev0 {
       'nc_202607071200_comment_attachments',
       'nc_202607090505_snapshot_schedule',
       'nc_202607091000_comments_meta',
+      'nc_202607180000_widen_operation_logs_entity_id',
     ]);
   }
 
@@ -368,6 +370,8 @@ export default class XcMigrationSourcev0 {
         return nc_202607090505_snapshot_schedule;
       case 'nc_202607091000_comments_meta':
         return nc_202607091000_comments_meta;
+      case 'nc_202607180000_widen_operation_logs_entity_id':
+        return nc_202607180000_widen_operation_logs_entity_id;
     }
   }
 }

--- a/packages/nocodb/src/meta/migrations/v0/nc_202607180000_widen_operation_logs_entity_id.ts
+++ b/packages/nocodb/src/meta/migrations/v0/nc_202607180000_widen_operation_logs_entity_id.ts
@@ -1,0 +1,20 @@
+import type { Knex } from 'knex';
+import { MetaTable } from '~/utils/globals';
+
+// `entity_id` stores the *user's own* primary key value for the record an
+// undo/redo op applies to, not a NocoDB-internal id — it was sized for the
+// latter (varchar(20)) and truncates on any external table with a longer
+// text PK, throwing StringDataRightTruncation on every edit.
+const up = async (knex: Knex) => {
+  await knex.schema.alterTable(MetaTable.OPERATION_LOGS, (table) => {
+    table.text('entity_id').alter();
+  });
+};
+
+const down = async (knex: Knex) => {
+  await knex.schema.alterTable(MetaTable.OPERATION_LOGS, (table) => {
+    table.string('entity_id', 20).alter();
+  });
+};
+
+export { up, down };


### PR DESCRIPTION
## Summary
Fixes #14285 — `nc_operation_logs.entity_id` is `varchar(20)`, sized for
NocoDB-internal ids, but it actually stores the *user's own* primary key
value for the record an undo/redo op applies to. Any external-DB table
with a text PK longer than 20 characters throws
`StringDataRightTruncation` on every edit, silently disabling undo/redo
for that record (the record update itself still succeeds).

## Fix
New migration widening `entity_id` to `text`, following the exact same
pattern as the existing `form_view.email` widen migration
(`nc_202606180000_form_view_email_text.ts`).

## Testing
Reproduced against a real Postgres instance using the actual migration
schema: confirmed the original varchar(20) column throws
`value too long for type character varying(20)` on a realistic long
text PK, then confirmed the same insert succeeds and round-trips
correctly once the new migration runs.

closes: #14285
