### PR TITLE
fix(nc-gui): don't load the chatwoot SDK when support chat is disabled

### DIFF
--- a/packages/nc-gui/composables/useChatWoot.ts
+++ b/packages/nc-gui/composables/useChatWoot.ts
@@ -1,0 +1,8 @@
+import { useChatWoot as useChatWootSdk } from '@productdevbook/chatwoot/vue'
+
+/**
+ * Re-exported so that `useChatWoot` stays auto-imported. It used to come from the
+ * `@productdevbook/chatwoot` nuxt module, which is no longer registered because its plugin injects the
+ * chatwoot SDK on app boot - see the note in `nuxt.config.ts` and `useProvideChatwoot`.
+ */
+export const useChatWoot = useChatWootSdk

--- a/packages/nc-gui/composables/useProvideChatwoot.ts
+++ b/packages/nc-gui/composables/useProvideChatwoot.ts
@@ -1,9 +1,22 @@
+import { createChatWoot } from '@productdevbook/chatwoot/vue'
+import type { OptionPlugin } from '@productdevbook/chatwoot/vue'
+
+/**
+ * Tracks whether the chatwoot SDK script has already been injected. `useProvideChatwoot` is called
+ * from more than one component, so the guard has to live outside of it.
+ */
+let isChatwootSdkInjected = false
+
 export const useProvideChatwoot = () => {
   const { setUser, setConversationCustomAttributes, setCustomAttributes } = useChatWoot()
 
-  const { $api } = useNuxtApp()
+  const nuxtApp = useNuxtApp()
 
-  const { user, appInfo } = useGlobal()
+  const { $api } = nuxtApp
+
+  const { chatwoot: chatwootConfig } = useRuntimeConfig().public
+
+  const { user, appInfo, appInfoStatus } = useGlobal()
   const router = useRouter()
   const route = router.currentRoute
 
@@ -12,6 +25,21 @@ export const useProvideChatwoot = () => {
   const chatwootReady = ref(false)
 
   const isChatWootEnabled = computed(() => !appInfo.value.disableSupportChat)
+
+  /**
+   * Injects the chatwoot SDK script. Deferred until `appInfo` is loaded so that an instance started
+   * with `NC_DISABLE_SUPPORT_CHAT=true` makes no request to chatwoot at all - `disableSupportChat` is
+   * only known once the backend has answered, and the SDK starts talking to `baseUrl` as soon as it
+   * is on the page.
+   */
+  const injectChatwootSdk = () => {
+    if (isChatwootSdkInjected) return
+
+    isChatwootSdkInjected = true
+
+    // runtime config widens the literal types it is declared with (`darkMode: string`), hence the cast
+    nuxtApp.vueApp.use(createChatWoot(chatwootConfig as OptionPlugin))
+  }
 
   const initUserCustomerAttributes = () => {
     if (!chatwootReady.value || ncIsPlaywright() || !user.value?.id || appInfo.value.disableSupportChat) {
@@ -63,14 +91,23 @@ export const useProvideChatwoot = () => {
     { immediate: true },
   )
 
+  /**
+   * `disableSupportChat` is only meaningful once `appInfo` has been fetched - until then it reads as
+   * `undefined`, which is why neither the SDK nor the metadata it reports on may be requested earlier.
+   */
+  watch(
+    () => appInfoStatus.value === 'loaded' && isChatWootEnabled.value,
+    (isEnabled) => {
+      if (!isEnabled) return
+
+      injectChatwootSdk()
+      loadAggMetaInfo()
+    },
+    { immediate: true },
+  )
+
   router.afterEach(() => {
     initUserCustomerAttributes()
-  })
-
-  onMounted(() => {
-    if (appInfo.value.disableSupportChat) return
-
-    loadAggMetaInfo()
   })
 
   return {

--- a/packages/nc-gui/nuxt.config.ts
+++ b/packages/nc-gui/nuxt.config.ts
@@ -16,22 +16,18 @@ export default defineNuxtConfig({
 
   ignore: [...(process.env.NODE_ENV === 'production' ? ['pages/playground/**/*'] : [])],
 
-  modules: ['@vueuse/nuxt', 'nuxt-windicss', '@nuxt/image', '@pinia/nuxt', '@productdevbook/chatwoot'],
+  /**
+   * `@productdevbook/chatwoot` is intentionally not registered as a module: its client plugin injects
+   * `<baseUrl>/packs/js/sdk.js` on app boot, before the backend has told us whether support chat is
+   * enabled. The SDK is instead installed on demand from `useProvideChatwoot`, so an instance running
+   * with `NC_DISABLE_SUPPORT_CHAT=true` never reaches out to chatwoot.
+   */
+  modules: ['@vueuse/nuxt', 'nuxt-windicss', '@nuxt/image', '@pinia/nuxt'],
   ssr: false,
 
   router: {
     options: {
       hashMode: false,
-    },
-  },
-  chatwoot: {
-    init: {
-      websiteToken: 'ke2YjiPnKw9gnz4PCq4RuQqR',
-      baseUrl: 'https://app.chatwoot.com',
-    },
-    settings: {
-      darkMode: 'light',
-      hideMessageBubble: true,
     },
   },
   spaLoadingTemplate: false,
@@ -143,6 +139,16 @@ export default defineNuxtConfig({
       ncBackendUrl: '',
       env: 'production',
       maxPageDesignerTableRows: 100,
+      chatwoot: {
+        init: {
+          websiteToken: 'ke2YjiPnKw9gnz4PCq4RuQqR',
+          baseUrl: 'https://app.chatwoot.com',
+        },
+        settings: {
+          darkMode: 'light',
+          hideMessageBubble: true,
+        },
+      },
     },
   },
 


### PR DESCRIPTION
## Change Summary

`closes: #13157`

Setting `NC_DISABLE_SUPPORT_CHAT=true` did not stop the browser from talking to `app.chatwoot.com`.

`@productdevbook/chatwoot` is registered as a nuxt module, and its client plugin calls
`loadScript('<baseUrl>/packs/js/sdk.js')` followed by `chatwootSDK.run()` from `install()` on app boot.
That happens before `appInfo` — and with it `disableSupportChat` — is known, and the module offers no
opt-out. #13423 could therefore only suppress the support button and the user identification; the SDK
itself still loaded and the widget kept opening conversation/contact/campaign requests against
chatwoot, which is what the reporter sees in the network tab.

This PR stops registering the module and installs the SDK from `useProvideChatwoot` instead, once
`appInfo` has loaded **and** support chat is enabled:

- `nuxt.config.ts` — drop `@productdevbook/chatwoot` from `modules`; its options move to
  `runtimeConfig.public.chatwoot`, keeping the same shape the module published (so
  `window.__NUXT__.config.public.chatwoot.*` still resolves).
- `composables/useProvideChatwoot.ts` — `injectChatwootSdk()` installs `createChatWoot(...)` on the vue
  app, guarded by a module-scoped flag because the composable is used by more than one component. It is
  driven by a watcher on `appInfoStatus === 'loaded' && isChatWootEnabled`. The `aggregatedMetaInfo`
  call moved onto the same gate — it only feeds chatwoot conversation attributes, and the `onMounted`
  guard added in #13423 never actually held because `appInfo` is still empty at mount.
- `composables/useChatWoot.ts` — thin re-export of the SDK composable, so `useChatWoot` stays
  auto-imported now that the module no longer registers it.

The dependency stays in `package.json`; only the auto-injecting nuxt module is dropped.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Ran `nc-gui` against a backend serving `/api/v1/db/meta/nocodb/info`, loaded the app in chromium and
recorded every outbound request, toggling `NC_DISABLE_SUPPORT_CHAT`:

| build | `NC_DISABLE_SUPPORT_CHAT` | requests to `app.chatwoot.com` | `sdk.js` script tag | `window.$chatwoot` |
| --- | --- | --- | --- | --- |
| `develop` | `true` | **8** | present | defined |
| this branch | `true` | **0** | absent | undefined |
| this branch | unset | 8 | present | defined |

With the flag set, the only remaining `chatwoot` hits are same-origin dev-server assets (the sidebar
icon and the lazily imported local module chunk). With the flag unset the widget boots exactly as
before — `sdk.js`, `/widget`, `conversations`, `messages`, `inbox_members`, `contact`, `campaigns` — so
cloud/default installs are unaffected.

Also verified after the change that `useChatWoot` still resolves through auto-imports
(`.nuxt/imports.d.ts`) and that no reference to the removed plugin remains in the generated `.nuxt`
output.
