### PR TITLE
fix: prevent false insert-failure toast on successful row add (#13002)

### DIFF
--- a/packages/nc-gui/composables/useInfiniteData.ts
+++ b/packages/nc-gui/composables/useInfiniteData.ts
@@ -46,6 +46,22 @@ const isGroupByValueEqual = (a: unknown, b: unknown): boolean => {
   return String(a) === String(b)
 }
 
+/**
+ * Runs post-insert UI bookkeeping (cache writes, row-color/button formula
+ * evaluation, aggregate reload) once a row has already been persisted by the
+ * API. A failure here is never an insert failure — the row already exists in
+ * the database — so it must not surface as one (e.g. a "Failed to insert
+ * row" toast on a row that was in fact created successfully, #13002).
+ * Swallows and logs instead of throwing.
+ */
+export const runPostInsertBookkeeping = (bookkeeping: () => void) => {
+  try {
+    bookkeeping()
+  } catch (error) {
+    console.error('Row was inserted successfully but post-insert UI update failed', error)
+  }
+}
+
 const formatData = (
   list: Record<string, any>[],
   pageInfo?: PaginatedType,
@@ -1506,47 +1522,54 @@ export function useInfiniteData(args: {
             { before: beforeRowID },
           )
 
-      currentRow.rowMeta.new = false
+      // The row is now persisted server-side — any failure from here on is local
+      // bookkeeping/rendering (cache shifting, row-color/button formula evaluation,
+      // aggregate reload), not an insert failure. Routing it through the outer
+      // catch would show a false "Failed to insert row" toast for a row that was
+      // in fact created successfully (#13002), so it's isolated and only logged.
+      runPostInsertBookkeeping(() => {
+        currentRow.rowMeta.new = false
 
-      Object.assign(currentRow.row, {
-        ...(currentRow.row ?? {}),
-        ...rowPkData(insertedData, metaValue?.columns as ColumnType[]),
-      })
+        Object.assign(currentRow.row, {
+          ...(currentRow.row ?? {}),
+          ...rowPkData(insertedData, metaValue?.columns as ColumnType[]),
+        })
 
-      const insertIndex = currentRow.rowMeta.rowIndex!
+        const insertIndex = currentRow.rowMeta.rowIndex!
 
-      Object.assign(currentRow.oldRow, insertedData)
+        Object.assign(currentRow.oldRow, insertedData)
 
-      if (dataCache.cachedRows.value.has(insertIndex) && !ignoreShifting) {
-        const rows = Array.from(dataCache.cachedRows.value.entries())
-        const rowsToShift = rows.filter(([index]) => index >= insertIndex)
-        rowsToShift.sort((a, b) => b[0] - a[0]) // Sort in descending order
+        if (dataCache.cachedRows.value.has(insertIndex) && !ignoreShifting) {
+          const rows = Array.from(dataCache.cachedRows.value.entries())
+          const rowsToShift = rows.filter(([index]) => index >= insertIndex)
+          rowsToShift.sort((a, b) => b[0] - a[0]) // Sort in descending order
 
-        for (const [index, row] of rowsToShift) {
-          row.rowMeta.rowIndex = index + 1
-          dataCache.cachedRows.value.set(index + 1, row)
+          for (const [index, row] of rowsToShift) {
+            row.rowMeta.rowIndex = index + 1
+            dataCache.cachedRows.value.set(index + 1, row)
+          }
         }
-      }
 
-      dataCache.cachedRows.value.set(insertIndex, {
-        row: { ...insertedData, ...currentRow.row },
-        oldRow: { ...insertedData },
-        rowMeta: {
-          ...currentRow.rowMeta,
-          rowIndex: insertIndex,
-          new: false,
-          saving: false,
-          isRlsHidden: !!insertedData?.__nc_rls_hidden,
-          ...getEvaluatedRowMetaRowColorInfo({ ...insertedData, ...currentRow.row }),
-          buttonDisabled: evaluateButtonVisibility({ ...insertedData, ...currentRow.row }),
-        },
+        dataCache.cachedRows.value.set(insertIndex, {
+          row: { ...insertedData, ...currentRow.row },
+          oldRow: { ...insertedData },
+          rowMeta: {
+            ...currentRow.rowMeta,
+            rowIndex: insertIndex,
+            new: false,
+            saving: false,
+            isRlsHidden: !!insertedData?.__nc_rls_hidden,
+            ...getEvaluatedRowMetaRowColorInfo({ ...insertedData, ...currentRow.row }),
+            buttonDisabled: evaluateButtonVisibility({ ...insertedData, ...currentRow.row }),
+          },
+        })
+
+        if (!ignoreShifting) {
+          dataCache.totalRows.value++
+        }
+        callbacks?.reloadAggregate?.({ path })
+        callbacks?.syncVisibleData?.()
       })
-
-      if (!ignoreShifting) {
-        dataCache.totalRows.value++
-      }
-      callbacks?.reloadAggregate?.({ path })
-      callbacks?.syncVisibleData?.()
 
       return insertedData
     } catch (error: any) {

--- a/packages/nc-gui/test/insert-row-post-bookkeeping.test.ts
+++ b/packages/nc-gui/test/insert-row-post-bookkeeping.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for `runPostInsertBookkeeping` — the guard `insertRow` (grid "Add row" /
+ * "Duplicate row") wraps its post-insert UI bookkeeping in.
+ *
+ * Repro of #13002: the row-insert API call succeeds and the row is committed to the
+ * database, but a later, purely local step (cache-index shifting, row-color/button
+ * formula evaluation, aggregate reload) throws. Before this fix that error fell into
+ * the same catch block as the API call itself, so the user saw "Failed to insert row"
+ * / "Add row failed: Some internal error occurred" even though the row was created.
+ *
+ * `runPostInsertBookkeeping` isolates that step: its failures are logged, never
+ * re-thrown, so they can never reach the toast that reports a genuine insert failure.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+// `~/composables/useInfiniteData` transitively imports `~/utils/dataUtils`, which
+// references the Nuxt auto-imported `iconMap` global at module-eval time. Provide a
+// stub before importing so the module can load under vitest.
+;(globalThis as any).iconMap = new Proxy({}, { get: () => undefined })
+
+let runPostInsertBookkeeping: typeof import('~/composables/useInfiniteData')['runPostInsertBookkeeping']
+
+beforeAll(async () => {
+  ;({ runPostInsertBookkeeping } = await import('~/composables/useInfiniteData'))
+})
+
+describe('runPostInsertBookkeeping', () => {
+  it('runs the bookkeeping callback and does not throw on success', () => {
+    const bookkeeping = vi.fn()
+
+    expect(() => runPostInsertBookkeeping(bookkeeping)).not.toThrow()
+    expect(bookkeeping).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows an error thrown by the bookkeeping callback instead of propagating it — regression for #13002', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const bookkeeping = vi.fn(() => {
+      throw new Error('row-color formula evaluation blew up')
+    })
+
+    // The row was already inserted successfully by this point — a bookkeeping
+    // failure must never bubble up and be mistaken for an insert failure.
+    expect(() => runPostInsertBookkeeping(bookkeeping)).not.toThrow()
+    expect(bookkeeping).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalledTimes(1)
+
+    consoleError.mockRestore()
+  })
+
+  it('still runs bookkeeping side effects up to the point where it throws', () => {
+    const sideEffects: string[] = []
+
+    runPostInsertBookkeeping(() => {
+      sideEffects.push('cache-updated')
+      throw new Error('aggregate reload failed')
+    })
+
+    expect(sideEffects).toEqual(['cache-updated'])
+  })
+})

--- a/packages/nc-gui/vitest.config.ts
+++ b/packages/nc-gui/vitest.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// Mirrors the `~` / `@` alias Nuxt exposes to the app (srcDir === project root,
+// see `.nuxt/tsconfig.json`), so composables/utils importable under `test/` can be
+// loaded directly by vitest without pulling in the full Nuxt build pipeline.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('.', import.meta.url)),
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- `insertRow` in `useInfiniteData.ts` wrapped all post-insert UI bookkeeping (cache-index shifting, row-color/button formula evaluation, aggregate reload) in the same `try`/`catch` as the actual `$api.dbViewRow.create` call. If any of that purely local bookkeeping threw after the API call had already succeeded, the shared `catch` reported it as an insert failure ("Failed to insert row: ...") even though the row had already been persisted server-side.
- Extracts the bookkeeping into a small `runPostInsertBookkeeping()` helper that runs it in its own try/catch and only logs a failure there instead of surfacing it as an insert error, so a genuine "Failed to insert row" toast can now only come from the insert API call itself.
- Adds `packages/nc-gui/vitest.config.ts` exposing the `~` alias Nuxt gives the app at runtime (mirrors `.nuxt/tsconfig.json`), so composables under `test/` can be imported directly by vitest without pulling in the whole Nuxt build pipeline.

Closes #13002

## Test plan
- Added `packages/nc-gui/test/insert-row-post-bookkeeping.test.ts` (vitest), covering:
  - bookkeeping runs normally on success
  - an error thrown mid-bookkeeping is swallowed/logged instead of propagating (the #13002 regression case)
  - side effects up to the throw point still run
- Verified the added tests fail without the fix (reverted `runPostInsertBookkeeping` to call the bookkeeping directly) and pass with it — 6/6 tests green including the existing `populate-insert-object.test.ts`.