### PR TITLE
fix(nc-gui): tab jumps to next enterable field in grid view

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useKeyboardNavigation.ts
@@ -1,12 +1,13 @@
 import { type ColumnType, UITypes } from 'nocodb-sdk'
-import { NO_EDITABLE_CELL } from '../utils/cell'
-import { EDIT_INTERACTABLE } from '../utils/constants'
+import { EDIT_INTERACTABLE, NO_EDITABLE_CELL } from '../utils/constants'
 import { findFirstExpandedGroupWithPath, findGroupByPath, getDefaultGroupData } from '../utils/groupby'
+import { findNextNavigableCellPosition, isLastNavigableColumnInRow } from '../utils/keyboardNavigation'
 
 // column types which support delete even when it's in edit state
 const EDIT_MODE_CLEARABLE_TYPES = [UITypes.SingleSelect, UITypes.MultiSelect, UITypes.User, UITypes.GeoData]
 
 const MIN_COLUMN_INDEX = 1
+
 export function useKeyboardNavigation({
   activeCell,
   columns,
@@ -373,7 +374,11 @@ export function useKeyboardNavigation({
       case 'Tab': {
         let isAdded = false
         e.preventDefault()
-        if (!e.shiftKey && activeCell.value.row === lastRow && activeCell.value.column === lastCol) {
+        if (
+          !e.shiftKey &&
+          activeCell.value.row === lastRow &&
+          isLastNavigableColumnInRow(columns.value, activeCell.value.column, lastCol)
+        ) {
           if (isAddingEmptyRowAllowed.value && !removeInlineAddRecord.value && isAddingEmptyRowPermitted.value) {
             addEmptyRow(undefined, false, undefined, defaultData, groupPath)
             isAdded = true
@@ -382,21 +387,17 @@ export function useKeyboardNavigation({
           return
         }
 
-        if (e.shiftKey) {
-          if (activeCell.value.column > MIN_COLUMN_INDEX) {
-            activeCell.value.column--
-          } else if (activeCell.value.row > 0) {
-            activeCell.value.row--
-            activeCell.value.column = lastCol
-          }
-        } else {
-          if (activeCell.value.column < lastCol) {
-            activeCell.value.column++
-          } else if (activeCell.value.row < (isAdded ? lastRow + 1 : lastRow)) {
-            activeCell.value.row++
-            activeCell.value.column = MIN_COLUMN_INDEX
-          }
-        }
+        const nextPosition = findNextNavigableCellPosition({
+          row: activeCell.value.row,
+          column: activeCell.value.column,
+          columns: columns.value,
+          lastRow: isAdded ? lastRow + 1 : lastRow,
+          lastCol,
+          isShiftKey: e.shiftKey,
+        })
+
+        activeCell.value.row = nextPosition.row
+        activeCell.value.column = nextPosition.column
         moved = true
         break
       }

--- a/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/index.vue
@@ -25,13 +25,14 @@ import { clearTextCache, defaultOffscreen2DContext, isBoxHovered, renderSingleLi
 import Tooltip from './components/Tooltip.vue'
 import Scroller from './components/Scroller.vue'
 import { columnTypeName, getCustomColumnTooltip } from './utils/headerUtils'
-import { MouseClickType, NO_EDITABLE_CELL, getMouseClickType, parseCellWidth } from './utils/cell'
+import { MouseClickType, getMouseClickType, parseCellWidth } from './utils/cell'
 import {
   ADD_NEW_COLUMN_WIDTH,
   AGGREGATION_HEIGHT,
   GROUP_HEADER_HEIGHT,
   GROUP_PADDING,
   MAX_SELECTED_ROWS,
+  NO_EDITABLE_CELL,
 } from './utils/constants'
 import { calculateGroupRowTop, comparePath, findGroupByPath, generateGroupPath, getDefaultGroupData } from './utils/groupby'
 import { CanvasElement, ElementTypes } from './utils/CanvasElement'

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
@@ -117,19 +117,6 @@ export const getUserColOptions = (column: ColumnType, baseUsers: (Partial<UserTy
   return colOptions
 }
 
-export const NO_EDITABLE_CELL = [
-  UITypes.Rating,
-  UITypes.Checkbox,
-  UITypes.ID,
-  UITypes.Rollup,
-  UITypes.CreatedBy,
-  UITypes.LastModifiedBy,
-  UITypes.LastModifiedTime,
-  UITypes.CreatedTime,
-  UITypes.Formula,
-  UITypes.UUID,
-]
-
 export const renderAsCellLookupOrLtarValue = [
   UITypes.SingleSelect,
   UITypes.MultiSelect,

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/constants.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/constants.ts
@@ -5,6 +5,18 @@ export const CELL_BOTTOM_BORDER_IN_PX = 1
 export const MAX_SELECTED_ROWS = 100
 export const ADD_NEW_COLUMN_WIDTH = 60
 export const EDIT_INTERACTABLE = [UITypes.SingleSelect, UITypes.MultiSelect, UITypes.User, UITypes.Links]
+export const NO_EDITABLE_CELL = [
+  UITypes.Rating,
+  UITypes.Checkbox,
+  UITypes.ID,
+  UITypes.Rollup,
+  UITypes.CreatedBy,
+  UITypes.LastModifiedBy,
+  UITypes.LastModifiedTime,
+  UITypes.CreatedTime,
+  UITypes.Formula,
+  UITypes.UUID,
+]
 export const ROW_META_COLUMN_WIDTH = 80
 export const ROW_COLOR_BORDER_WIDTH = 4
 

--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/keyboardNavigation.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/keyboardNavigation.ts
@@ -1,0 +1,74 @@
+import type { UITypes } from 'nocodb-sdk'
+import type { CanvasGridColumn } from '../../../../../lib/types'
+import { NO_EDITABLE_CELL } from './constants'
+
+const MIN_COLUMN_INDEX = 1
+
+export function isNavigableColumn(column: CanvasGridColumn | undefined) {
+  return (
+    !!column &&
+    !column.readonly &&
+    !column.isSyncedColumn &&
+    column.isCellEditable &&
+    !NO_EDITABLE_CELL.includes(column.columnObj?.uidt as UITypes) &&
+    !column.columnObj?.readonly
+  )
+}
+
+export function isLastNavigableColumnInRow(columns: Array<CanvasGridColumn | undefined>, column: number, lastCol: number) {
+  for (let i = column + 1; i <= lastCol; i++) {
+    if (isNavigableColumn(columns[i])) return false
+  }
+  return true
+}
+
+export function findNextNavigableCellPosition({
+  row,
+  column,
+  columns,
+  lastRow,
+  lastCol,
+  isShiftKey,
+}: {
+  row: number
+  column: number
+  columns: Array<CanvasGridColumn | undefined>
+  lastRow: number
+  lastCol: number
+  isShiftKey: boolean
+}) {
+  let currentRow = row
+  let currentColumn = column
+  const totalPositions = (lastRow + 1) * (lastCol + 1)
+
+  for (let attempt = 0; attempt < totalPositions; attempt++) {
+    if (isShiftKey) {
+      if (currentColumn > MIN_COLUMN_INDEX) {
+        currentColumn--
+      } else if (currentRow > 0) {
+        currentRow--
+        currentColumn = lastCol
+      } else {
+        break
+      }
+    } else {
+      if (currentColumn < lastCol) {
+        currentColumn++
+      } else if (currentRow < lastRow) {
+        currentRow++
+        currentColumn = MIN_COLUMN_INDEX
+      } else {
+        break
+      }
+    }
+
+    if (currentColumn >= MIN_COLUMN_INDEX && currentColumn <= lastCol && isNavigableColumn(columns[currentColumn])) {
+      return { row: currentRow, column: currentColumn }
+    }
+  }
+
+  return {
+    row: Math.min(Math.max(row, 0), lastRow),
+    column: Math.min(Math.max(column, MIN_COLUMN_INDEX), lastCol),
+  }
+}

--- a/packages/nc-gui/test/grid-keyboard-navigation.test.ts
+++ b/packages/nc-gui/test/grid-keyboard-navigation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { UITypes } from 'nocodb-sdk'
+import { findNextNavigableCellPosition } from '../components/smartsheet/grid/canvas/utils/keyboardNavigation'
+
+function createColumn(uidt: UITypes, overrides: Record<string, any> = {}) {
+  return {
+    id: `${uidt}-${Math.random()}`,
+    readonly: false,
+    isCellEditable: overrides.isCellEditable ?? true,
+    isSyncedColumn: false,
+    columnObj: {
+      uidt,
+      readonly: false,
+      ...overrides.columnObj,
+    },
+    ...overrides,
+  }
+}
+
+describe('findNextNavigableCellPosition', () => {
+  it('skips non-editable columns and moves to the next editable one', () => {
+    const columns = [
+      createColumn(UITypes.AutoNumber),
+      createColumn(UITypes.Rating, { isCellEditable: false }),
+      createColumn(UITypes.SingleLineText),
+      createColumn(UITypes.Checkbox),
+    ]
+
+    const nextCell = findNextNavigableCellPosition({
+      row: 0,
+      column: 1,
+      columns,
+      lastRow: 0,
+      lastCol: columns.length - 1,
+      isShiftKey: false,
+    })
+
+    expect(nextCell).toEqual({ row: 0, column: 2 })
+  })
+
+  it('moves backwards to the previous editable column when shift-tab is used', () => {
+    const columns = [
+      createColumn(UITypes.AutoNumber),
+      createColumn(UITypes.SingleLineText),
+      createColumn(UITypes.Rating, { isCellEditable: false }),
+      createColumn(UITypes.SingleLineText),
+    ]
+
+    const nextCell = findNextNavigableCellPosition({
+      row: 0,
+      column: 3,
+      columns,
+      lastRow: 0,
+      lastCol: columns.length - 1,
+      isShiftKey: true,
+    })
+
+    expect(nextCell).toEqual({ row: 0, column: 1 })
+  })
+})


### PR DESCRIPTION
Grid view: Tab now jumps to the next fillable-in field instead of every column.

Previously, pressing Tab moved to the literal next column regardless of
whether it could be edited — so tabbing through a row would stop on
Checkbox, Rating, Formula, Rollup, and similar read-only fields, forcing
users to tab past them manually.

Now Tab/Shift+Tab skip those column types and land only on fields you can
actually type into. This also fixes a knock-on issue: the "pressing Tab at
the end of the last row adds a new row" behavior used to check whether you
were on the grid's literal last column — which broke if that last column
happened to be a non-editable type (e.g. a trailing Formula or CreatedTime
field), since the cursor could never land there anymore. It now checks for
the last fillable-in column instead, so adding a new row via Tab still
works correctly.

Fixes #13916

- Added unit tests (test/grid-keyboard-navigation.test.ts) covering
  forward/backward skip-over-non-editable-column behavior.
- Manually verified in the browser: built a table with Name/Notes
  (editable) followed by IsDone (Checkbox), Score (Rating), and Summary
  (Formula) as the last column.
  - Tab from Notes correctly skipped IsDone/Score/Summary and landed on
    the next row's Name field.
  - Tab from Notes on the last row correctly added a new row, even though
    the grid's actual last column (Summary) is non-editable.

No breaking changes. Also removed a duplicated NO_EDITABLE_CELL column-type
list — it now lives in one place (utils/constants.ts) instead of being
defined twice.
