### PR TITLE
fix(mcp): queryRecords sort is silently ignored — schema key should be `direction`, not `description`

### DIFF
--- a/packages/nocodb/src/mcp/mcp.service.ts
+++ b/packages/nocodb/src/mcp/mcp.service.ts
@@ -207,7 +207,7 @@ export class McpService {
             .array(
               z.object({
                 field: z.string().describe('Field Name'),
-                description: z.enum(['asc', 'desc']).describe('Sort Direction'),
+                direction: z.enum(['asc', 'desc']).describe('Sort Direction'),
               }),
             )
             .optional(),


### PR DESCRIPTION
### Problem

The `queryRecords` MCP tool accepts a `sort` argument, but sorting is **silently ignored** — records always come back in default order, with no error raised.

The tool's input schema declares the sort-direction key as `description`:

https://github.com/nocodb/nocodb/blob/5cd1f1f5b779533db65d52e358b474ac81f4ab73/packages/nocodb/src/mcp/mcp.service.ts#L206-L213

```ts
sort: z
  .array(
    z.object({
      field: z.string().describe('Field Name'),
      description: z.enum(['asc', 'desc']).describe('Sort Direction'),  // <-- here
    }),
  )
  .optional(),
```

but the consumer, `extractSortsObject`, reads `direction` (`packages/nocodb/src/helpers/dbHelpers.ts`, V3 branch):

```ts
return (_sorts as { direction: string; field: string }[]).map((s) => {
  const sort: SortType = {
    direction: s.direction as 'asc' | 'desc' | 'count-desc' | 'count-asc',
    fk_column_id: aliasColObjMap[s.field]?.id,
  };
```

`s.direction` is therefore always `undefined`, and the ordering is dropped.

### Why it fails silently instead of erroring

`validateDataListQueryParams` in `packages/nocodb/src/services/v3/data-v3.service.ts` guards the direction check with a truthiness short-circuit:

```ts
parsedSort.some((s) => s.direction && !['asc', 'desc'].includes(s.direction))
```

An `undefined` direction skips the check entirely. Note that `field` *is* validated, so an unknown field name raises "field not found" while a missing direction passes quietly — a confusing asymmetry for MCP clients.

Because the schema is a zod object, a client cannot work around this by sending `direction` itself: the unknown key is stripped before it reaches the service, so there is no client-side fix.

### Fix

Rename the schema key `description` → `direction` so it matches what the consumer reads.

No other change is required — the `typeof param.query.sort === 'object'` branch in `validateDataListQueryParams` already accepts the array form.

### Verification

Reproduced against a self-hosted NocoDB `2026.06.2` instance over the MCP endpoint: a `queryRecords` call with

```json
{ "sort": [{ "field": "sequence_value", "description": "desc" }] }
```

returned rows in default (unsorted) order, with no error. `mcp.service.ts` is byte-identical at tags `2026.06.2`, `2026.07.0` and on `develop`, so current releases are affected.

Practical impact: we hit this while reading `MAX(sequence_value)` to allocate the next number in an audited sequence. "Sort desc, take the first row" silently returned an arbitrary row — a failure mode that can produce duplicate numbers in a ledger. We now fetch the full table and compute the max client-side as a workaround.

### Credit / relation to #12961

This is the same rename proposed in #12961 by @rongfengliang (opened 2026-01-28). That PR is now stale and marked `CONFLICTING`, and its second change — accepting an array/object `sort` in `validateDataListQueryParams` — has already landed upstream independently, so only the schema-key rename remains outstanding.

Opening this as a minimal, conflict-free alternative. Happy to close it in favour of a rebased #12961 if the author or a maintainer prefers.
