### PR TITLE
fix(nocodb): register pg type parser for INTERVAL to prevent [object Object]

### DIFF
--- a/packages/nocodb/src/db/CustomKnex.ts
+++ b/packages/nocodb/src/db/CustomKnex.ts
@@ -14,6 +14,7 @@ const pgTypes = {
   FLOAT4: 700,
   FLOAT8: 701,
   DATE: 1082,
+  INTERVAL: 1186,
   TIMESTAMP: 1114,
   TIMESTAMPTZ: 1184,
   NUMERIC: 1700,
@@ -21,6 +22,8 @@ const pgTypes = {
 
 // override parsing date column to Date()
 types.setTypeParser(pgTypes.DATE, (val) => val);
+// keep interval as the raw Postgres string — default parser returns a JS object
+types.setTypeParser(pgTypes.INTERVAL, (val) => val);
 // override timestamp
 types.setTypeParser(pgTypes.TIMESTAMP, (val) => {
   return dayjs.utc(val).format('YYYY-MM-DD HH:mm:ssZ');


### PR DESCRIPTION
## Summary

Postgres `interval` columns (e.g. a .NET `TimeSpan` property mapped by EF Core) displayed `[object Object]` in NocoDB instead of the human-readable duration string like `03:00:00`.

**Root cause:** `CustomKnex.ts` registers custom `pg` type parsers for DATE, TIMESTAMP, TIMESTAMPTZ, FLOAT8, and NUMERIC, but omits OID **1186** (`INTERVAL`). The `pg` driver's built-in interval parser returns a structured JS object `{years, months, days, hours, minutes, seconds, milliseconds}` which coerces to `[object Object]` when stored or displayed.

**Fix:** Register a pass-through type parser for OID 1186 (identical to the existing DATE parser) so the raw Postgres wire-format string is returned unchanged — e.g. `03:00:00` or `1 year 2 days 03:04:05`.

```ts
// before (no INTERVAL parser — pg returns a JS object)
const pgTypes = { FLOAT4: 700, FLOAT8: 701, DATE: 1082, ... };

// after
const pgTypes = { FLOAT4: 700, FLOAT8: 701, DATE: 1082, INTERVAL: 1186, ... };
types.setTypeParser(pgTypes.INTERVAL, (val) => val);
```

Fixes #14306