### PR TITLE
fix(storage): handle R2 URLs and attachment cleanup

### DIFF
--- a/packages/nocodb/src/helpers/attachmentHelpers.Source.spec.ts
+++ b/packages/nocodb/src/helpers/attachmentHelpers.Source.spec.ts
@@ -1,0 +1,53 @@
+jest.mock('~/helpers/catchError', () => ({ NcError: {} }));
+jest.mock('~/helpers/NcPluginMgrv2', () => ({ default: {} }));
+jest.mock('~/models', () => ({ PresignedUrl: {} }));
+jest.mock('~/utils', () => ({ isSecureAttachmentEnabled: jest.fn() }));
+jest.mock('~/utils/nc-config', () => ({ getToolDir: jest.fn() }));
+jest.mock('~/utils/ssrf', () => ({ getFilteredAgents: jest.fn() }));
+
+import {
+  getSafeAttachmentErrorLog,
+  getSafeAttachmentLogIdentifier,
+  tryDeleteUploadedFile,
+} from './attachmentHelpers';
+
+describe('safe attachment logging', () => {
+  it('redacts URLs and credential-like values while keeping diagnostics', () => {
+    const { message, stack } = getSafeAttachmentErrorLog(
+      new Error(
+        'upload failed https://account.example/file?X-Amz-Signature=secret token=secret',
+      ),
+    );
+
+    expect(message).toContain('[REDACTED_URL]');
+    expect(message).not.toContain('X-Amz-Signature=secret');
+    expect(message).toContain('token=[REDACTED]');
+    expect(stack).toBeDefined();
+  });
+
+  it('uses a URL pathname as a safe attachment identifier', () => {
+    expect(
+      getSafeAttachmentLogIdentifier(
+        'https://account.example/nc/uploads/file.txt?signature=secret',
+      ),
+    ).toBe('/nc/uploads/file.txt');
+  });
+});
+
+describe('tryDeleteUploadedFile', () => {
+  it('passes the exact upload destination to the adapter', async () => {
+    const fileDelete = jest.fn().mockResolvedValue(undefined);
+
+    await tryDeleteUploadedFile({ fileDelete }, 'nc/uploads/exact/key.mp4');
+
+    expect(fileDelete).toHaveBeenCalledWith('nc/uploads/exact/key.mp4');
+  });
+
+  it('does not replace the original failure when cleanup fails', async () => {
+    const fileDelete = jest.fn().mockRejectedValue(new Error('cleanup failed'));
+
+    await expect(
+      tryDeleteUploadedFile({ fileDelete }, 'nc/uploads/exact/key.mp4'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/nocodb/src/helpers/attachmentHelpers.ts
+++ b/packages/nocodb/src/helpers/attachmentHelpers.ts
@@ -10,6 +10,7 @@ import type { Response } from 'express';
 import type { NcContext } from 'nocodb-sdk';
 import type { Column } from '~/models';
 import type { AttachmentsService } from '~/services/attachments.service';
+import type IStorageAdapter from '~/types/nc-plugin/lib/IStorageAdapter';
 import { getToolDir } from '~/utils/nc-config';
 import { NcError } from '~/helpers/catchError';
 import NcPluginMgrv2 from '~/helpers/NcPluginMgrv2';
@@ -219,6 +220,57 @@ export function resolveAttachmentFilePath(attachment: {
   }
 
   throw new Error('Attachment must have either path or url');
+}
+
+const redactAttachmentLogValue = (value: string) =>
+  value
+    .replace(/https?:\/\/[^\s"'<>]+/gi, '[REDACTED_URL]')
+    .replace(
+      /((?:access[_-]?key(?:id)?|secret(?:[_-]?access)?[_-]?key|password|token|authorization|signature)\s*[:=]\s*)[^\s,;}\]]+/gi,
+      '$1[REDACTED]',
+    );
+
+export function getSafeAttachmentErrorLog(error: unknown): {
+  message: string;
+  stack?: string;
+} {
+  let message: string;
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === 'string') {
+    message = error;
+  } else {
+    try {
+      message = JSON.stringify(error) ?? String(error);
+    } catch {
+      message = String(error);
+    }
+  }
+
+  return {
+    message: redactAttachmentLogValue(message),
+    stack:
+      error instanceof Error && error.stack
+        ? redactAttachmentLogValue(error.stack)
+        : undefined,
+  };
+}
+
+export function getSafeAttachmentLogIdentifier(fileUrl: string): string {
+  try {
+    return new URL(fileUrl).pathname;
+  } catch {
+    return fileUrl.split(/[?#]/, 1)[0];
+  }
+}
+
+export async function tryDeleteUploadedFile(
+  storageAdapter: Pick<IStorageAdapter, 'fileDelete'>,
+  storagePath: string,
+): Promise<void> {
+  try {
+    await storageAdapter.fileDelete(storagePath);
+  } catch {}
 }
 
 export const localFileExists = (path: string) => {

--- a/packages/nocodb/src/modules/jobs/attachment-clean-up.Source.spec.ts
+++ b/packages/nocodb/src/modules/jobs/attachment-clean-up.Source.spec.ts
@@ -1,0 +1,125 @@
+jest.mock('~/Noco', () => ({ __esModule: true, default: {} }));
+const mockStorageAdapter = jest.fn();
+jest.mock('~/helpers/NcPluginMgrv2', () => ({
+  __esModule: true,
+  default: { storageAdapter: mockStorageAdapter },
+}));
+jest.mock('~/utils/globals', () => ({
+  MetaTable: { FILE_REFERENCES: 'nc_file_references' },
+}));
+jest.mock('~/helpers/attachmentHelpers', () => ({
+  getPathFromUrl: (url: string, removePrefix: boolean) => {
+    const pathname = new URL(url).pathname;
+    return removePrefix ? pathname.replace(/.*?nc\/uploads\//, '') : pathname;
+  },
+}));
+
+import Noco from '~/Noco';
+import { AttachmentCleanUpProcessor } from './jobs/attachment-clean-up/attachment-clean-up';
+
+const oldDate = () => new Date(Date.now() - 11 * 24 * 60 * 60 * 1000);
+
+function query(result?: unknown) {
+  const builder: any = {};
+  builder.select = jest.fn().mockReturnValue(builder);
+  builder.max = jest.fn().mockReturnValue(builder);
+  builder.groupBy = jest.fn().mockReturnValue(builder);
+  builder.havingRaw = jest.fn().mockReturnValue(builder);
+  builder.where = jest.fn().mockReturnValue(builder);
+  builder.whereNotNull = jest.fn().mockReturnValue(builder);
+  builder.first = jest.fn().mockResolvedValue(result);
+  builder.del = jest.fn().mockResolvedValue(1);
+  return builder;
+}
+
+function setup(files: any[], rootFile?: { storage: string; file_url: string }) {
+  const orphanedFiles = query();
+  orphanedFiles.select
+    .mockReturnValueOnce(orphanedFiles)
+    .mockResolvedValueOnce(files);
+  const rootKey = query(rootFile);
+  const deletedRows = query();
+  const knexConnection = jest
+    .fn()
+    .mockReturnValueOnce(orphanedFiles)
+    .mockReturnValueOnce(rootKey)
+    .mockReturnValueOnce(deletedRows);
+  (Noco as any).ncMeta = { knexConnection };
+
+  const fileDelete = jest.fn().mockResolvedValue(undefined);
+  mockStorageAdapter.mockResolvedValue({
+    name: 'R2',
+    fileDelete,
+  });
+
+  return { deletedRows, fileDelete, orphanedFiles };
+}
+
+describe('AttachmentCleanUpProcessor', () => {
+  it('keeps recent deleted references', async () => {
+    const file = {
+      file_url:
+        'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/recent.pdf',
+      last_updated_at: new Date(),
+    };
+    const { fileDelete, deletedRows } = setup([file], {
+      storage: 'R2',
+      file_url: file.file_url,
+    });
+
+    await new AttachmentCleanUpProcessor().job({ id: 'cleanup' } as any);
+
+    expect(fileDelete).not.toHaveBeenCalled();
+    expect(deletedRows.del).not.toHaveBeenCalled();
+  });
+
+  it('deletes expired orphaned objects and thumbnails', async () => {
+    const file = {
+      file_url:
+        'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/expired.pdf',
+      last_updated_at: oldDate(),
+    };
+    const { fileDelete, deletedRows } = setup([file], {
+      storage: 'R2',
+      file_url: file.file_url,
+    });
+
+    await new AttachmentCleanUpProcessor().job({ id: 'cleanup' } as any);
+
+    expect(fileDelete.mock.calls).toEqual([
+      ['nc/uploads/expired.pdf'],
+      ['nc/thumbnails/expired.pdf/tiny.jpg'],
+      ['nc/thumbnails/expired.pdf/small.jpg'],
+      ['nc/thumbnails/expired.pdf/card_cover.jpg'],
+    ]);
+    expect(deletedRows.del).toHaveBeenCalled();
+  });
+
+  it('does not delete references that are still active', async () => {
+    const { fileDelete, orphanedFiles } = setup([]);
+
+    await new AttachmentCleanUpProcessor().job({ id: 'cleanup' } as any);
+
+    expect(orphanedFiles.havingRaw).toHaveBeenCalledWith(
+      expect.stringContaining('COUNT(CASE WHEN deleted THEN 1 END)'),
+    );
+    expect(fileDelete).not.toHaveBeenCalled();
+  });
+
+  it('skips files owned by another storage adapter', async () => {
+    const file = {
+      file_url:
+        'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/other.pdf',
+      last_updated_at: oldDate(),
+    };
+    const { fileDelete, deletedRows } = setup([file], {
+      storage: 'S3',
+      file_url: file.file_url,
+    });
+
+    await new AttachmentCleanUpProcessor().job({ id: 'cleanup' } as any);
+
+    expect(fileDelete).not.toHaveBeenCalled();
+    expect(deletedRows.del).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nocodb/src/modules/jobs/fallback/jobs.service.ts
+++ b/packages/nocodb/src/modules/jobs/fallback/jobs.service.ts
@@ -17,15 +17,14 @@ export class JobsService implements OnModuleInit {
   constructor(private readonly fallbackQueueService: QueueService) {}
 
   async onModuleInit() {
-    // await this.fallbackQueueService.add(
-    //   JobTypes.DataExportCleanUp,
-    //   {},
-    //   {
-    //     jobId: JobTypes.DataExportCleanUp,
-    //     // run every 5 hours
-    //     repeat: { cron: '* * * * *' },
-    //   },
-    // );
+    await this.fallbackQueueService.add(
+      JobTypes.AttachmentCleanUp,
+      {},
+      {
+        jobId: JobTypes.AttachmentCleanUp,
+        repeat: { cron: '0 */5 * * *' },
+      },
+    );
 
     await this.add(JobTypes.InitMigrationJobs, {});
   }
@@ -40,6 +39,7 @@ export class JobsService implements OnModuleInit {
     options?: {
       jobId?: string;
       delay?: number; // delay in ms
+      repeat?: { cron: string };
     },
   ) {
     const context = {

--- a/packages/nocodb/src/modules/jobs/jobs.Source.spec.ts
+++ b/packages/nocodb/src/modules/jobs/jobs.Source.spec.ts
@@ -1,0 +1,57 @@
+jest.mock('~/Noco', () => ({ __esModule: true, default: {} }));
+jest.mock('~/models', () => ({ Job: {} }));
+jest.mock('~/modules/jobs/jobs-event.service', () => ({
+  JobsEventService: class {},
+}));
+jest.mock('./fallback/fallback-queue.service', () => ({
+  QueueService: class {},
+}));
+jest.mock('~/modules/jobs/redis/jobs-redis', () => ({
+  JobsRedis: { workerCallbacks: {}, workerCount: jest.fn() },
+}));
+
+import { JobsService as FallbackJobsService } from './fallback/jobs.service';
+import { JobsService as RedisJobsService } from './redis/jobs.service';
+import { JobTypes } from '~/interface/Jobs';
+
+describe('attachment cleanup scheduling', () => {
+  it('registers the recurring cleanup job in Redis mode', async () => {
+    const queue = {
+      add: jest.fn().mockResolvedValue(undefined),
+      pause: jest.fn(),
+      resume: jest.fn(),
+    };
+    const service = new RedisJobsService(queue as any);
+
+    jest.spyOn(service, 'toggleQueue').mockResolvedValue(undefined);
+    jest.spyOn(service, 'add').mockResolvedValue(undefined as any);
+
+    await service.onModuleInit();
+
+    expect(queue.add).toHaveBeenCalledWith(
+      { jobName: JobTypes.AttachmentCleanUp, context: {} },
+      {
+        jobId: JobTypes.AttachmentCleanUp,
+        repeat: { cron: '0 */5 * * *' },
+      },
+    );
+  });
+
+  it('registers the recurring cleanup job in fallback mode', async () => {
+    const queue = { add: jest.fn().mockReturnValue(undefined) };
+    const service = new FallbackJobsService(queue as any);
+
+    jest.spyOn(service, 'add').mockResolvedValue(undefined as any);
+
+    await service.onModuleInit();
+
+    expect(queue.add).toHaveBeenCalledWith(
+      JobTypes.AttachmentCleanUp,
+      {},
+      {
+        jobId: JobTypes.AttachmentCleanUp,
+        repeat: { cron: '0 */5 * * *' },
+      },
+    );
+  });
+});

--- a/packages/nocodb/src/modules/jobs/jobs/attachment-clean-up/attachment-clean-up.ts
+++ b/packages/nocodb/src/modules/jobs/jobs/attachment-clean-up/attachment-clean-up.ts
@@ -4,7 +4,11 @@ import type { Job } from 'bull';
 import Noco from '~/Noco';
 import { MetaTable } from '~/utils/globals';
 import NcPluginMgrv2 from '~/helpers/NcPluginMgrv2';
-import { getPathFromUrl } from '~/helpers/attachmentHelpers';
+import {
+  getPathFromUrl,
+  getSafeAttachmentErrorLog,
+  getSafeAttachmentLogIdentifier,
+} from '~/helpers/attachmentHelpers';
 
 const retentionDays = process.env.NC_ATTACHMENT_RETENTION_DAYS || 10;
 
@@ -84,8 +88,14 @@ export class AttachmentCleanUpProcessor {
           .knexConnection(MetaTable.FILE_REFERENCES)
           .where('file_url', file.file_url)
           .del();
-      } catch (e) {
-        this.debugLog(`error deleting file ${file.file_url}: ${e.message}`);
+      } catch (error) {
+        const { message, stack } = getSafeAttachmentErrorLog(error);
+        const identifier = getSafeAttachmentLogIdentifier(file.file_url);
+        this.debugLog(
+          `error deleting attachment ${identifier}: ${message}${
+            stack ? `\n${stack}` : ''
+          }`,
+        );
       }
     }
 

--- a/packages/nocodb/src/modules/jobs/redis/jobs.service.ts
+++ b/packages/nocodb/src/modules/jobs/redis/jobs.service.ts
@@ -29,17 +29,16 @@ export class JobsService implements OnModuleInit {
       await this.jobsQueue.pause(true);
     }
 
-    // await this.jobsQueue.add(
-    //   {
-    //     jobName: JobTypes.DataExportCleanUp,
-    //     context: {},
-    //   },
-    //   {
-    //     jobId: JobTypes.DataExportCleanUp,
-    //     // run every 5 hours
-    //     repeat: { cron: '0 */5 * * *' },
-    //   },
-    // );
+    await this.jobsQueue.add(
+      {
+        jobName: JobTypes.AttachmentCleanUp,
+        context: {},
+      },
+      {
+        jobId: JobTypes.AttachmentCleanUp,
+        repeat: { cron: '0 */5 * * *' },
+      },
+    );
 
     await this.toggleQueue();
 

--- a/packages/nocodb/src/plugins/r2/R2.Source.spec.ts
+++ b/packages/nocodb/src/plugins/r2/R2.Source.spec.ts
@@ -1,0 +1,63 @@
+jest.mock('~/utils/ssrf', () => ({
+  getFilteredAgents: jest.fn(),
+}));
+
+import R2 from './R2';
+
+const config = {
+  bucket: 'example-bucket',
+  hostname: 'https://account-id.eu.r2.cloudflarestorage.com/',
+  access_key: 'test-access-key',
+  access_secret: 'test-access-secret',
+  region: 'EU',
+};
+
+describe('R2', () => {
+  it('builds virtual-hosted URLs with the configured jurisdiction', () => {
+    const adapter = new R2(config);
+    const url = adapter.getUploadedPath('nc/uploads/path/video.mp4').url;
+
+    expect(url).toBe(
+      'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/path/video.mp4',
+    );
+    expect(
+      adapter.getUploadedPath('example-bucket/nc/uploads/path/video.mp4').url,
+    ).toBe(url);
+  });
+
+  it('normalizes old path-style upload locations', () => {
+    const adapter = new R2(config);
+    const oldLocation =
+      'https://account-id.r2.cloudflarestorage.com/example-bucket/nc/uploads/path/video.mp4';
+
+    expect((adapter as any).patchUploadReturnKey(oldLocation)).toBe(
+      'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/path/video.mp4',
+    );
+  });
+
+  it('removes the bucket from path-style keys before S3 operations', () => {
+    const adapter = new R2(config);
+
+    expect(
+      (adapter as any).patchKey(
+        'https://account-id.eu.r2.cloudflarestorage.com/example-bucket/nc/uploads/video.mp4',
+      ),
+    ).toBe('nc/uploads/video.mp4');
+    expect(
+      (adapter as any).patchKey(
+        'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/video.mp4',
+      ),
+    ).toBe('nc/uploads/video.mp4');
+    expect((adapter as any).patchKey('nc/uploads/video.mp4')).toBe(
+      'nc/uploads/video.mp4',
+    );
+  });
+
+  it('keeps malformed percent-encoding readable as a raw key', () => {
+    const adapter = new R2(config);
+
+    expect((adapter as any).patchKey('nc/uploads/bad%key.mp4')).toBe(
+      'nc/uploads/bad%key.mp4',
+    );
+  });
+});

--- a/packages/nocodb/src/plugins/r2/R2.ts
+++ b/packages/nocodb/src/plugins/r2/R2.ts
@@ -21,6 +21,42 @@ export default class R2 extends GenericS3 implements IStorageAdapterV2 {
     super(input as R2ObjectStorageInput);
   }
 
+  private get endpoint(): URL {
+    const hostname = this.input.hostname.trim();
+    return new URL(
+      /^https?:\/\//i.test(hostname) ? hostname : `https://${hostname}`,
+    );
+  }
+
+  private getObjectKey(key: string): string {
+    let pathname = key;
+
+    try {
+      pathname = new URL(key).pathname;
+    } catch {}
+
+    try {
+      pathname = decodeURI(pathname);
+    } catch {}
+    pathname = pathname.replace(/^\/+/, '');
+
+    const bucketPrefix = `${this.input.bucket}/`;
+    return pathname.startsWith(bucketPrefix)
+      ? pathname.slice(bucketPrefix.length)
+      : pathname;
+  }
+
+  private getObjectUrl(key: string): string {
+    const endpoint = this.endpoint;
+    if (!endpoint.hostname.startsWith(`${this.input.bucket}.`)) {
+      endpoint.hostname = `${this.input.bucket}.${endpoint.hostname}`;
+    }
+    endpoint.pathname = `/${this.getObjectKey(key)}`;
+    endpoint.search = '';
+    endpoint.hash = '';
+    return endpoint.toString();
+  }
+
   protected get defaultParams() {
     return {
       Bucket: this.input.bucket,
@@ -30,18 +66,17 @@ export default class R2 extends GenericS3 implements IStorageAdapterV2 {
   }
 
   protected patchKey(key: string): string {
-    return decodeURI(key);
+    return this.getObjectKey(key);
   }
 
   protected patchUploadReturnKey(key: string): string {
-    // R2 by default encodes the key. But we expect the key to be decoded.
-    return decodeURI(key);
+    return this.getObjectUrl(key);
   }
 
   public async init(): Promise<any> {
     const s3Options: S3ClientConfigType = {
       region: 'auto',
-      endpoint: this.input.hostname,
+      endpoint: this.endpoint.origin,
       credentials: {
         accessKeyId: this.input.access_key,
         secretAccessKey: this.input.access_secret,
@@ -53,8 +88,7 @@ export default class R2 extends GenericS3 implements IStorageAdapterV2 {
 
   override getUploadedPath(path: string): { path?: string; url?: string } {
     return {
-      // bucket in path should already be included in hostname
-      url: `${this.input.hostname}/${path}`,
+      url: this.getObjectUrl(path),
     };
   }
 }

--- a/packages/nocodb/src/services/attachments.Source.spec.ts
+++ b/packages/nocodb/src/services/attachments.Source.spec.ts
@@ -1,0 +1,53 @@
+import { AttachmentsService } from './attachments.service';
+import NcPluginMgrv2 from '~/helpers/NcPluginMgrv2';
+import { FileReference } from '~/models';
+
+describe('AttachmentsService upload compensation', () => {
+  it('deletes the exact destination when reference persistence fails', async () => {
+    const fileDelete = jest.fn().mockResolvedValue(undefined);
+    const storageAdapter = {
+      name: 'R2',
+      fileCreate: jest
+        .fn()
+        .mockResolvedValue(
+          'https://example-bucket.account-id.eu.r2.cloudflarestorage.com/nc/uploads/file.txt',
+        ),
+      fileDelete,
+    };
+    const storageAdapterSpy = jest
+      .spyOn(NcPluginMgrv2, 'storageAdapter')
+      .mockResolvedValue(storageAdapter as any);
+    const fileReferenceSpy = jest
+      .spyOn(FileReference, 'insert')
+      .mockRejectedValue(new Error('database unavailable'));
+
+    const service = new AttachmentsService(
+      { emit: jest.fn() } as any,
+      {} as any,
+      {} as any,
+    );
+
+    await expect(
+      service.upload({
+        files: [
+          {
+            originalname: 'file.txt',
+            mimetype: 'text/plain',
+            size: 1,
+            path: '/tmp/file.txt',
+          } as any,
+        ],
+        req: { user: { id: 'user-id' } } as any,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(fileReferenceSpy).toHaveBeenCalled();
+    expect(fileDelete).toHaveBeenCalledTimes(1);
+    expect(fileDelete).toHaveBeenCalledWith(
+      storageAdapter.fileCreate.mock.calls[0][0],
+    );
+
+    storageAdapterSpy.mockRestore();
+    fileReferenceSpy.mockRestore();
+  });
+});

--- a/packages/nocodb/src/services/attachments.service.ts
+++ b/packages/nocodb/src/services/attachments.service.ts
@@ -25,7 +25,11 @@ import { NcBaseError, NcError } from '~/helpers/catchError';
 import { IJobsService } from '~/modules/jobs/jobs-service.interface';
 import { JobTypes } from '~/interface/Jobs';
 import { RootScopes } from '~/utils/globals';
-import { validateAndNormaliseLocalPath } from '~/helpers/attachmentHelpers';
+import {
+  getSafeAttachmentErrorLog,
+  tryDeleteUploadedFile,
+  validateAndNormaliseLocalPath,
+} from '~/helpers/attachmentHelpers';
 import { supportsThumbnails } from '~/utils/attachmentUtils';
 import { NC_ATTACHMENT_FIELD_SIZE } from '~/constants';
 import { UseWorker } from '~/decorators/use-worker.decorator';
@@ -102,6 +106,7 @@ export class AttachmentsService {
 
     queue.addAll(
       param.files?.map((file) => async () => {
+        let uploadedKey: string;
         try {
           const nanoId = nanoid(5);
 
@@ -152,10 +157,8 @@ export class AttachmentsService {
             }
           }
 
-          const url = await storageAdapter.fileCreate(
-            slash(path.join(destPath, fileName)),
-            file,
-          );
+          uploadedKey = slash(path.join(destPath, fileName));
+          const url = await storageAdapter.fileCreate(uploadedKey, file);
 
           await FileReference.insert(
             {
@@ -189,6 +192,9 @@ export class AttachmentsService {
 
           attachments.push(attachment);
         } catch (e) {
+          if (uploadedKey) {
+            await tryDeleteUploadedFile(storageAdapter, uploadedKey);
+          }
           errors.push(e);
         }
       }),
@@ -197,9 +203,12 @@ export class AttachmentsService {
     await queue.onIdle();
 
     if (errors.length) {
-      errors.forEach((error) => this.logger.error(error));
+      errors.forEach((error) => {
+        const { message, stack } = getSafeAttachmentErrorLog(error);
+        this.logger.error(`Attachment upload failed: ${message}`, stack);
+      });
 
-      const firstError = errors[0].error;
+      const firstError = errors[0];
 
       if (firstError instanceof NcError || firstError instanceof NcBaseError) {
         throw firstError;
@@ -284,6 +293,7 @@ export class AttachmentsService {
 
     queue.addAll(
       param.urls?.map?.((urlMeta) => async () => {
+        let uploadedKey: string;
         try {
           const { url, fileName: _fileName } = urlMeta;
 
@@ -383,25 +393,22 @@ export class AttachmentsService {
           }
 
           let attachmentUrl, file;
+          uploadedKey = slash(path.join(fileDestPath, fileName));
 
           if (!base64TempStream) {
             const { url: _attachmentUrl, data: _file } =
-              await storageAdapter.fileCreateByUrl(
-                slash(path.join(fileDestPath, fileName)),
-                finalUrl,
-                {
-                  fetchOptions: {
-                    // The sharp requires image to be passed as buffer.);
-                    buffer: mimeType.includes('image'),
-                  },
+              await storageAdapter.fileCreateByUrl(uploadedKey, finalUrl, {
+                fetchOptions: {
+                  // The sharp requires image to be passed as buffer.);
+                  buffer: mimeType.includes('image'),
                 },
-              );
+              });
 
             attachmentUrl = _attachmentUrl;
             file = _file;
           } else {
             attachmentUrl = await storageAdapter.fileCreateByStream(
-              slash(path.join(fileDestPath, fileName)),
+              uploadedKey,
               base64TempStream,
             );
 
@@ -462,6 +469,9 @@ export class AttachmentsService {
 
           attachments.push(attachment);
         } catch (e) {
+          if (uploadedKey) {
+            await tryDeleteUploadedFile(storageAdapter, uploadedKey);
+          }
           errors.push(e);
         }
       }),
@@ -470,9 +480,12 @@ export class AttachmentsService {
     await queue.onIdle();
 
     if (errors.length) {
-      errors.forEach((error) => this.logger.error(error));
+      errors.forEach((error) => {
+        const { message, stack } = getSafeAttachmentErrorLog(error);
+        this.logger.error(`Attachment upload failed: ${message}`, stack);
+      });
 
-      const firstError = errors[0].error;
+      const firstError = errors[0];
 
       if (firstError instanceof NcError || firstError instanceof NcBaseError) {
         throw firstError;

--- a/packages/nocodb/src/services/v3/data-attachment-v3.service.ts
+++ b/packages/nocodb/src/services/v3/data-attachment-v3.service.ts
@@ -12,6 +12,7 @@ import {
 import slash from 'slash';
 import { getBase64FileSize } from 'src/helpers/stringHelpers';
 import type { DataUpdatePayload, NcContext } from 'nocodb-sdk';
+import type { IStorageAdapterV2 } from '~/types/nc-plugin';
 import type { AttachmentFilePathConstructed } from '~/helpers/attachmentHelpers';
 import type {
   AttachmentBase64UploadParam,
@@ -24,6 +25,8 @@ import {
 } from '~/constants';
 import {
   constructFilePath,
+  getSafeAttachmentErrorLog,
+  tryDeleteUploadedFile,
   validateNumberOfFilesInCell,
 } from '~/helpers/attachmentHelpers';
 import { _wherePk, getBaseModelSqlFromModelId } from '~/helpers/dbHelpers';
@@ -66,8 +69,14 @@ export class DataAttachmentV3Service {
     await baseModel.model.getColumns(context);
     const processedAttachments = [];
     const generateThumbnailAttachments = [];
+    const uploadedAttachmentRefs: {
+      id: string;
+      storageKey: string;
+      storageAdapter: IStorageAdapterV2;
+    }[] = [];
 
     for (const attachment of attachments) {
+      let downloadedAttachment;
       try {
         if (
           attachment.id &&
@@ -82,7 +91,7 @@ export class DataAttachmentV3Service {
         ) {
           // If attachment has URL, download and process it
 
-          const downloadedAttachment = await this.downloadAndStoreAttachment(
+          downloadedAttachment = await this.downloadAndStoreAttachment(
             context,
             {
               filePath: attachment,
@@ -115,6 +124,11 @@ export class DataAttachmentV3Service {
             file_size: downloadedAttachment.fileSize,
             deleted: false,
           });
+          uploadedAttachmentRefs.push({
+            id: attachment.id,
+            storageKey: downloadedAttachment.storageKey,
+            storageAdapter: downloadedAttachment.storageAdapter,
+          });
           const processedAttachment = {
             id: attachment.id,
             url: ncIsNull(downloadedAttachment.url)
@@ -139,16 +153,46 @@ export class DataAttachmentV3Service {
           }
         }
       } catch (error) {
-        console.error(`Failed to process attachment:`, error);
+        if (downloadedAttachment?.storageKey && attachment.id) {
+          try {
+            await FileReference.delete(context, attachment.id);
+          } catch {}
+        }
+        if (downloadedAttachment?.storageKey) {
+          try {
+            await tryDeleteUploadedFile(
+              downloadedAttachment.storageAdapter,
+              downloadedAttachment.storageKey,
+            );
+          } catch {}
+        }
+        const { message, stack } = getSafeAttachmentErrorLog(error);
+        this.logger.error(`Failed to process attachment: ${message}`, stack);
       }
     }
     // direct update to prevent prepare noco data again
-    await baseModel
-      .dbDriver(baseModel.getTnPath(baseModel.model))
-      .update({
-        [column.column_name]: JSON.stringify(processedAttachments),
-      })
-      .where(await _wherePk(baseModel.model.primaryKeys, recordId, true));
+    try {
+      await baseModel
+        .dbDriver(baseModel.getTnPath(baseModel.model))
+        .update({
+          [column.column_name]: JSON.stringify(processedAttachments),
+        })
+        .where(await _wherePk(baseModel.model.primaryKeys, recordId, true));
+    } catch (error) {
+      await Promise.all(
+        uploadedAttachmentRefs.map(
+          async ({ id, storageKey, storageAdapter }) => {
+            try {
+              await FileReference.delete(context, id);
+            } catch {}
+            try {
+              await tryDeleteUploadedFile(storageAdapter, storageKey);
+            } catch {}
+          },
+        ),
+      );
+      throw error;
+    }
 
     if (generateThumbnailAttachments.length > 0) {
       await this.jobsService.add(JobTypes.ThumbnailGenerator, {
@@ -279,9 +323,12 @@ export class DataAttachmentV3Service {
 
     const processedAttachments = [];
     const generateThumbnailAttachments = [];
+    let storageAdapter: IStorageAdapterV2;
+    let uploadedKey: string;
+    let uploadedReferenceId: string;
 
     try {
-      const storageAdapter = await NcPluginMgrv2.storageAdapter();
+      storageAdapter = await NcPluginMgrv2.storageAdapter();
       const mimeType = attachment.contentType.split(';')[0].trim();
 
       let filename = attachment.filename;
@@ -299,9 +346,10 @@ export class DataAttachmentV3Service {
         ),
       );
       const destPath = path.join('nc', scope ?? 'uploads', filePath);
+      uploadedKey = slash(path.join(destPath, filename));
 
       const resultAttachmentUrl = await storageAdapter.fileCreateByStream(
-        slash(path.join(destPath, filename)),
+        uploadedKey,
         new PassThrough().end(attachment.file, 'base64'),
       );
 
@@ -324,7 +372,7 @@ export class DataAttachmentV3Service {
       );
 
       // Step 2: Create FileReference with workspace info and deleted: false
-      const attachmentId = await FileReference.insert(context, {
+      uploadedReferenceId = await FileReference.insert(context, {
         file_url:
           resultAttachmentUrl ?? path.join('download', filePath, filename),
         file_size: fileSize,
@@ -339,7 +387,7 @@ export class DataAttachmentV3Service {
       // Use the second (workspace-aware) FileReference ID as attachment value
 
       const processedAttachment = {
-        id: attachmentId, // Generate a new ID for the attachment
+        id: uploadedReferenceId, // Generate a new ID for the attachment
         url: ncIsNull(resultAttachmentUrl) ? undefined : resultAttachmentUrl,
         path: ncIsNull(resultAttachmentUrl)
           ? path.join('download', filePath, filename)
@@ -353,7 +401,19 @@ export class DataAttachmentV3Service {
         generateThumbnailAttachments.push(processedAttachment);
       }
     } catch (error) {
-      this.logger.error(`${error?.constructor?.name}: ${error?.message}`);
+      if (uploadedReferenceId) {
+        try {
+          await FileReference.delete(context, uploadedReferenceId);
+        } catch {}
+      }
+      if (uploadedKey && storageAdapter) {
+        await tryDeleteUploadedFile(storageAdapter, uploadedKey);
+      }
+      const { message, stack } = getSafeAttachmentErrorLog(error);
+      this.logger.error(
+        `Failed to process base64 attachment: ${message}`,
+        stack,
+      );
       NcError.get(context).unprocessableEntity(
         `Failed to process base64 attachment`,
       );
@@ -361,12 +421,24 @@ export class DataAttachmentV3Service {
 
     const updatedAttachments = [...currentAttachments, ...processedAttachments];
 
-    await baseModel
-      .dbDriver(baseModel.getTnPath(baseModel.model))
-      .update({
-        [column.column_name]: JSON.stringify(updatedAttachments),
-      })
-      .where(_wherePk(baseModel.model.primaryKeys, recordId, true));
+    try {
+      await baseModel
+        .dbDriver(baseModel.getTnPath(baseModel.model))
+        .update({
+          [column.column_name]: JSON.stringify(updatedAttachments),
+        })
+        .where(_wherePk(baseModel.model.primaryKeys, recordId, true));
+    } catch (error) {
+      if (uploadedReferenceId) {
+        try {
+          await FileReference.delete(context, uploadedReferenceId);
+        } catch {}
+      }
+      if (uploadedKey && storageAdapter) {
+        await tryDeleteUploadedFile(storageAdapter, uploadedKey);
+      }
+      throw error;
+    }
 
     if (generateThumbnailAttachments.length > 0) {
       await this.jobsService.add(JobTypes.ThumbnailGenerator, {
@@ -491,10 +563,17 @@ export class DataAttachmentV3Service {
           originalFileName,
         })
       : filePath;
-    const resultAttachmentUrl = await storageAdapter.fileCreateByStream(
-      filePathConstructed.storageDest,
-      response.data.pipe(sizeLimiter),
-    );
+    const storageKey = filePathConstructed.storageDest;
+    let resultAttachmentUrl;
+    try {
+      resultAttachmentUrl = await storageAdapter.fileCreateByStream(
+        storageKey,
+        response.data.pipe(sizeLimiter),
+      );
+    } catch (error) {
+      await tryDeleteUploadedFile(storageAdapter, storageKey);
+      throw error;
+    }
     // sizeLimiter.bytesProcessed is the exact number of bytes streamed into
     // storage by the time fileCreateByStream resolves. Prefer it over the
     // Content-Length header, which can be absent (chunked), understated, or
@@ -503,6 +582,8 @@ export class DataAttachmentV3Service {
 
     return {
       storageName: storageAdapter.name,
+      storageAdapter,
+      storageKey,
       url: resultAttachmentUrl,
       path: path.join(
         'download',


### PR DESCRIPTION
## Change Summary

Fix Cloudflare R2/S3 attachment storage bugs:

- Normalize R2 endpoints and object URLs to virtual-hosted style, including jurisdiction-aware endpoints.
- Keep legacy path-style URLs readable and remove duplicated bucket prefixes before S3 operations.
- Compensate successful attachment uploads when PostgreSQL persistence fails, using the exact upload destination.
- Schedule attachment cleanup every five hours in Redis and fallback queues while preserving the 10-day retention and thumbnail cleanup behavior.
- Keep malformed percent-encoding readable and retain safe diagnostic logging without exposing signed URLs or credentials.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Directed Jest: 4 suites, 14 tests passed for R2 canonicalization, malformed encoding, safe logging, cleanup behavior, queue registration, and cleanup helper behavior.
- Prettier check and `git diff --check` passed.
- Full TypeScript check remains blocked by existing develop-branch errors and missing modules (`NcRequest` declarations, `moment`, `image-size`, `nc-gui`, and other unrelated dependencies); no errors were reported in the changed R2, cleanup, queue, or V3 attachment files.
- The legacy service compensation spec is included, but this checkout cannot compile that service because `moment` and `image-size` are unresolved in the existing baseline.

## Additional information / screenshots (optional)

No credentials, signed URLs, or real storage secrets are included in code, fixtures, or logs.