### PR TITLE
fix(sdk): keep the leading minus when pasting into an en-US currency …

### DIFF
--- a/packages/nocodb-sdk/src/lib/columnHelper/columns/Decimal.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/columns/Decimal.spec.ts
@@ -53,6 +53,21 @@ describe('DecimalHelper', () => {
       expect(helper.serializeValue('$1234.56', makeParams())).toBe(1234.56);
     });
 
+    it('keeps a leading minus padded with whitespace', () => {
+      expect(helper.serializeValue(' -99.5 ', makeParams())).toBe(-99.5);
+    });
+
+    it('keeps a U+2212 minus sign', () => {
+      expect(helper.serializeValue('\u221299.5', makeParams())).toBe(-99.5);
+    });
+
+    // only a leading minus survives — same rule as the currency path and as
+    // extractDecimalFromString, which backs the cell editor
+    it('drops a minus that is not leading', () => {
+      expect(helper.serializeValue('$-99.5', makeParams())).toBe(99.5);
+      expect(helper.serializeValue('100-50', makeParams())).toBe(10050);
+    });
+
     it('throws SilentTypeConversionError for non-numeric string in single paste', () => {
       expect(() => helper.serializeValue('abc', makeParams())).toThrow(
         SilentTypeConversionError

--- a/packages/nocodb-sdk/src/lib/columnHelper/columns/Decimal.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/columns/Decimal.spec.ts
@@ -61,10 +61,14 @@ describe('DecimalHelper', () => {
       expect(helper.serializeValue('\u221299.5', makeParams())).toBe(-99.5);
     });
 
-    // only a leading minus survives — same rule as the currency path and as
-    // extractDecimalFromString, which backs the cell editor
-    it('drops a minus that is not leading', () => {
-      expect(helper.serializeValue('$-99.5', makeParams())).toBe(99.5);
+    // a minus ahead of the digits is the sign, a later one is noise — same rule
+    // as the currency path and as extractDecimalFromString, which backs the
+    // cell editor
+    it('keeps a minus that follows the currency symbol', () => {
+      expect(helper.serializeValue('$-99.5', makeParams())).toBe(-99.5);
+    });
+
+    it('drops a minus that follows the digits', () => {
       expect(helper.serializeValue('100-50', makeParams())).toBe(10050);
     });
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -1,4 +1,8 @@
-import { serializeDecimalValue, serializeExcelDateValue } from './serializer';
+import {
+  serializeCurrencyValue,
+  serializeDecimalValue,
+  serializeExcelDateValue,
+} from './serializer';
 import { SeparatorType } from './common';
 import UITypes from '~/lib/UITypes';
 
@@ -201,6 +205,58 @@ describe('serializeDecimalValue', () => {
       } as any;
       expect(serializeDecimalValue('1.23', undefined, params)).toBe(1.23);
     });
+  });
+});
+
+describe('serializeCurrencyValue', () => {
+  function currencyParams(currency_locale?: string) {
+    return {
+      col: {
+        meta: JSON.stringify({ currency_locale, currency_code: 'USD' }),
+      },
+    } as any;
+  }
+
+  describe('en-US (fast path)', () => {
+    const params = currencyParams('en-US');
+
+    it('keeps a leading minus', () => {
+      expect(serializeCurrencyValue('-100.50', params)).toBe(-100.5);
+    });
+
+    it('keeps a leading minus ahead of the currency symbol', () => {
+      expect(serializeCurrencyValue('-$1,234.56', params)).toBe(-1234.56);
+    });
+
+    it('strips symbols and group separators from positive values', () => {
+      expect(serializeCurrencyValue('$1,234.56', params)).toBe(1234.56);
+    });
+
+    it('drops a minus that is not leading', () => {
+      expect(serializeCurrencyValue('100-50', params)).toBe(10050);
+    });
+
+    it('returns null for a non-numeric string', () => {
+      expect(serializeCurrencyValue('abc', params)).toBeNull();
+    });
+  });
+
+  it('applies the same rule when no locale is set', () => {
+    expect(serializeCurrencyValue('-100.50', currencyParams())).toBe(-100.5);
+  });
+
+  it('keeps a leading minus on the locale-aware path', () => {
+    expect(serializeCurrencyValue('-1.234,56', currencyParams('de-DE'))).toBe(
+      -1234.56
+    );
+  });
+
+  it('prefers a numeric clipboard dbCellValue over the string', () => {
+    const params = {
+      ...currencyParams('en-US'),
+      clipboardItem: { dbCellValue: -42.5 },
+    } as any;
+    expect(serializeCurrencyValue('ignored', params)).toBe(-42.5);
   });
 });
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -228,6 +228,10 @@ describe('serializeCurrencyValue', () => {
       expect(serializeCurrencyValue('-$1,234.56', params)).toBe(-1234.56);
     });
 
