### PR TITLE
fix(meta-dependency): pass non-transactional ncMeta to getAffectedDependency to prevent SQLite deadlock

### DIFF
--- a/packages/nocodb/src/services/meta-dependency/event-handler.service.ts
+++ b/packages/nocodb/src/services/meta-dependency/event-handler.service.ts
@@ -74,10 +74,13 @@ export class MetaDependencyEventHandler implements OnModuleInit {
     let trxNcMeta: MetaService;
     try {
       for (const handler of this.metaEventHandlerMap[param.eventType] ?? []) {
+        // Always probe with the non-transactional ncMeta: getAffectedDependency
+        // is a read-only check and must not run inside the write transaction,
+        // or it will deadlock on SQLite (pool size = 1) once trxNcMeta is set.
         const affectedDependencies = await handler.getAffectedDependency(
           nextContext,
           param,
-          trxNcMeta ?? ncMeta,
+          ncMeta,
         );
         if (affectedDependencies) {
           trxNcMeta = trxNcMeta ?? (await ncMeta.startTransaction());


### PR DESCRIPTION
## Problem

`PATCH /api/v2/meta/columns/{columnId}` hangs for ~60 seconds then returns HTTP 500 on SQLite deployments whenever the column type (`uidt`) changes.

**Root cause:** `MetaDependencyEventHandler.handleEvent` passes `trxNcMeta ?? ncMeta` to each handler's `getAffectedDependency` call. After the first handler triggers a transaction, `trxNcMeta` is set and all subsequent `getAffectedDependency` probes receive the transaction-bound `MetaService`. Any handler whose probe internally acquires a second connection tries to get it from a fully-occupied pool (SQLite pool size = 1), causing a `KnexTimeoutError` after 60 seconds.

`getAffectedDependency` is a read-only probe — it does not need to participate in the write transaction.

## Fix

Always pass the non-transactional `ncMeta` to `getAffectedDependency`. The write transaction (`trxNcMeta`) is still used correctly inside `handler.handle`.

```diff
-          trxNcMeta ?? ncMeta,
+          ncMeta,
```

Fixes #14347.