### PR TITLE
feat: surface removed column impacts in meta diff

### DIFF
--- a/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
+++ b/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
@@ -1,8 +1,12 @@
 import { ModelTypes, UITypes } from 'nocodb-sdk';
-import { collectRemovedColumnImpact } from '~/helpers/metaDiffImpact';
+import {
+  attachRemovedColumnImpacts,
+  collectRemovedColumnImpact,
+} from '~/helpers/metaDiffImpact';
 import type {
   FormulaDependencyResolver,
   ImpactColumn,
+  RemovedColumnImpact,
 } from '~/helpers/metaDiffImpact';
 import type { NcContext } from '~/interface/config';
 
@@ -19,10 +23,11 @@ type RemovedColumnMetaDiff = {
   source_id: string;
   type: ModelTypes;
   detectedChanges: Array<{
-    type: 'TABLE_COLUMN_REMOVE' | 'VIEW_COLUMN_REMOVE';
+    type: 'TABLE_COLUMN_REMOVE' | 'VIEW_COLUMN_REMOVE' | 'TABLE_COLUMN_ADD';
     cn: string;
-    column: TestColumn;
+    column?: TestColumn;
     msg?: string;
+    id?: string;
   }>;
 };
 
@@ -184,5 +189,97 @@ describe('Meta Diff removed-column impact discovery', () => {
     expect(JSON.stringify(columns)).toBe(columnsBefore);
     expect(JSON.stringify(metaDiffs)).toBe(diffBefore);
     expect(columnsByModelId.get(modelId)).toBe(columns);
+  });
+});
+
+describe('Meta Diff removed-column impact enrichment', () => {
+  it('attaches matching impacts to removed columns without changing unrelated changes', () => {
+    const firstRemovedColumn = makeColumn();
+    const secondRemovedColumn = makeColumn({
+      id: 'cl_removed_other',
+      title: 'Other Removed',
+      column_name: 'removed_other',
+    });
+    const formulaImpact: RemovedColumnImpact = {
+      dependencyType: 'formula',
+      removedColumnId: firstRemovedColumn.id,
+      resource: {
+        id: 'cl_formula',
+        title: 'Total Label',
+        uidt: UITypes.Formula,
+      },
+    };
+    const buttonImpact: RemovedColumnImpact = {
+      dependencyType: 'button',
+      removedColumnId: secondRemovedColumn.id,
+      resource: {
+        id: 'cl_button',
+        title: 'Open Invoice',
+        uidt: UITypes.Button,
+      },
+    };
+    const unrelatedChange = {
+      type: 'TABLE_COLUMN_ADD' as const,
+      cn: 'new_column',
+      id: modelId,
+      msg: 'New column(new_column)',
+    };
+    const metaDiffs: RemovedColumnMetaDiff[] = [
+      {
+        table_name: 'orders',
+        source_id: 'ds_external',
+        type: ModelTypes.TABLE,
+        detectedChanges: [
+          {
+            type: 'TABLE_COLUMN_REMOVE',
+            cn: firstRemovedColumn.column_name,
+            column: firstRemovedColumn,
+          },
+          unrelatedChange,
+          {
+            type: 'VIEW_COLUMN_REMOVE',
+            cn: secondRemovedColumn.column_name,
+            column: secondRemovedColumn,
+          },
+        ],
+      },
+    ];
+
+    const enriched = attachRemovedColumnImpacts(metaDiffs, [
+      formulaImpact,
+      buttonImpact,
+    ]);
+
+    expect(enriched).not.toBe(metaDiffs);
+    expect(enriched[0]).not.toBe(metaDiffs[0]);
+    expect(enriched[0].detectedChanges).not.toBe(metaDiffs[0].detectedChanges);
+    expect(enriched[0].detectedChanges?.[0]).toEqual({
+      ...metaDiffs[0].detectedChanges[0],
+      impacts: [formulaImpact],
+    });
+    expect(enriched[0].detectedChanges?.[1]).toEqual(unrelatedChange);
+    expect(enriched[0].detectedChanges?.[1]).not.toHaveProperty('impacts');
+    expect(enriched[0].detectedChanges?.[2]).toEqual({
+      ...metaDiffs[0].detectedChanges[2],
+      impacts: [buttonImpact],
+    });
+  });
+
+  it('attaches an empty impact collection and does not mutate inputs', () => {
+    const removedColumn = makeColumn();
+    const metaDiffs = [makeRemovedColumnDiff(removedColumn)];
+    const impacts: RemovedColumnImpact[] = [];
+    const diffBefore = JSON.stringify(metaDiffs);
+    const impactsBefore = JSON.stringify(impacts);
+
+    const enriched = attachRemovedColumnImpacts(metaDiffs, impacts);
+
+    expect(enriched[0].detectedChanges?.[0]).toEqual({
+      ...metaDiffs[0].detectedChanges[0],
+      impacts: [],
+    });
+    expect(JSON.stringify(metaDiffs)).toBe(diffBefore);
+    expect(JSON.stringify(impacts)).toBe(impactsBefore);
+    expect(metaDiffs[0].detectedChanges[0]).not.toHaveProperty('impacts');
   });
 });