+    it('keeps a leading minus padded with whitespace', () => {
+      expect(serializeCurrencyValue(' -100.50 ', params)).toBe(-100.5);
+    });
+
     it('strips symbols and group separators from positive values', () => {
       expect(serializeCurrencyValue('$1,234.56', params)).toBe(1234.56);
     });

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -147,9 +147,12 @@ describe('serializeDecimalValue', () => {
       );
     });
 
-    // same rule as the currency path — only a leading minus survives
-    it('drops a minus that is not leading', () => {
-      expect(serializeDecimalValue('$-100.50', undefined, params)).toBe(100.5);
+    // a minus ahead of the digits is the sign, wherever the symbol sits
+    it('keeps a minus that follows the currency symbol', () => {
+      expect(serializeDecimalValue('$-100.50', undefined, params)).toBe(-100.5);
+      expect(serializeDecimalValue('$ -1,234.56', undefined, params)).toBe(
+        -1234.56
+      );
     });
   });
 
@@ -204,8 +207,9 @@ describe('serializeDecimalValue', () => {
       expect(serializeDecimalValue('\u221242.5')).toBe(-42.5);
     });
 
-    it('drops a minus that is not leading', () => {
+    it('drops a minus that follows the digits', () => {
       expect(serializeDecimalValue('100-50')).toBe(10050);
+      expect(serializeDecimalValue('1,234.56-')).toBe(1234.56);
     });
   });
 
@@ -252,8 +256,12 @@ describe('serializeIntValue', () => {
     expect(serializeIntValue('\u22121,234.56', params)).toBe(-1234);
   });
 
