### PR TITLE
fix(ai): fall back to plain generateText when structured output fails on OpenAI-compatible endpoints

### DIFF
--- a/packages/noco-integrations/core/src/ai/types.ts
+++ b/packages/noco-integrations/core/src/ai/types.ts
@@ -316,23 +316,55 @@ export abstract class AiIntegration<
     const model = this.getModel({ customModel: args.customModel });
     const tools = args.websearch ? this.webSearchTool() : undefined;
 
-    const response = await sdkGenerateText({
-      model,
-      output: Output.object({ schema: args.schema }),
-      messages: args.messages,
-      temperature: this.temperature,
-      ...(tools ? { tools } : {}),
-    });
+    try {
+      const response = await sdkGenerateText({
+        model,
+        output: Output.object({ schema: args.schema }),
+        messages: args.messages,
+        temperature: this.temperature,
+        ...(tools ? { tools } : {}),
+      });
 
-    return {
-      usage: {
-        input_tokens: response.usage.inputTokens,
-        output_tokens: response.usage.outputTokens,
-        total_tokens: response.usage.totalTokens,
-        model: model.modelId,
-      },
-      data: response.output as T,
-    };
+      return {
+        usage: {
+          input_tokens: response.usage.inputTokens,
+          output_tokens: response.usage.outputTokens,
+          total_tokens: response.usage.totalTokens,
+          model: model.modelId,
+        },
+        data: response.output as T,
+      };
+    } catch (err: any) {
+      // OpenAI-compatible endpoints (Ollama, local models, etc.) may not support
+      // structured output mode and return plain text instead, causing
+      // AI_NoObjectGeneratedError. Fall back to plain generateText and parse JSON
+      // from the text response.
+      if (err?.name !== 'AI_NoObjectGeneratedError') {
+        throw err;
+      }
+
+      const fallbackResponse = await sdkGenerateText({
+        model,
+        messages: args.messages,
+        temperature: this.temperature,
+        ...(tools ? { tools } : {}),
+      });
+
+      const jsonText = fallbackResponse.text.trim();
+      // Strip markdown code fences if the model wraps the JSON
+      const stripped = jsonText.replace(/^```(?:json)?\n?/, '').replace(/\n?```$/, '');
+      const parsed = JSON.parse(stripped) as T;
+
+      return {
+        usage: {
+          input_tokens: fallbackResponse.usage.inputTokens,
+          output_tokens: fallbackResponse.usage.outputTokens,
+          total_tokens: fallbackResponse.usage.totalTokens,
+          model: model.modelId,
+        },
+        data: parsed,
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #14268.

`generateObject()` in `noco-integrations` uses the Vercel AI SDK's `Output.object({ schema })` mode, which requires the provider to support structured output. OpenAI-compatible endpoints (Ollama, llama.cpp, local models) often don't implement this and return plain text, causing `AI_NoObjectGeneratedError` to bubble up uncaught.

When that specific error is thrown, the call is retried as a plain `generateText` request (no structured output mode). The text response is then parsed as JSON after stripping any markdown code fences the model may have added. All other errors are re-thrown unchanged.