### PR TITLE
fix(nocodb-sdk): make generate:sdk work on windows

### DIFF
--- a/packages/nocodb-sdk/package.json
+++ b/packages/nocodb-sdk/package.json
@@ -35,7 +35,7 @@
     "test:spelling": "cspell \"{README.md,.github/*.md,src/**/*.ts}\"",
     "test:unit": "ENV_FILE=./config/.env.test jest",
     "watch:build": "tsc -p tsconfig.json -w",
-    "generate:sdk": "node build-script/mergeAndGenerateSwaggerCE && pnpm dlx swagger-typescript-api@10.0.3 -r -p ./nc_swagger.json -o ./src/lib/  --axios --unwrap-response-data  --module-name-first-tag --type-suffix=Type --templates ../../scripts/sdk/templates; rm ./nc_swagger.json",
+    "generate:sdk": "node build-script/mergeAndGenerateSwaggerCE && pnpm dlx swagger-typescript-api@10.0.3 -r -p ./nc_swagger.json -o ./src/lib/  --axios --unwrap-response-data  --module-name-first-tag --type-suffix=Type --templates ../../scripts/sdk/templates && node -e \"fs.rmSync('nc_swagger.json',{force:true})\"",
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {


### PR DESCRIPTION
Building on Windows (pnpm bootstrap or pnpm --filter nocodb-sdk build) fails with

```
packages/nocodb-sdk/src/lib/filter/filterUtils.ts:998:23 - error TS2339:
Property 'postOperation' does not exist on type '{ internalPostOperation: ...'
```

The generate:sdk script ended with `; rm ./nc_swagger.json`, which is bash
syntax. On Windows, npm/pnpm run scripts through cmd.exe, where `;` is not a
command separator, so it gets glued onto the value of `--templates`:

```
✨ try to read templates from directory "...\scripts\sdk\templates;"
⚠️ api template not found in undefined
⚠️ Code generator will use the default template
```

With the custom templates missing, swagger-typescript-api falls back to its
defaults, which name the methods after the swagger operationId
(`internal-post-operation` -> `internalPostOperation`). The repo templates use
the existing scheme (`postOperation`). Once Api.ts is regenerated that way,
every `$api.internal.postOperation()` / `getOperation()` call stops
type-checking (~200 calls in nc-gui).

With this change the templates dir is read correctly and the generated Api.ts
is byte-identical to the committed one.

`nc_swagger.json` is already in packages/nocodb-sdk/.gitignore, so the trailing
`rm` was not needed.

Related: #13602, #12635 (same bootstrap failure on Windows).
