### PR TITLE
fix(currency): preserve minus sign when pasting negative values in en-US locale (Fixes #14413)

### DIFF
--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -282,7 +282,7 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        return value?.replace(/[^0-9.]/g, '')?.trim();
+        return value?.replace(/[^\d.-]/g, '')?.trim();
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(


### PR DESCRIPTION
## Summary

Fixes #14413

When pasting a negative value (e.g., `-100.50`) into a Currency field with the default `en-US` locale, the minus sign was silently dropped because the sanitizer regex `[^0-9.]` only kept digits and the decimal point, discarding the leading `-`.

## Root Cause

In `serializer.ts`, the `serializeCurrencyValue` function has a special fast path for `en-US` locale (line 285):

```typescript
// Before (buggy): strips minus sign
return value?.replace(/[^0-9.]/g, '')?.trim();

// After: keeps minus sign, matching the locale-aware path
return value?.replace(/[^\d.-]/g, '')?.trim();
```

The locale-aware path used by other locales (e.g., `de-DE`) already used `[^\d.-]` which correctly preserves the minus sign. This fix aligns the `en-US` fast path with the same logic.