### PR TITLE
fix(mcp): serialize query record sorts

### DIFF
--- a/packages/nocodb/src/mcp/mcp.service.ts
+++ b/packages/nocodb/src/mcp/mcp.service.ts
@@ -207,7 +207,7 @@ export class McpService {
             .array(
               z.object({
                 field: z.string().describe('Field Name'),
-                description: z.enum(['asc', 'desc']).describe('Sort Direction'),
+                direction: z.enum(['asc', 'desc']).describe('Sort Direction'),
               }),
             )
             .optional(),
@@ -227,7 +227,7 @@ export class McpService {
           // Prepare parameters
           const params: any = { pageSize, page };
           if (where) params.where = where;
-          if (sort) params.sort = sort;
+          if (sort) params.sort = JSON.stringify(sort);
           if (fields) params.fields = fields;
 
           const records = await this.datasV3Service.dataList(context, {


### PR DESCRIPTION
## Change

- correct the `queryRecords` sort schema to use `direction`
- serialize the sort array before passing it to the V3 data service

This ensures sorting is applied and preserved in pagination URLs instead of being rendered as `[object Object]`.

## Verification

- `git diff --check`

No new tests added.