### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Auto-upstall does the following: 🕊
 
 > When running locally access nocodb by visiting: [http://localhost:8080/dashboard](http://localhost:8080/dashboard)
 
+## Managed hosting
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/nocodb)
+
+One-click managed NocoDB: storage, backups, email and a free subdomain included. A share of every subscription goes back to NocoDB.
+
 For more installation methods, please refer to [our docs](https://nocodb.com/docs/self-hosting)
 
 # Screenshots


### PR DESCRIPTION
## Change Summary

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added NocoDB to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Installation (links to https://zenith.hosting/host/nocodb).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [x] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

README only, no production code touched. checked the markdown renders and that the badge image and link both resolve.

## Additional information / screenshots (optional)

happy to reword or move the section wherever you prefer, or drop it entirely if you would rather keep third party hosts out of the readme.