--- a/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
+++ b/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
@@ -76,6 +76,230 @@ const collectImpact = (
   });
 
 describe('Meta Diff removed-column impact discovery', () => {
+  it('keeps impacts isolated and ordered when multiple columns are removed', async () => {
+    const secondModelId = 'md_invoices';
+    const firstRemovedColumn = makeColumn({
+      id: 'cl_removed_first',
+      title: 'First Removed',
+      column_name: 'removed_first',
+    });
+    const secondRemovedColumn = makeColumn({
+      id: 'cl_removed_second',
+      title: 'Second Removed',
+      column_name: 'removed_second',
+      fk_model_id: secondModelId,
+    });
+    const firstFormula = makeColumn({
+      id: 'cl_formula_first',
+      title: 'First Formula',
+      uidt: UITypes.Formula,
+    });
+    const firstButton = makeColumn({
+      id: 'cl_button_first',
+      title: 'First Button',
+      uidt: UITypes.Button,
+    });
+    const secondFormula = makeColumn({
+      id: 'cl_formula_second',
+      title: 'Second Formula',
+      uidt: UITypes.Formula,
+      fk_model_id: secondModelId,
+    });
+    const firstModelColumns = [firstRemovedColumn, firstFormula, firstButton];
+    const secondModelColumns = [secondRemovedColumn, secondFormula];
+    const metaDiffs: RemovedColumnMetaDiff[] = [
+      {
+        table_name: 'orders',
+        source_id: 'ds_external',
+        type: ModelTypes.TABLE,
+        detectedChanges: [
+          {
+            type: 'TABLE_COLUMN_REMOVE',
+            cn: firstRemovedColumn.column_name,
+            column: firstRemovedColumn,
+          },
+        ],
+      },
+      {
+        table_name: 'invoices',
+        source_id: 'ds_external',
+        type: ModelTypes.TABLE,
+        detectedChanges: [
+          {
+            type: 'TABLE_COLUMN_REMOVE',
+            cn: secondRemovedColumn.column_name,
+            column: secondRemovedColumn,
+          },
+        ],
+      },
+    ];
+    const resolveFormulaDependencies = jest
+      .fn<Promise<ImpactColumn[]>, Parameters<FormulaDependencyResolver>>()
+      .mockResolvedValueOnce([firstFormula, firstButton])
+      .mockResolvedValueOnce([secondFormula]);
+
+    const impact = await collectRemovedColumnImpact(context, {
+      metaDiffs,
+      columnsByModelId: new Map([
+        [modelId, firstModelColumns],
+        [secondModelId, secondModelColumns],
+      ]),
+      resolveFormulaDependencies,
+    });
+    const enriched = attachRemovedColumnImpacts(metaDiffs, impact);
+
+    expect(resolveFormulaDependencies).toHaveBeenCalledTimes(2);
+    expect(resolveFormulaDependencies.mock.calls).toEqual([
+      [context, { column: firstRemovedColumn, columns: firstModelColumns }],
+      [context, { column: secondRemovedColumn, columns: secondModelColumns }],
+    ]);
+    expect(impact.map((item) => item.removedColumnId)).toEqual([
+      firstRemovedColumn.id,
+      firstRemovedColumn.id,
+      secondRemovedColumn.id,
+    ]);
+    expect(impact.map((item) => item.resource.id)).toEqual([
+      firstFormula.id,
+      firstButton.id,
+      secondFormula.id,
+    ]);
+    expect(
+      enriched[0].detectedChanges?.[0].impacts?.map((item) => item.resource.id),
+    ).toEqual([firstFormula.id, firstButton.id]);
+    expect(
+      enriched[1].detectedChanges?.[0].impacts?.map((item) => item.resource.id),
+    ).toEqual([secondFormula.id]);
+    expect(enriched[0].detectedChanges?.[0].impacts).not.toContainEqual(
+      expect.objectContaining({ removedColumnId: secondRemovedColumn.id }),
+    );
+    expect(enriched[1].detectedChanges?.[0].impacts).not.toContainEqual(
+      expect.objectContaining({ removedColumnId: firstRemovedColumn.id }),
+    );
+  });
+
+  it('collects and attaches impacts for removed view columns', async () => {
+    const removedColumn = makeColumn({
+      id: 'cl_view_removed',
+      title: 'View Removed',
+      column_name: 'view_removed',
+    });
+    const buttonColumn = makeColumn({
+      id: 'cl_view_button',
+      title: 'Open View URL',
+      uidt: UITypes.Button,
+    });
+    const columns = [removedColumn, buttonColumn];
+    const metaDiffs: RemovedColumnMetaDiff[] = [
+      {
+        table_name: 'orders_view',
+        source_id: 'ds_external',
+        type: ModelTypes.VIEW,
+        detectedChanges: [
+          {
+            type: 'VIEW_COLUMN_REMOVE',
+            cn: removedColumn.column_name,
+            column: removedColumn,
+          },
+        ],
+      },
+    ];
+    const resolveFormulaDependencies = makeResolver([buttonColumn]);
+
+    const impact = await collectImpact(
+      metaDiffs,
+      columns,
+      resolveFormulaDependencies,
+    );
+    const enriched = attachRemovedColumnImpacts(metaDiffs, impact);
+
+    expect(resolveFormulaDependencies).toHaveBeenCalledTimes(1);
+    expect(resolveFormulaDependencies).toHaveBeenCalledWith(context, {
+      column: removedColumn,
+      columns,
+    });
+    expect(impact).toEqual([
+      {
+        dependencyType: 'button',
+        removedColumnId: removedColumn.id,
+        resource: {
+          id: buttonColumn.id,
+          title: buttonColumn.title,
+          uidt: buttonColumn.uidt,
+        },
+      },
+    ]);
+    expect(enriched[0].detectedChanges?.[0]).toEqual({
+      ...metaDiffs[0].detectedChanges[0],
+      impacts: impact,
+    });
+  });
+
+  it('skips removed columns whose model columns are unavailable', async () => {
+    const removedColumn = makeColumn({
+      fk_model_id: 'md_missing',
+    });
+    const metaDiffs = [makeRemovedColumnDiff(removedColumn)];
+    const resolveFormulaDependencies = makeResolver([]);
+
+    await expect(
+      collectRemovedColumnImpact(context, {
+        metaDiffs,
+        columnsByModelId: new Map([[modelId, [removedColumn]]]),
+        resolveFormulaDependencies,
+      }),
+    ).resolves.toEqual([]);
+    expect(resolveFormulaDependencies).not.toHaveBeenCalled();
+
+    const enriched = attachRemovedColumnImpacts(metaDiffs, []);
+    expect(enriched[0].detectedChanges?.[0]).toEqual({
+      ...metaDiffs[0].detectedChanges[0],
+      impacts: [],
+    });
+  });
+
+  it('propagates resolver rejections', async () => {
+    const removedColumn = makeColumn();
+    const expectedError = new Error('formula resolver failed');
+    const resolveFormulaDependencies = jest
+      .fn<Promise<ImpactColumn[]>, Parameters<FormulaDependencyResolver>>()
+      .mockRejectedValue(expectedError);
+
+    await expect(
+      collectImpact(
+        [makeRemovedColumnDiff(removedColumn)],
+        [removedColumn],
+        resolveFormulaDependencies,
+      ),
+    ).rejects.toBe(expectedError);
+  });
+
+  it('ignores non-formula and non-button resolver results', async () => {
+    const removedColumn = makeColumn();
+    const physicalColumn = makeColumn({
+      id: 'cl_physical',
+      title: 'Physical Column',
+      column_name: 'physical',
+      uidt: UITypes.SingleLineText,
+    });
+    const formulaColumn = makeColumn({
+      id: 'cl_formula',
+      title: 'Formula Column',
+      uidt: UITypes.Formula,
+    });
+    const resolveFormulaDependencies = makeResolver([
+      physicalColumn,
+      formulaColumn,
+    ]);
+
+    const impact = await collectImpact(
+      [makeRemovedColumnDiff(removedColumn)],
+      [removedColumn, physicalColumn, formulaColumn],
+      resolveFormulaDependencies,
+    );
+
+    expect(impact.map((item) => item.resource.id)).toEqual([formulaColumn.id]);
+  });
+
   it('maps resolver results, preserves order, and removes duplicate dependencies', async () => {
     const removedColumn = makeColumn();
     const firstFormula = makeColumn({

--- a/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
+++ b/packages/nocodb/src/helpers/metaDiffImpact.Source.spec.ts
@@ -1,0 +1,188 @@
+import { ModelTypes, UITypes } from 'nocodb-sdk';
+import { collectRemovedColumnImpact } from '~/helpers/metaDiffImpact';
+import type {
+  FormulaDependencyResolver,
+  ImpactColumn,
+} from '~/helpers/metaDiffImpact';
+import type { NcContext } from '~/interface/config';
+
+type TestColumn = ImpactColumn & {
+  id: string;
+  title: string;
+  column_name: string;
+  uidt: UITypes;
+  fk_model_id: string;
+};
+
+type RemovedColumnMetaDiff = {
+  table_name: string;
+  source_id: string;
+  type: ModelTypes;
+  detectedChanges: Array<{
+    type: 'TABLE_COLUMN_REMOVE' | 'VIEW_COLUMN_REMOVE';
+    cn: string;
+    column: TestColumn;
+    msg?: string;
+  }>;
+};
+
+const context = { workspace_id: 'ws_test', base_id: 'base_test' } as NcContext;
+const modelId = 'md_orders';
+
+const makeColumn = (overrides: Partial<TestColumn> = {}): TestColumn => ({
+  id: 'cl_removed',
+  title: 'Column4',
+  column_name: 'removed',
+  uidt: UITypes.SingleLineText,
+  fk_model_id: modelId,
+  ...overrides,
+});
+
+const makeRemovedColumnDiff = (
+  removedColumn: TestColumn,
+): RemovedColumnMetaDiff => ({
+  table_name: 'orders',
+  source_id: 'ds_external',
+  type: ModelTypes.TABLE,
+  detectedChanges: [
+    {
+      type: 'TABLE_COLUMN_REMOVE',
+      cn: removedColumn.column_name,
+      column: removedColumn,
+      msg: `Column ${removedColumn.title} removed`,
+    },
+  ],
+});
+
+const makeResolver = (dependencies: ImpactColumn[]) =>
+  jest
+    .fn<Promise<ImpactColumn[]>, Parameters<FormulaDependencyResolver>>()
+    .mockResolvedValue(dependencies);
+
+const collectImpact = (
+  metaDiffs: RemovedColumnMetaDiff[],
+  columns: TestColumn[],
+  resolveFormulaDependencies: FormulaDependencyResolver,
+) =>
+  collectRemovedColumnImpact(context, {
+    metaDiffs,
+    columnsByModelId: new Map([[modelId, columns]]),
+    resolveFormulaDependencies,
+  });
+
+describe('Meta Diff removed-column impact discovery', () => {
+  it('maps resolver results, preserves order, and removes duplicate dependencies', async () => {
+    const removedColumn = makeColumn();
+    const firstFormula = makeColumn({
+      id: 'cl_formula',
+      title: 'Total Label',
+      uidt: UITypes.Formula,
+    });
+    const buttonColumn = makeColumn({
+      id: 'cl_button',
+      title: 'Open Invoice',
+      uidt: UITypes.Button,
+    });
+    const unrelatedColumn = makeColumn({
+      id: 'cl_unrelated',
+      title: 'Column1',
+      column_name: 'unrelated',
+    });
+    const unrelatedFormulaColumn = makeColumn({
+      id: 'cl_unrelated_formula',
+      title: 'Unrelated Formula',
+      uidt: UITypes.Formula,
+    });
+    const secondFormula = makeColumn({
+      id: 'cl_formula_a',
+      title: 'A Formula',
+      uidt: UITypes.Formula,
+    });
+    const columns = [
+      removedColumn,
+      firstFormula,
+      buttonColumn,
+      unrelatedColumn,
+      unrelatedFormulaColumn,
+      secondFormula,
+    ];
+    const resolveFormulaDependencies = makeResolver([
+      firstFormula,
+      buttonColumn,
+      firstFormula,
+      secondFormula,
+    ]);
+
+    const impact = await collectImpact(
+      [makeRemovedColumnDiff(removedColumn)],
+      columns,
+      resolveFormulaDependencies,
+    );
+
+    expect(resolveFormulaDependencies).toHaveBeenCalledTimes(1);
+    expect(resolveFormulaDependencies).toHaveBeenCalledWith(context, {
+      column: removedColumn,
+      columns,
+    });
+    expect(impact.map((item) => item.resource.id)).toEqual([
+      firstFormula.id,
+      buttonColumn.id,
+      secondFormula.id,
+    ]);
+    expect(impact.map((item) => item.dependencyType)).toEqual([
+      'formula',
+      'button',
+      'formula',
+    ]);
+    expect(impact.map((item) => item.resource.id)).not.toContain(
+      unrelatedFormulaColumn.id,
+    );
+    expect(
+      impact.filter((item) => item.resource.id === firstFormula.id),
+    ).toHaveLength(1);
+  });
+
+  it('returns an empty collection when the resolver finds no references', async () => {
+    const removedColumn = makeColumn();
+    const columns = [removedColumn];
+    const resolveFormulaDependencies = makeResolver([]);
+
+    await expect(
+      collectImpact(
+        [makeRemovedColumnDiff(removedColumn)],
+        columns,
+        resolveFormulaDependencies,
+      ),
+    ).resolves.toEqual([]);
+    expect(resolveFormulaDependencies).toHaveBeenCalledTimes(1);
+    expect(resolveFormulaDependencies).toHaveBeenCalledWith(context, {
+      column: removedColumn,
+      columns,
+    });
+  });
+
+  it('does not mutate columns, metadata maps, or the input diff object', async () => {
+    const removedColumn = makeColumn();
+    const formulaColumn = makeColumn({
+      id: 'cl_formula',
+      title: 'Total Label',
+      uidt: UITypes.Formula,
+    });
+    const metaDiffs = [makeRemovedColumnDiff(removedColumn)];
+    const columns = [removedColumn, formulaColumn];
+    const columnsByModelId = new Map([[modelId, columns]]);
+    const resolveFormulaDependencies = makeResolver([formulaColumn]);
+    const columnsBefore = JSON.stringify(columns);
+    const diffBefore = JSON.stringify(metaDiffs);
+
+    await collectRemovedColumnImpact(context, {
+      metaDiffs,
+      columnsByModelId,
+      resolveFormulaDependencies,
+    });
+
+    expect(JSON.stringify(columns)).toBe(columnsBefore);
+    expect(JSON.stringify(metaDiffs)).toBe(diffBefore);
+    expect(columnsByModelId.get(modelId)).toBe(columns);
+  });
+});

--- a/packages/nocodb/src/helpers/metaDiffImpact.ts
+++ b/packages/nocodb/src/helpers/metaDiffImpact.ts
@@ -1,0 +1,116 @@
+import { UITypes } from 'nocodb-sdk';
+import type { NcContext } from '~/interface/config';
+
+type RemovedColumnChangeType = 'TABLE_COLUMN_REMOVE' | 'VIEW_COLUMN_REMOVE';
+
+export type ImpactColumn = {
+  id?: string;
+  title?: string;
+  uidt?: UITypes;
+  fk_model_id?: string;
+};
+
+export type FormulaDependencyResolver = (
+  context: NcContext,
+  params: {
+    column: ImpactColumn;
+    columns: ImpactColumn[];
+  },
+) => Promise<ImpactColumn[]>;
+
+type RemovedColumnChange = {
+  type?: RemovedColumnChangeType | string;
+  column?: ImpactColumn | null;
+};
+
+type MetaDiffWithDetectedChanges = {
+  detectedChanges?: RemovedColumnChange[] | null;
+};
+
+export type RemovedColumnImpact = {
+  dependencyType: 'formula' | 'button';
+  removedColumnId: string;
+  resource: {
+    id: string;
+    title: string;
+    uidt: UITypes;
+  };
+};
+
+const removedColumnChangeTypes = new Set<string>([
+  'TABLE_COLUMN_REMOVE',
+  'VIEW_COLUMN_REMOVE',
+]);
+
+const isFormulaOrButtonColumn = (column?: ImpactColumn | null) =>
+  column?.uidt === UITypes.Formula || column?.uidt === UITypes.Button;
+
+const hasRequiredColumnIdentity = (
+  column?: ImpactColumn | null,
+): column is ImpactColumn & { id: string; title: string; uidt: UITypes } =>
+  !!column?.id && !!column?.title && !!column?.uidt;
+
+export async function collectRemovedColumnImpact(
+  context: NcContext,
+  {
+    metaDiffs,
+    columnsByModelId,
+    resolveFormulaDependencies,
+  }: {
+    metaDiffs?: MetaDiffWithDetectedChanges[] | null;
+    columnsByModelId?: { get(modelId: string): ImpactColumn[] | undefined } | null;
+    resolveFormulaDependencies: FormulaDependencyResolver;
+  },
+): Promise<RemovedColumnImpact[]> {
+  const impact: RemovedColumnImpact[] = [];
+  const seen = new Set<string>();
+
+  if (!Array.isArray(metaDiffs) || !columnsByModelId) return impact;
+
+  for (const metaDiff of metaDiffs) {
+    const detectedChanges = Array.isArray(metaDiff?.detectedChanges)
+      ? metaDiff.detectedChanges
+      : [];
+
+    for (const change of detectedChanges) {
+      if (!removedColumnChangeTypes.has(change?.type ?? '')) continue;
+
+      const removedColumn = change.column;
+      if (!removedColumn?.id || !removedColumn.fk_model_id) continue;
+
+      const columns = columnsByModelId.get(removedColumn.fk_model_id);
+      if (!Array.isArray(columns)) continue;
+
+      const dependentColumns = await resolveFormulaDependencies(context, {
+        column: removedColumn,
+        columns,
+      });
+
+      for (const dependentColumn of dependentColumns) {
+        if (
+          !hasRequiredColumnIdentity(dependentColumn) ||
+          !isFormulaOrButtonColumn(dependentColumn)
+        ) {
+          continue;
+        }
+
+        const dedupeKey = `${removedColumn.id}:${dependentColumn.id}`;
+        if (seen.has(dedupeKey)) continue;
+
+        seen.add(dedupeKey);
+        impact.push({
+          dependencyType:
+            dependentColumn.uidt === UITypes.Button ? 'button' : 'formula',
+          removedColumnId: removedColumn.id,
+          resource: {
+            id: dependentColumn.id,
+            title: dependentColumn.title,
+            uidt: dependentColumn.uidt,
+          },
+        });
+      }
+    }
+  }
+
+  return impact;
+}

--- a/packages/nocodb/src/helpers/metaDiffImpact.ts
+++ b/packages/nocodb/src/helpers/metaDiffImpact.ts
@@ -21,10 +21,13 @@ export type FormulaDependencyResolver = (
 type RemovedColumnChange = {
   type?: RemovedColumnChangeType | string;
   column?: ImpactColumn | null;
+  impacts?: RemovedColumnImpact[];
+  [key: string]: unknown;
 };
 
-type MetaDiffWithDetectedChanges = {
+export type MetaDiffWithDetectedChanges = {
   detectedChanges?: RemovedColumnChange[] | null;
+  [key: string]: unknown;
 };
 
 export type RemovedColumnImpact = {
@@ -50,6 +53,44 @@ const hasRequiredColumnIdentity = (
 ): column is ImpactColumn & { id: string; title: string; uidt: UITypes } =>
   !!column?.id && !!column?.title && !!column?.uidt;
 
+export function attachRemovedColumnImpacts(
+  metaDiffs: MetaDiffWithDetectedChanges[],
+  impacts: RemovedColumnImpact[],
+): MetaDiffWithDetectedChanges[] {
+  const impactsByRemovedColumnId = impacts.reduce((acc, impact) => {
+    const existing = acc.get(impact.removedColumnId);
+
+    if (existing) {
+      existing.push(impact);
+    } else {
+      acc.set(impact.removedColumnId, [impact]);
+    }
+
+    return acc;
+  }, new Map<string, RemovedColumnImpact[]>());
+
+  return metaDiffs.map((metaDiff) => ({
+    ...metaDiff,
+    detectedChanges: Array.isArray(metaDiff.detectedChanges)
+      ? metaDiff.detectedChanges.map((change) => {
+          if (
+            removedColumnChangeTypes.has(change?.type ?? '') &&
+            change.column?.id
+          ) {
+            return {
+              ...change,
+              impacts: [
+                ...(impactsByRemovedColumnId.get(change.column.id) ?? []),
+              ],
+            };
+          }
+
+          return { ...change };
+        })
+      : metaDiff.detectedChanges,
+  }));
+}
+
 export async function collectRemovedColumnImpact(
   context: NcContext,
   {
@@ -58,7 +99,9 @@ export async function collectRemovedColumnImpact(
     resolveFormulaDependencies,
   }: {
     metaDiffs?: MetaDiffWithDetectedChanges[] | null;
-    columnsByModelId?: { get(modelId: string): ImpactColumn[] | undefined } | null;
+    columnsByModelId?: {
+      get(modelId: string): ImpactColumn[] | undefined;
+    } | null;
     resolveFormulaDependencies: FormulaDependencyResolver;
   },
 ): Promise<RemovedColumnImpact[]> {

--- a/packages/nocodb/src/services/meta-diffs.service.ts
+++ b/packages/nocodb/src/services/meta-diffs.service.ts
@@ -29,12 +29,21 @@ import {
   resolvePkAfterSync,
 } from '~/services/meta-diffs/pk-preservation';
 import { formatLinkDbMapping } from '~/helpers/formatLinkDbMapping';
+import { getFormulasReferredTheColumn } from '~/helpers/formulaHelpers';
+import {
+  attachRemovedColumnImpacts,
+  collectRemovedColumnImpact,
+} from '~/helpers/metaDiffImpact';
 import NcHelp from '~/utils/NcHelp';
 import NcConnectionMgrv2 from '~/utils/common/NcConnectionMgrv2';
 import Noco from '~/Noco';
 import NocoCache from '~/cache/NocoCache';
 import { CacheScope, MetaTable } from '~/utils/globals';
 import { Base, Column, Model, Source } from '~/models';
+import type {
+  ImpactColumn,
+  RemovedColumnImpact,
+} from '~/helpers/metaDiffImpact';
 
 // todo:move enum and types
 export enum MetaDiffType {
@@ -59,6 +68,10 @@ const applyChangesPriorityOrder = [
   MetaDiffType.VIEW_COLUMN_REMOVE,
   MetaDiffType.TABLE_RELATION_REMOVE,
 ];
+
+type GetMetaDiffOptions = {
+  includeRemovedColumnImpact?: boolean;
+};
 
 type MetaDiff = {
   title?: string;
@@ -93,15 +106,23 @@ type MetaDiffChange = {
   | {
       type:
         | MetaDiffType.TABLE_COLUMN_TYPE_CHANGE
-        | MetaDiffType.VIEW_COLUMN_TYPE_CHANGE
-        | MetaDiffType.TABLE_COLUMN_REMOVE
-        | MetaDiffType.VIEW_COLUMN_REMOVE;
+        | MetaDiffType.VIEW_COLUMN_TYPE_CHANGE;
       tn?: string;
       model?: Model;
       id?: string;
       cn: string;
       column: Column;
       colId?: string;
+    }
+  | {
+      type: MetaDiffType.TABLE_COLUMN_REMOVE | MetaDiffType.VIEW_COLUMN_REMOVE;
+      tn?: string;
+      model?: Model;
+      id?: string;
+      cn: string;
+      column: Column;
+      colId?: string;
+      impacts?: RemovedColumnImpact[];
     }
   | {
       type: MetaDiffType.TABLE_RELATION_REMOVE;
@@ -165,6 +186,7 @@ export class MetaDiffsService {
     sqlClient,
     base: Base,
     source: Source,
+    options: GetMetaDiffOptions = {},
   ): Promise<Array<MetaDiff>> {
     // if meta base then return empty array
     if (source.isMeta()) {
@@ -180,6 +202,9 @@ export class MetaDiffsService {
 
     const changes: Array<MetaDiff> = [];
     const virtualRelationColumns: Column<LinkToAnotherRecordColumn>[] = [];
+    const columnsByModelId = options.includeRemovedColumnImpact
+      ? new Map<string, Column[]>()
+      : null;
 
     // @ts-ignore
     const tableList: Array<{ tn: string }> = (
@@ -261,6 +286,9 @@ export class MetaDiffsService {
       )?.data?.list;
 
       await oldMeta.getColumns(context);
+      if (columnsByModelId && oldMeta.id && Array.isArray(oldMeta.columns)) {
+        columnsByModelId.set(oldMeta.id, [...oldMeta.columns]);
+      }
 
       for (const column of colListRef[table.tn]) {
         const oldColIdx = oldMeta.columns.findIndex(
@@ -744,6 +772,9 @@ export class MetaDiffsService {
       )?.data?.list;
 
       await oldMeta.getColumns(context);
+      if (columnsByModelId && oldMeta.id && Array.isArray(oldMeta.columns)) {
+        columnsByModelId.set(oldMeta.id, [...oldMeta.columns]);
+      }
 
       for (const column of colListRef[view.tn]) {
         const oldColIdx = oldMeta.columns.findIndex(
@@ -831,6 +862,20 @@ export class MetaDiffsService {
       });
     }
 
+    if (options.includeRemovedColumnImpact) {
+      const impacts = await collectRemovedColumnImpact(context, {
+        metaDiffs: changes,
+        columnsByModelId,
+        resolveFormulaDependencies: async (resolverContext, params) =>
+          (await getFormulasReferredTheColumn(resolverContext, {
+            column: params.column as Column,
+            columns: params.columns as Column[],
+          })) as ImpactColumn[],
+      });
+
+      return attachRemovedColumnImpacts(changes, impacts) as Array<MetaDiff>;
+    }
+
     return changes;
   }
 
@@ -845,7 +890,9 @@ export class MetaDiffsService {
         // @ts-ignore
         const sqlClient = await NcConnectionMgrv2.getSqlClient(source);
         changes = changes.concat(
-          await this.getMetaDiff(context, sqlClient, base, source),
+          await this.getMetaDiff(context, sqlClient, base, source, {
+            includeRemovedColumnImpact: true,
+          }),
         );
       } catch (e) {
         console.log(e);
@@ -865,7 +912,9 @@ export class MetaDiffsService {
     let changes = [];
 
     const sqlClient = await NcConnectionMgrv2.getSqlClient(source);
-    changes = await this.getMetaDiff(context, sqlClient, base, source);
+    changes = await this.getMetaDiff(context, sqlClient, base, source, {
+      includeRemovedColumnImpact: true,
+    });
 
     return changes;
   }

--- a/packages/nocodb/src/services/meta-diffs.service.ts
+++ b/packages/nocodb/src/services/meta-diffs.service.ts
@@ -863,17 +863,28 @@ export class MetaDiffsService {
     }
 
     if (options.includeRemovedColumnImpact) {
-      const impacts = await collectRemovedColumnImpact(context, {
-        metaDiffs: changes,
-        columnsByModelId,
-        resolveFormulaDependencies: async (resolverContext, params) =>
-          (await getFormulasReferredTheColumn(resolverContext, {
-            column: params.column as Column,
-            columns: params.columns as Column[],
-          })) as ImpactColumn[],
-      });
+      try {
+        // Optional removed-column impact analysis must not block existing Meta Diff
+        // results.
+        const impacts = await collectRemovedColumnImpact(context, {
+          metaDiffs: changes,
+          columnsByModelId,
+          resolveFormulaDependencies: async (resolverContext, params) =>
+            (await getFormulasReferredTheColumn(resolverContext, {
+              column: params.column as Column,
+              columns: params.columns as Column[],
+            })) as ImpactColumn[],
+        });
 
-      return attachRemovedColumnImpacts(changes, impacts) as Array<MetaDiff>;
+        return attachRemovedColumnImpacts(changes, impacts) as Array<MetaDiff>;
+      } catch (e) {
+        console.warn(
+          `Failed to collect removed-column impacts for source ${
+            source.alias || source.id
+          }`,
+          e,
+        );
+      }
     }
 
     return changes;


### PR DESCRIPTION
## Summary

This PR adds dependency impact information to Meta Diff previews when an external table or view column is removed.

Before applying metadata changes, the preview can identify NocoDB formula and URL-button columns that depend on the removed column.

## What changed

- Added a helper to collect formula and URL-button dependencies for removed columns.
- Added an 'additive' field to removed-column meta diff changes.
- Enabled impact analysis only for Meta Diff preview flows.
- Kept the Meta Sync apply path unchanged.
- Isolated optional impact analysis failures so the original meta diff remains available.
- Preserved deterministic ordering without mutating the original meta diff input.

## Example

When `unit_price` is removed externally and `total_price` uses the following:

```text
{quantity} * {unit_price}
```

The Meta Diff preview returns the following:

```json
{
  "type": "TABLE_COLUMN_REMOVE",
  "cn": "unit_price",
  "impacts": [
    {
      "dependencyType": "formula",
      "removedColumnId": "removed-column-id",
      "resource": {
        "id": "dependent-column-id",
        "title": "total_price",
        "uidt": "Formula"
      }
    }
  ]
}
```

## Validation

- 10 targeted Jest tests passing.
- Backend TypeScript check passing.
- Prettier check passing.
- `git diff --check` passing.
- Verified end-to-end using a local PostgreSQL external source.
- Created a ``table containing `quantity` and `unit_price`.
- Added a NocoDB formula column named `total_price`.
- Removed `unit_price` directly from PostgreSQL.
- Confirmed the completed Meta Diff preview job detected `TABLE_COLUMN_REMOVE ''.
- Confirmed the response reported `total_price it as an impacted formula.
- No meta sync apply action was performed during validation.

### End-to-end result

<img width="877" height="420" alt="Screenshot 2026-07-24 223807" src="https://github.com/user-attachments/assets/403fc533-7264-4d4a-9a25-910f0e68225f" />



<img width="707" height="420" alt="Screenshot 2026-07-24 223745" src="https://github.com/user-attachments/assets/fd51f8e6-134a-4550-a4c4-590088d94c9f" />



## Scope

This PR intentionally focuses on removed table/view columns and their formula or URL-button dependencies.

It does not:

- Change the meta sync apply path.
- Automatically block or apply schema changes.
- Add UI rendering for the new impact information.
- Cover other dependency types such as links, rollups, lookups, webhooks, or dashboards.