### PR TITLE
chore: bump bundled Postgres from 17 to 18

### DIFF
--- a/docker-compose/1_Auto_Upstall/docker-compose.yml
+++ b/docker-compose/1_Auto_Upstall/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: nocodb

--- a/docker-compose/1_Auto_Upstall/noco.sh
+++ b/docker-compose/1_Auto_Upstall/noco.sh
@@ -446,7 +446,7 @@ EOF
     cat >> "$f" <<EOF
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: ${PG_USER}
       POSTGRES_PASSWORD: ${PG_PASSWORD}

--- a/docker-compose/1_Auto_Upstall/tests/golden/external-redis/docker-compose.yml
+++ b/docker-compose/1_Auto_Upstall/tests/golden/external-redis/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: __PASSWORD__

--- a/docker-compose/1_Auto_Upstall/tests/golden/local/docker-compose.yml
+++ b/docker-compose/1_Auto_Upstall/tests/golden/local/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: __PASSWORD__

--- a/docker-compose/1_Auto_Upstall/tests/golden/production-ip/docker-compose.yml
+++ b/docker-compose/1_Auto_Upstall/tests/golden/production-ip/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: __PASSWORD__

--- a/docker-compose/1_Auto_Upstall/tests/golden/production-ssl/docker-compose.yml
+++ b/docker-compose/1_Auto_Upstall/tests/golden/production-ssl/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: __PASSWORD__

--- a/docker-compose/examples/quickstart-demo/docker-compose.yml
+++ b/docker-compose/examples/quickstart-demo/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - nocodb-network
 
   db:
-    image: postgres:17.10
+    image: postgres:18.6
     environment:
       POSTGRES_USER: nocodb
       POSTGRES_PASSWORD: quickstart_demo_pw_change_me


### PR DESCRIPTION
## Change Summary

Bumps the bundled Postgres image from **17.10 to 18.6** in the Auto-Upstall installer and the checked-in example stacks.

| File | Change |
|---|---|
| `docker-compose/1_Auto_Upstall/noco.sh` (line 449) | compose generator's `db` image |
| `docker-compose/1_Auto_Upstall/docker-compose.yml` | reference stack |
| `docker-compose/examples/quickstart-demo/docker-compose.yml` | quickstart demo |
| `tests/golden/{local,production-ip,production-ssl,external-redis}/docker-compose.yml` | regenerated fixtures |

`18.6` is the current 18.x patch release, keeping the pinned-patch style of `17.10`.

Companion PR in the internal repo: nocodb/nocohub#10190 (same compose bump, plus CI service containers and the nc-migrator client tools, which do not exist here).

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [x] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Golden fixtures were **not** hand-edited: they were regenerated with `tests/lib/regen-golden.sh` after changing `noco.sh`, so generator and fixtures cannot disagree. Regeneration touched exactly the 4 bundled-Postgres scenarios and nothing else; the 4 external-Postgres scenarios are byte-identical, as expected.
- Confirmed `postgres:18.6` exists on Docker Hub.
- `bats` is not installed locally, so `tests/install/*.bats` was not executed. CI covers it.

## Additional information / screenshots (optional)

**This is not an in-place upgrade for existing installs.** A Postgres 18 container will refuse to start against a PG 17 data directory, so anyone who re-runs the installer or pulls a new compose file over an existing `postgres_data` volume needs a `pg_dump`/restore rather than a raw volume reuse. New installs are unaffected. A docs PR covering the upgrade path is being prepared alongside this.

Worth considering separately: `noco.sh` lives here while a copy of its golden fixtures also lives in the internal repo, which is how the two drifted apart in the first place. Colocating the generator with its fixtures (or regenerating them in CI) would remove that class of drift.
