### PR TITLE
fix(nocodb): retain all button visibility filters on save

### DIFF
--- a/packages/nc-gui/components/smartsheet/column/ButtonOptions/index.vue
+++ b/packages/nc-gui/components/smartsheet/column/ButtonOptions/index.vue
@@ -374,12 +374,31 @@ const filtersCount = ref(0)
 
 if (isEdit.value) {
   const existingFilters = (vModel.value.colOptions as ButtonType)?.filters
-  if (Array.isArray(existingFilters) && existingFilters.length) {
-    vModel.value.filters = existingFilters.map((f: FilterType) => ({ ...f }))
+  // Prefer draft filters already on the form (e.g. restored from an unsaved
+  // edit) over colOptions so remounting the editor does not drop in-progress
+  // visibility conditions.
+  if (!Array.isArray(vModel.value.filters) || !vModel.value.filters.length) {
+    if (Array.isArray(existingFilters) && existingFilters.length) {
+      vModel.value.filters = existingFilters.map((f: FilterType) => ({ ...f }))
+    }
+  }
+  if (Array.isArray(vModel.value.filters) && vModel.value.filters.length) {
     isFilterSectionOpen.value = true
-    filtersCount.value = existingFilters.filter((f: FilterType) => !f.is_group && f.fk_column_id).length
+    filtersCount.value = vModel.value.filters.filter((f: FilterType) => !f.is_group && f.fk_column_id).length
   }
 }
+
+// Keep formState.filters in sync with the filter editor (same pattern as
+// LTAR/Lookup/Rollup). Relying only on v-model can lose entries when the
+// editor remounts or when deep filter mutations do not re-emit the array.
+watch(
+  () => filterRef.value?.filters,
+  (next) => {
+    if (!vModel.value) return
+    vModel.value.filters = next ? [...next] : []
+  },
+  { deep: true },
+)
 </script>
 
 <template>

--- a/packages/nc-gui/components/smartsheet/details/Fields.vue
+++ b/packages/nc-gui/components/smartsheet/details/Fields.vue
@@ -284,7 +284,13 @@ const changingField = ref(false)
 
 // Field types whose editors are kept alive (v-show) across field switches so filter
 // state inside SmartsheetToolbarColumnFilter is never destroyed.
-const KEEP_ALIVE_TYPES = [UITypes.Links, UITypes.LinkToAnotherRecord, UITypes.Rollup, UITypes.Lookup]
+const KEEP_ALIVE_TYPES = [
+  UITypes.Links,
+  UITypes.LinkToAnotherRecord,
+  UITypes.Rollup,
+  UITypes.Lookup,
+  UITypes.Button,
+]
 
 const isKeepAliveType = (field?: TableExplorerColumn) => !!(field?.uidt && KEEP_ALIVE_TYPES.includes(field.uidt as UITypes))
 

--- a/packages/nocodb/src/models/Column.ts
+++ b/packages/nocodb/src/models/Column.ts
@@ -1308,6 +1308,10 @@ export default class Column<T = any> implements ColumnType {
     }
 
     const oldCol = await Column.get(context, { colId }, ncMeta);
+    // Target uidt after this update — fall back to the existing type when the
+    // payload omits uidt (partial updates). Used to decide whether button
+    // visibility filters should be wiped on colOption rebuild.
+    const incomingUidt = (column.uidt as UITypes) || oldCol.uidt;
     const requiredColAvail =
       !requiredColumnsToRecreate[oldCol.uidt] ||
       requiredColumnsToRecreate[oldCol.uidt].every((k) => column[k]);


### PR DESCRIPTION
## Summary
- Fixes undefined `incomingUidt` when rebuilding button colOptions on column update — the prior guard never defined the variable, so visibility filters were still wiped and only newly created filters survived save (Fixes #14337).
- Syncs button visibility filters via `filterRef` (same pattern as LTAR/Lookup/Rollup) and avoids overwriting in-progress draft filters on editor remount.
- Includes Button in keep-alive field editors so filter UI state is preserved across field switches in the table explorer.

## Test plan
- [ ] Edit a Button (webhook) column and add one visibility filter; save — filter persists
- [ ] Add a second visibility filter and save — **both** filters remain active
- [ ] Re-open the column editor — both filters are shown
- [ ] Convert the Button column to another type — visibility filters are cleaned up
- [ ] In Fields tab, switch away from and back to a Button field while editing filters — draft filters are retained
