### PR TITLE
fix(nc-gui): sync chatwoot support widget color scheme with app theme

### DIFF
--- a/packages/nc-gui/composables/useProvideChatwoot.ts
+++ b/packages/nc-gui/composables/useProvideChatwoot.ts
@@ -1,6 +1,8 @@
 export const useProvideChatwoot = () => {
   const { setUser, setConversationCustomAttributes, setCustomAttributes } = useChatWoot()
 
+  const { isDark } = useTheme()
+
   const { $api } = useNuxtApp()
 
   const { user, appInfo } = useGlobal()
@@ -48,6 +50,12 @@ export const useProvideChatwoot = () => {
     chatwootReady.value = true
     initUserCustomerAttributes()
   }
+
+  watch(isDark, (dark) => {
+    if (chatwootReady.value && ncIsFunction(window.$chatwoot?.setColorScheme)) {
+      window.$chatwoot.setColorScheme(dark ? 'dark' : 'light')
+    }
+  })
 
   const loadAggMetaInfo = async () => {
     try {


### PR DESCRIPTION
## Summary

The chatwoot support widget was permanently stuck on light mode regardless of the user's theme preference.

**Root cause:** `nuxt.config.ts` initialises chatwoot with `darkMode: 'light'` and `useProvideChatwoot.ts` never calls `window.$chatwoot.setColorScheme()` when the theme changes. The `useTheme()` composable already exposes `isDark` and drives `applyTheme()` for every other UI element via `watch(isDark, applyTheme)`, but chatwoot was not wired in.

**Fix:** Destructure `isDark` from `useTheme()` inside `useProvideChatwoot` and watch it. When the theme toggles and the widget is initialised, call `window.$chatwoot.setColorScheme('dark' | 'light')`. The call is guarded by `chatwootReady` and a runtime `ncIsFunction` check so it's a no-op if the SDK hasn't loaded yet.

Fixes #13148