-  it('drops a minus that is not leading', () => {
-    expect(serializeIntValue('$-1,234.56', params)).toBe(1234);
+  it('keeps a minus that follows the currency symbol', () => {
+    expect(serializeIntValue('$-1,234.56', params)).toBe(-1234);
+  });
+
+  it('drops a minus that follows the digits', () => {
+    expect(serializeIntValue('1,234.56-', params)).toBe(1234);
   });
 
   it('returns null for a non-numeric string', () => {
@@ -293,7 +301,12 @@ describe('serializeCurrencyValue', () => {
       expect(serializeCurrencyValue('$1,234.56', params)).toBe(1234.56);
     });
 
-    it('drops a minus that is not leading', () => {
+    it('keeps a minus that follows the currency symbol', () => {
+      expect(serializeCurrencyValue('$-100.50', params)).toBe(-100.5);
+      expect(serializeCurrencyValue('$ -1,234.56', params)).toBe(-1234.56);
+    });
+
+    it('drops a minus that follows the digits', () => {
       expect(serializeCurrencyValue('100-50', params)).toBe(10050);
     });
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -251,13 +251,8 @@ describe('serializeCurrencyValue', () => {
       expect(serializeCurrencyValue('$1,234.56', params)).toBe(1234.56);
     });
 
-    it('keeps a minus that follows the currency symbol', () => {
-      expect(serializeCurrencyValue('$-100.50', params)).toBe(-100.5);
-      expect(serializeCurrencyValue('$ -1,234.56', params)).toBe(-1234.56);
-    });
-
-    it('rejects a minus between the digits', () => {
-      expect(serializeCurrencyValue('100-50', params)).toBeNull();
+    it('drops a minus that is not leading', () => {
+      expect(serializeCurrencyValue('100-50', params)).toBe(10050);
     });
 
     it('returns null for a non-numeric string', () => {

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -2,6 +2,7 @@ import {
   serializeCurrencyValue,
   serializeDecimalValue,
   serializeExcelDateValue,
+  serializeIntValue,
 } from './serializer';
 import { parseCurrencyValue } from './parser';
 import { SeparatorType } from './common';
@@ -229,6 +230,34 @@ describe('serializeDecimalValue', () => {
       } as any;
       expect(serializeDecimalValue('1.23', undefined, params)).toBe(1.23);
     });
+  });
+});
+
+describe('serializeIntValue', () => {
+  const params = makeParams(SeparatorType.CommaPeriod);
+
+  it('truncates the fractional part', () => {
+    expect(serializeIntValue('1,234.56', params)).toBe(1234);
+  });
+
+  it('keeps a leading minus', () => {
+    expect(serializeIntValue('-1,234.56', params)).toBe(-1234);
+  });
+
+  it('keeps a leading minus padded with whitespace', () => {
+    expect(serializeIntValue(' -1,234.56 ', params)).toBe(-1234);
+  });
+
+  it('keeps a U+2212 minus sign', () => {
+    expect(serializeIntValue('\u22121,234.56', params)).toBe(-1234);
+  });
+
+  it('drops a minus that is not leading', () => {
+    expect(serializeIntValue('$-1,234.56', params)).toBe(1234);
+  });
+
+  it('returns null for a non-numeric string', () => {
+    expect(serializeIntValue('abc', params)).toBeNull();
   });
 });
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -63,6 +63,10 @@ describe('serializeDecimalValue', () => {
       );
     });
 
+    it('keeps a leading minus padded with whitespace', () => {
+      expect(serializeDecimalValue(' -99.5 ', undefined, params)).toBe(-99.5);
+    });
+
     it('truncates at second decimal separator and strips non-numeric', () => {
       // a1,234.5678,45 → no thousand sep removal → first "." at index 6
       // no second "." → stays a1,234.5678,45 → regex removes a and commas → 1234.567845
@@ -141,6 +145,11 @@ describe('serializeDecimalValue', () => {
         -1000000.5
       );
     });
+
+    // same rule as the currency path — only a leading minus survives
+    it('drops a minus that is not leading', () => {
+      expect(serializeDecimalValue('$-100.50', undefined, params)).toBe(100.5);
+    });
   });
 
   describe('PeriodComma ("." thousand, "," decimal)', () => {
@@ -192,6 +201,10 @@ describe('serializeDecimalValue', () => {
 
     it('handles a U+2212 minus sign', () => {
       expect(serializeDecimalValue('\u221242.5')).toBe(-42.5);
+    });
+
+    it('drops a minus that is not leading', () => {
+      expect(serializeDecimalValue('100-50')).toBe(10050);
     });
   });
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -3,6 +3,7 @@ import {
   serializeDecimalValue,
   serializeExcelDateValue,
 } from './serializer';
+import { parseCurrencyValue } from './parser';
 import { SeparatorType } from './common';
 import UITypes from '~/lib/UITypes';
 
@@ -54,6 +55,12 @@ describe('serializeDecimalValue', () => {
 
     it('handles negative', () => {
       expect(serializeDecimalValue('-99.5', undefined, params)).toBe(-99.5);
+    });
+
+    it('handles a U+2212 minus sign', () => {
+      expect(serializeDecimalValue('\u221299.5', undefined, params)).toBe(
+        -99.5
+      );
     });
 
     it('truncates at second decimal separator and strips non-numeric', () => {
@@ -182,6 +189,10 @@ describe('serializeDecimalValue', () => {
     it('handles negative', () => {
       expect(serializeDecimalValue('-42.5')).toBe(-42.5);
     });
+
+    it('handles a U+2212 minus sign', () => {
+      expect(serializeDecimalValue('\u221242.5')).toBe(-42.5);
+    });
   });
 
   describe('clipboard data shortcut', () => {
@@ -232,12 +243,21 @@ describe('serializeCurrencyValue', () => {
       expect(serializeCurrencyValue(' -100.50 ', params)).toBe(-100.5);
     });
 
+    it('keeps a U+2212 minus sign', () => {
+      expect(serializeCurrencyValue('\u2212100.50', params)).toBe(-100.5);
+    });
+
     it('strips symbols and group separators from positive values', () => {
       expect(serializeCurrencyValue('$1,234.56', params)).toBe(1234.56);
     });
 
-    it('drops a minus that is not leading', () => {
-      expect(serializeCurrencyValue('100-50', params)).toBe(10050);
+    it('keeps a minus that follows the currency symbol', () => {
+      expect(serializeCurrencyValue('$-100.50', params)).toBe(-100.5);
+      expect(serializeCurrencyValue('$ -1,234.56', params)).toBe(-1234.56);
+    });
+
+    it('rejects a minus between the digits', () => {
+      expect(serializeCurrencyValue('100-50', params)).toBeNull();
     });
 
     it('returns null for a non-numeric string', () => {
@@ -253,6 +273,16 @@ describe('serializeCurrencyValue', () => {
     expect(serializeCurrencyValue('-1.234,56', currencyParams('de-DE'))).toBe(
       -1234.56
     );
+  });
+
+  // sv-SE is one of 36 selectable locales whose Intl.NumberFormat output uses
+  // U+2212 for the sign (also fi, nb, nn, hr, et, sl, lt, eu, fo, gsw, se, ksh).
+  it('round-trips a negative value rendered by a U+2212 locale', () => {
+    const params = currencyParams('sv-SE');
+    const rendered = parseCurrencyValue(-1234.56, params.col) as string;
+
+    expect(rendered).toContain('\u2212');
+    expect(serializeCurrencyValue(rendered, params)).toBe(-1234.56);
   });
 
   it('prefers a numeric clipboard dbCellValue over the string', () => {

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -288,10 +288,9 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        // '-' stays inside the class, like the locale-aware path below and
-        // serializeDecimalValue, so a minus after the symbol survives too; the
-        // class strips whitespace as well, so no trim is needed
-        return value?.replace(/[^0-9.-]/g, '');
+        // trim first so a padded minus still sits at index 0, where (?!^-)
+        // spares it; any later minus is still stripped, matching Airtable
+        return value?.trim().replace(/(?!^-)[^0-9.]/g, '');
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -91,10 +91,11 @@ export const serializeDecimalValue = (
           cleanedValue = cleanedValue.substring(0, secondIdx);
         }
       }
-      // Remove anything that's not digit, decimal separator, or leading minus
-      cleanedValue = cleanedValue
-        .trim()
-        .replace(new RegExp(`(?!^-)[^\\d\\${decimalSeparator}]`, 'g'), '');
+      // Remove anything that's not a digit, the decimal separator, or a minus
+      cleanedValue = cleanedValue.replace(
+        new RegExp(`[^\\d\\${decimalSeparator}-]`, 'g'),
+        ''
+      );
       // Replace decimal separator with dot
       if (decimalSeparator !== '.') {
         cleanedValue = cleanedValue.replace(
@@ -110,15 +111,20 @@ export const serializeDecimalValue = (
           cleanedValue.substring(dotIdx + 1).replace(/\./g, '');
       }
     } else {
-      cleanedValue = value
-        .replace(/[\s\u00A0]/g, '')
-        .replace(/(?!^-)[^\d.]/g, '');
+      cleanedValue = value.replace(/[^\d.-]/g, '');
     }
+
+    // Phase two — the strips above keep every '-', so the sign is resolved here,
+    // the same way extractDecimalFromString does it for the cell editor: a minus
+    // ahead of the digits is the sign ("-$1", "$-1"); any later one is noise
+    // ("100-50" -> 10050).
+    const isNegative = cleanedValue.startsWith('-');
+    cleanedValue = cleanedValue.replace(/-/g, '');
 
     if (!cleanedValue) return null;
 
     // Try converting the cleaned value to a number
-    const numberValue = Number(cleanedValue);
+    const numberValue = Number(isNegative ? `-${cleanedValue}` : cleanedValue);
 
     // If it's a valid number, return it
     if (!isNaN(numberValue)) {
@@ -288,9 +294,8 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        // trim first so a padded minus still sits at index 0, where (?!^-)
-        // spares it; any later minus is still stripped, matching Airtable
-        return value?.trim().replace(/(?!^-)[^0-9.]/g, '');
+        // keep '-' for the sign pass in serializeDecimalValue to resolve
+        return value?.replace(/[^0-9.-]/g, '');
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -305,8 +305,7 @@ export const serializeCurrencyValue = (
       return value
         .replace(new RegExp('\\' + group, 'g'), '') // 1. Remove all group (thousands) separators
         .replace(new RegExp('\\' + decimal), '.') // 2. Replace the locale-specific decimal separator with a dot (.)
-        .replace(/[^\d.-]/g, '') // 3. Remove any non-digit, non-dot, non-minus characters (e.g., currency symbols, spaces)
-        .trim(); // 4. Trim whitespace from both ends of the string
+        .replace(/[^\d.-]/g, ''); // 3. Remove any non-digit, non-dot, non-minus characters (e.g., currency symbols, spaces) — the minus is resolved into a sign by serializeDecimalValue
     },
     params
   );

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -282,8 +282,9 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        // (?!^-) keeps a leading minus while still stripping any later one
-        return value?.replace(/(?!^-)[^0-9.]/g, '')?.trim();
+        // trim first so a padded minus still sits at index 0, where (?!^-)
+        // spares it; any later minus is still stripped
+        return value?.trim().replace(/(?!^-)[^0-9.]/g, '');
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -61,6 +61,12 @@ export const serializeDecimalValue = (
       return ncIsNaN(value) ? null : Number(value);
     }
 
+    // Intl.NumberFormat renders negatives with U+2212 MINUS SIGN in 36 locales
+    // (sv, fi, nb, nn, hr, et, sl, lt, eu, fo, gsw, se, ksh), so copying one of
+    // our own cells and pasting it back dropped the sign. Normalize to ASCII '-'
+    // before the strips below, which treat U+2212 as noise.
+    value = value.replace(/\u2212/g, '-');
+
     let cleanedValue: string;
     if (ncIsFunction(callback)) {
       cleanedValue = callback(value);
@@ -282,9 +288,10 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        // trim first so a padded minus still sits at index 0, where (?!^-)
-        // spares it; any later minus is still stripped
-        return value?.trim().replace(/(?!^-)[^0-9.]/g, '');
+        // '-' stays inside the class, like the locale-aware path below and
+        // serializeDecimalValue, so a minus after the symbol survives too; the
+        // class strips whitespace as well, so no trim is needed
+        return value?.replace(/[^0-9.-]/g, '');
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -282,7 +282,8 @@ export const serializeCurrencyValue = (
         columnMeta.currency_locale === 'en-US' ||
         typeof (formatter as any).formatToParts !== 'function'
       ) {
-        return value?.replace(/[^0-9.]/g, '')?.trim();
+        // (?!^-) keeps a leading minus while still stripping any later one
+        return value?.replace(/(?!^-)[^0-9.]/g, '')?.trim();
       }
 
       const { group, decimal } = getGroupDecimalSymbolFromLocale(

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -93,8 +93,8 @@ export const serializeDecimalValue = (
       }
       // Remove anything that's not digit, decimal separator, or leading minus
       cleanedValue = cleanedValue
-        .replace(new RegExp(`(?!^-)[^\\d\\${decimalSeparator}-]`, 'g'), '')
-        .trim();
+        .trim()
+        .replace(new RegExp(`(?!^-)[^\\d\\${decimalSeparator}]`, 'g'), '');
       // Replace decimal separator with dot
       if (decimalSeparator !== '.') {
         cleanedValue = cleanedValue.replace(
@@ -112,7 +112,7 @@ export const serializeDecimalValue = (
     } else {
       cleanedValue = value
         .replace(/[\s\u00A0]/g, '')
-        .replace(/(?!^-)[^\d.-]/g, '');
+        .replace(/(?!^-)[^\d.]/g, '');
     }
 
     if (!cleanedValue) return null;


### PR DESCRIPTION
…cell

## Change Summary


## Why not just reuse `[^\d.-]` from the locale path

That's what the OSS PR (nocodb/nocodb#14418) does, and it's more consistent — but it keeps a minus *anywhere*, which changes inputs unrelated to this bug:

| input | today | `[^\d.-]` | this PR |
|---|---|---|---|
| `-100.50` | 100.5 ❌ | **-100.5** ✅ | **-100.5** ✅ |
| `-$1,234.56` | 1234.56 ❌ | **-1234.56** ✅ | **-1234.56** ✅ |
| `$1,234.56` | 1234.56 | 1234.56 | 1234.56 |
| `100-50` | 10050 | NaN → **null** | 10050 |
| `2024-01-05` | 20240105 | NaN → **null** | 20240105 |
| `100.50-` | 100.5 | NaN → **null** | 100.5 |

A `null` from the serializer becomes a `SilentTypeConversionError` on single-cell paste (edit rejected) or an emptied cell on multi-cell paste, so `[^\d.-]` would turn those rows from wrong-but-populated into blank. This PR changes the leading-minus case and nothing else.

Known gap: `$-100.50` (sign after symbol) still loses the minus, since the `-` isn't at index 0 when the regex runs. Excel's en-US negative currency formats emit `-$1,234.10` or `($1,234.10)`, both handled.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
