### PR TITLE
fix: return 404 when deleting a non-existent API token

### DIFF
--- a/packages/nocodb/src/services/api-tokens.service.spec.ts
+++ b/packages/nocodb/src/services/api-tokens.service.spec.ts
@@ -1,13 +1,59 @@
 import { Test } from '@nestjs/testing';
-import { ApiTokensService } from './api-tokens.service';
+import { ApiTokensService } from '~/services/api-tokens.service';
+import { AppHooksService } from '~/services/app-hooks/app-hooks.service';
 import type { TestingModule } from '@nestjs/testing';
+import { ApiToken } from '~/models';
+import { NcError } from '~/helpers/catchError';
+import { validatePayload } from '~/helpers';
+import { OrgUserRoles } from 'nocodb-sdk';
+
+jest.mock('~/models', () => ({
+  ApiToken: {
+    get: jest.fn(),
+    delete: jest.fn(),
+    insert: jest.fn(),
+    list: jest.fn(),
+    listForNonSsoUser: jest.fn(),
+    listWithCreatedBy: jest.fn(),
+    count: jest.fn(),
+  },
+}));
+
+jest.mock('~/helpers/catchError', () => ({
+  NcError: {
+    notFound: jest.fn(),
+    _: { notFound: jest.fn() },
+  },
+}));
+
+jest.mock('~/helpers', () => ({
+  validatePayload: jest.fn(),
+}));
+
+jest.mock('~/services/app-hooks/app-hooks.service', () => ({
+  AppHooksService: jest.fn().mockImplementation(() => ({
+    emit: jest.fn(),
+  })),
+}));
 
 describe('ApiTokensService', () => {
   let service: ApiTokensService;
+  const notFoundSpy = NcError.notFound as unknown as jest.Mock;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    // The real NcError.notFound always throws (return type `never`).
+    notFoundSpy.mockImplementation(() => {
+      throw new Error('Token not found');
+    });
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ApiTokensService],
+      providers: [
+        ApiTokensService,
+        {
+          provide: AppHooksService,
+          useValue: { emit: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<ApiTokensService>(ApiTokensService);
@@ -15,5 +61,52 @@ describe('ApiTokensService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('apiTokenDelete', () => {
+    it('should return 404 (notFound) when the token does not exist', async () => {
+      (ApiToken.get as jest.Mock).mockResolvedValue(undefined);
+
+      const user = {
+        id: 'user-1',
+        roles: JSON.stringify({ [OrgUserRoles.SUPER_ADMIN]: true }),
+      };
+
+      await expect(
+        service.apiTokenDelete({
+          tokenId: 'missing-token',
+          user: user as any,
+          req: {} as any,
+        }),
+      ).rejects.toThrow('Token not found');
+
+      expect(notFoundSpy).toHaveBeenCalledWith('Token not found');
+      // The ownership check and emit must never dereference an undefined token.
+      expect(ApiToken.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete the token when it exists and belongs to the user', async () => {
+      (ApiToken.get as jest.Mock).mockResolvedValue({
+        id: 'token-1',
+        description: 'my token',
+        fk_user_id: 'user-1',
+      });
+      (ApiToken.delete as jest.Mock).mockResolvedValue({ id: 'token-1' });
+
+      const user = {
+        id: 'user-1',
+        roles: JSON.stringify({ [OrgUserRoles.VIEWER]: true }),
+      };
+
+      const res = await service.apiTokenDelete({
+        tokenId: 'token-1',
+        user: user as any,
+        req: {} as any,
+      });
+
+      expect(notFoundSpy).not.toHaveBeenCalled();
+      expect(ApiToken.delete).toHaveBeenCalledWith('token-1');
+      expect(res).toEqual({ id: 'token-1' });
+    });
   });
 });

--- a/packages/nocodb/src/services/api-tokens.service.ts
+++ b/packages/nocodb/src/services/api-tokens.service.ts
@@ -56,6 +56,9 @@ export class ApiTokensService {
 
   async apiTokenDelete(param: { tokenId: string; user: User; req: NcRequest }) {
     const apiToken = await ApiToken.get(param.tokenId);
+    if (!apiToken) {
+      NcError.notFound('Token not found');
+    }
     if (
       !extractRolesObj(param.user.roles)[OrgUserRoles.SUPER_ADMIN] &&
       apiToken.fk_user_id !== param.user.id

--- a/packages/nocodb/src/services/org-tokens.service.spec.ts
+++ b/packages/nocodb/src/services/org-tokens.service.spec.ts
@@ -1,13 +1,57 @@
 import { Test } from '@nestjs/testing';
-import { OrgTokensService } from './org-tokens.service';
 import type { TestingModule } from '@nestjs/testing';
+import { OrgTokensService } from '~/services/org-tokens.service';
+import { AppHooksService } from '~/services/app-hooks/app-hooks.service';
+import { ApiToken } from '~/models';
+import { NcError } from '~/helpers/catchError';
+import { validatePayload } from '~/helpers';
+import { OrgUserRoles } from 'nocodb-sdk';
+
+jest.mock('~/models', () => ({
+  ApiToken: {
+    get: jest.fn(),
+    delete: jest.fn(),
+    insert: jest.fn(),
+    listWithCreatedBy: jest.fn(),
+    count: jest.fn(),
+  },
+}));
+
+jest.mock('~/helpers/catchError', () => ({
+  NcError: {
+    notFound: jest.fn(),
+    _: { notFound: jest.fn() },
+  },
+}));
+
+jest.mock('~/helpers', () => ({
+  validatePayload: jest.fn(),
+}));
+
+jest.mock('~/services/app-hooks/app-hooks.service', () => ({
+  AppHooksService: jest.fn().mockImplementation(() => ({
+    emit: jest.fn(),
+  })),
+}));
 
 describe('OrgTokensService', () => {
   let service: OrgTokensService;
+  const notFoundSpy = NcError.notFound as unknown as jest.Mock;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+    // The real NcError.notFound always throws (return type `never`).
+    notFoundSpy.mockImplementation(() => {
+      throw new Error('Token not found');
+    });
     const module: TestingModule = await Test.createTestingModule({
-      providers: [OrgTokensService],
+      providers: [
+        OrgTokensService,
+        {
+          provide: AppHooksService,
+          useValue: { emit: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<OrgTokensService>(OrgTokensService);
@@ -15,5 +59,71 @@ describe('OrgTokensService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('apiTokenDelete', () => {
+    it('should return 404 (notFound) when the token does not exist', async () => {
+      (ApiToken.get as jest.Mock).mockResolvedValue(undefined);
+
+      const superAdmin = {
+        id: 'user-1',
+        roles: JSON.stringify({ [OrgUserRoles.SUPER_ADMIN]: true }),
+      };
+
+      await expect(
+        service.apiTokenDelete({
+          tokenId: 'missing-token',
+          user: superAdmin as any,
+          req: {} as any,
+        }),
+      ).rejects.toThrow('Token not found');
+
+      expect(notFoundSpy).toHaveBeenCalledWith('Token not found');
+      // The ownership check and emit must never dereference an undefined token.
+      expect(ApiToken.delete).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 (notFound) regardless of role when the token does not exist', async () => {
+      (ApiToken.get as jest.Mock).mockResolvedValue(undefined);
+
+      const regularUser = {
+        id: 'user-1',
+        roles: JSON.stringify({ [OrgUserRoles.VIEWER]: true }),
+      };
+
+      await expect(
+        service.apiTokenDelete({
+          tokenId: 'missing-token',
+          user: regularUser as any,
+          req: {} as any,
+        }),
+      ).rejects.toThrow('Token not found');
+
+      expect(notFoundSpy).toHaveBeenCalledWith('Token not found');
+    });
+
+    it('should delete the token when it exists and belongs to the user', async () => {
+      (ApiToken.get as jest.Mock).mockResolvedValue({
+        id: 'token-1',
+        description: 'my token',
+        fk_user_id: 'user-1',
+      });
+      (ApiToken.delete as jest.Mock).mockResolvedValue({ id: 'token-1' });
+
+      const user = {
+        id: 'user-1',
+        roles: JSON.stringify({ [OrgUserRoles.VIEWER]: true }),
+      };
+
+      const res = await service.apiTokenDelete({
+        tokenId: 'token-1',
+        user: user as any,
+        req: {} as any,
+      });
+
+      expect(notFoundSpy).not.toHaveBeenCalled();
+      expect(ApiToken.delete).toHaveBeenCalledWith('token-1');
+      expect(res).toEqual({ id: 'token-1' });
+    });
   });
 });

--- a/packages/nocodb/src/services/org-tokens.service.ts
+++ b/packages/nocodb/src/services/org-tokens.service.ts
@@ -74,6 +74,9 @@ export class OrgTokensService {
   async apiTokenDelete(param: { user: User; tokenId: string; req: NcRequest }) {
     const fk_user_id = param.user.id;
     const apiToken = await ApiToken.get(param.tokenId);
+    if (!apiToken) {
+      NcError.notFound('Token not found');
+    }
     if (
       !extractRolesObj(param.user.roles)[OrgUserRoles.SUPER_ADMIN] &&
       apiToken.fk_user_id !== fk_user_id


### PR DESCRIPTION
## Change Summary

Fixes #14349 — `DELETE /api/v1/tokens/{tokenId}` crashed with a **500 error** when the token did not exist, because the service dereferenced `apiToken.fk_user_id` without a null check.

Now a missing token returns **404 Not Found** (via `NcError.notFound`) instead of crashing, in both `OrgTokensService` (the reported path for the org-scoped endpoint) and `ApiTokensService` (the base-scope endpoint, which had the identical defect).

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Added regression tests to both `org-tokens.service.spec.ts` and `api-tokens.service.spec.ts`:
  - missing token → `notFound` (404), no `delete` call (admin and non-admin role paths)
  - existing token owned by the user → deletes successfully
- Verified locally: 7/7 tests pass across both spec files (run under Node 22 with `jest --testPathPattern`; the repo's default `testRegex` does not match `.service.spec.ts` files, same as the pre-existing specs).

## Additional information / screenshots (optional)

The root cause: `ApiToken.get()` returns `undefined` for a missing token, and both services then read `apiToken.fk_user_id` unconditionally, throwing `TypeError` → 500. The guard mirrors the existing `NcError.notFound('Token not found')` convention already used in the ownership check below it.
