### PR TITLE
fix: disable legacy_alter_table for SQLite DROP COLUMN support

### DIFF
--- a/packages/nocodb/src/db/sql-client/lib/sqlite/SqliteClient.ts
+++ b/packages/nocodb/src/db/sql-client/lib/sqlite/SqliteClient.ts
@@ -1625,7 +1625,7 @@ class SqliteClient extends KnexClient {
       if (fkCheckEnabled)
         await this.sqlClient.raw('PRAGMA foreign_keys = OFF;');
 
-      await this.sqlClient.raw('PRAGMA legacy_alter_table = ON;');
+      await this.sqlClient.raw('PRAGMA legacy_alter_table = OFF;');
 
       /*
         This is a hack to avoid the following error:


### PR DESCRIPTION
## Description

Fixes [#14299](https://github.com/nocodb/nocodb/issues/14299) - users cannot delete or modify fields on a connected SQLite database. The error `SQLITE_ERROR: SQL logic error` appears when attempting `ALTER TABLE ... DROP COLUMN`.

## Root Cause

The code was setting `PRAGMA legacy_alter_table = ON` before the column modification transaction. When `legacy_alter_table` is ON (the legacy compatibility mode), SQLite only supports `RENAME TABLE` and `ADD COLUMN`. The `DROP COLUMN` operation requires `legacy_alter_table = OFF`.

## Fix

Changed `PRAGMA legacy_alter_table = ON` to `PRAGMA legacy_alter_table = OFF` in `SqliteClient.ts`. The finally block already unconditionally resets it to `OFF` after the transaction, so the post-transaction state is unchanged.

Closes #14299