### PR TITLE
fix: copy a single LongText cell without CSV quoting

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/composables/useCopyPaste.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/composables/useCopyPaste.ts
@@ -14,6 +14,7 @@ import {
   isSystemColumn,
   isVirtualCol,
   populateUniqueFileName,
+  unquoteSingleCellClipboardValue,
 } from 'nocodb-sdk'
 import { generateUniqueColumnName } from '../../../../../helpers/parsers/parserHelpers'
 import convertCellData from '../../../../../composables/useMultiSelect/convertCellData'
@@ -1354,7 +1355,13 @@ export function useCopyPaste({
             { enrichClipboard: true, includeHtml: true },
           )
 
-          const plainTextValue = isValidValue(textToCopy) ? textToCopy : ''
+          // #14442: a single-cell copy must carry the RAW value. LongText's
+          // parseValue CSV-quotes its output so multi-cell TSV keeps grid
+          // structure; unwrapping it only for the lone-cell clipboard text
+          // leaves in-app paste (dbCellValueArr) and range copies intact.
+          const plainTextValue = isValidValue(textToCopy)
+            ? unquoteSingleCellClipboardValue(textToCopy, columnObj)
+            : ''
 
           await copyMimes({ 'text/plain': plainTextValue, ...clipboardContent })
 

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.spec.ts
@@ -3,6 +3,8 @@ import {
   serializeDecimalValue,
   serializeExcelDateValue,
   serializeIntValue,
+  serializeStringValue,
+  unquoteSingleCellClipboardValue,
 } from './serializer';
 import { parseCurrencyValue } from './parser';
 import { SeparatorType } from './common';
@@ -410,5 +412,51 @@ describe('serializeExcelDateValue', () => {
         '2025-01-01 18:00:00+00:00'
       );
     });
+  });
+});
+
+describe('unquoteSingleCellClipboardValue', () => {
+  const longTextCol = { uidt: UITypes.LongText } as any;
+  const singleLineCol = { uidt: UITypes.SingleLineText } as any;
+
+  it('unwraps what LongText.parseValue quoted so a lone cell copies raw', () => {
+    const quoted = `"line one\nline with \"inner\" quotes"`;
+    expect(unquoteSingleCellClipboardValue(quoted, longTextCol)).toBe(
+      'line one\nline with "inner" quotes'
+    );
+  });
+
+  it('unwraps the minimal empty-string quoting to an empty string', () => {
+    expect(unquoteSingleCellClipboardValue('""', longTextCol)).toBe('');
+  });
+
+  it('keeps values that parseValue would not have quoted', () => {
+    expect(unquoteSingleCellClipboardValue('plain', longTextCol)).toBe('plain');
+  });
+
+  it('passes nullish through instead of coercing to a string', () => {
+    expect(unquoteSingleCellClipboardValue(null, longTextCol)).toBe(null);
+    expect(unquoteSingleCellClipboardValue(undefined, longTextCol)).toBe(
+      undefined
+    );
+  });
+
+  it('never touches other column types, even fully quoted values', () => {
+    expect(
+      unquoteSingleCellClipboardValue('"legitimately quoted"', singleLineCol)
+    ).toBe('"legitimately quoted"');
+    expect(unquoteSingleCellClipboardValue('"quoted"', undefined)).toBe(
+      '"quoted"'
+    );
+  });
+
+  it('round-trips with serializeStringValue, the paste-side unwrapper', () => {
+    const original = 'a\tb\nc with "quotes"';
+    const quotedByParseValue = `"${original.replace(/"/g, '\\"')}"`;    const copiedRaw = unquoteSingleCellClipboardValue(
+      quotedByParseValue,
+      longTextCol
+    );
+    expect(copiedRaw).toBe(original);
+    expect(serializeStringValue(copiedRaw)).toBe(copiedRaw);
   });
 });

--- a/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
+++ b/packages/nocodb-sdk/src/lib/columnHelper/utils/serializer.ts
@@ -33,6 +33,32 @@ export const serializeStringValue = (value: any) => {
   return value;
 };
 
+/**
+ * Return the raw text a SINGLE-CELL copy should place on the clipboard.
+ *
+ * LongText.parseValue CSV-quotes its value (escaping inner quotes) so that
+ * multi-cell selections keep their grid structure when the cells are joined
+ * into TSV. A single-cell copy has no grid to protect: pasting the quoted
+ * form into any other application wraps the value in literal quotes and
+ * escapes its inner ones (#14442). In-app paste is unaffected either way —
+ * it round-trips through the clipboard item's dbCellValueArr, not the plain
+ * text.
+ *
+ * Only LongText columns are unwrapped (the one parser that quotes), so a
+ * legitimate value of any other type that happens to start and end with a
+ * quote character is never touched.
+ */
+export const unquoteSingleCellClipboardValue = (
+  value: any,
+  col?: ColumnType
+): any => {
+  if (col?.uidt !== UITypes.LongText) return value;
+
+  const unquoted = serializeStringValue(value);
+
+  return unquoted === null ? value : unquoted;
+};
+
 export const serializeDecimalValue = (
   value: string | null | number,
   callback?: (val: any) => any,


### PR DESCRIPTION
## Overview

Copying a single Long Text cell put a CSV-quoted value on the clipboard, so pasting into any other application wrapped the content in literal `"` … `"` with inner quotes escaped as `\"`.

Closes #14442

## Root cause

`LongText.parseValue` unconditionally returns `"<escaped>"`. That quoting exists for a good reason: multi-cell selections are joined into TSV, and quoting keeps a long text's embedded newlines/tabs from breaking the grid structure (paste-side `serializeValue` strips it again via `serializeStringValue`). But the **single-cell** copy path (`useCopyPaste`'s lone-cell branch) put `parseValue`'s output straight onto the clipboard as `text/plain` — quotes included, with no grid to protect.

## Fix

- New `unquoteSingleCellClipboardValue(value, col)` in the sdk (`columnHelper/utils/serializer.ts`): returns the raw text for a single-cell copy by unwrapping exactly what `LongText.parseValue` quoted. Applied to **LongText columns only** — the one parser that quotes — so a legitimate value of any other type that happens to start and end with a quote character is never touched. Nullish values pass through untouched.
- `useCopyPaste.ts`'s single-cell branch applies it to the plain-text clipboard value (and `copiedPlainText`, keeping the internal fallback consistent).

What does **not** change:

- **In-app paste**: round-trips through the clipboard item's `dbCellValueArr` (raw DB values), not the plain text.
- **Range copies**: keep their per-cell quoting, so TSV grid structure and the external TSV contract are unchanged.
- **`parseValue`/`serializeValue` themselves**: rendering, fill-drag, and every other consumer keep the exact contract they had.

## Testing

Colocated `serializer.spec.ts` additions (the sdk jest suite does not run in CI today, so I also verified against the real module with a tsx driver — all cases pass on this branch, and the helper does not exist on `develop` to pass them):

- unwraps the quoted multiline form (with escaped inner quotes) back to the raw value;
- `""` → empty string; plain values, `null`/`undefined` pass through;
- SingleLineText and column-less values are never touched, even fully quoted ones;
- full round trip: `parseValue`-quoted → unwrapped copy → paste-side `serializeStringValue` leaves the raw text intact.

Differential note: on `develop`, copying a cell containing `line one
line 2` puts `"line one
line 2"` (quoted) on the OS clipboard; with this branch it puts `line one
line 2`.