### PR TITLE
fix(gui): respect NC_SITE_URL pathname as Nuxt app.baseURL for subpath deployments

### DIFF
--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -8,6 +8,21 @@ import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfil
 import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 
 import PurgeIcons from 'vite-plugin-purge-icons'
+
+// Derive app.baseURL from NC_SITE_URL so subpath deployments
+// (e.g. https://host/nocodb/) serve assets at the correct path.
+// Falls back to '/' when NC_SITE_URL is unset or has no meaningful pathname.
+const _ncSiteUrl = process.env.NC_SITE_URL || '/'
+let _appBaseURL = '/'
+try {
+  const _pathname = new URL(_ncSiteUrl).pathname
+  if (_pathname && _pathname !== '/') {
+    _appBaseURL = _pathname.endsWith('/') ? _pathname : `${_pathname}/`
+  }
+} catch {
+  // NC_SITE_URL is not a valid absolute URL (e.g. just '/') — keep default
+}
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   future: {
@@ -37,6 +52,7 @@ export default defineNuxtConfig({
   spaLoadingTemplate: false,
 
   app: {
+    baseURL: _appBaseURL,
     pageTransition: process.env.NUXT_PAGE_TRANSITION_DISABLE
       ? false
       : {


### PR DESCRIPTION
Fixes #13870

**Problem**

When NocoDB is deployed at a subpath (e.g. `https://host/nocodb/`), Nuxt emits all static assets with root-relative paths (`/_nuxt/...`). These 404 because the reverse proxy expects them at `/nocodb/_nuxt/...`. The `NC_SITE_URL` env var already carries the correct base URL but `nuxt.config.ts` never read it for `app.baseURL`.

**Fix**

Read `NC_SITE_URL` at build time in `nuxt.config.ts`, extract the pathname, and set it as `app.baseURL`:

```typescript
const _ncSiteUrl = process.env.NC_SITE_URL || '/'
let _appBaseURL = '/'
try {
  const _pathname = new URL(_ncSiteUrl).pathname
  if (_pathname && _pathname !== '/') {
    _appBaseURL = _pathname.endsWith('/') ? _pathname : `${_pathname}/`
  }
} catch {
  // NC_SITE_URL is not a valid absolute URL — keep default '/'
}
```

**Default case is safe:** when `NC_SITE_URL` is unset, not a valid absolute URL, or resolves to `/`, `_appBaseURL` stays `'/'` — no behaviour change for root deployments.