### PR TITLE
fix: include Formula in renderAsCellLookupOrLtarValue so lookup fields inherit URL formatting

### DIFF
--- a/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
+++ b/packages/nc-gui/components/smartsheet/grid/canvas/utils/cell.ts
@@ -150,6 +150,7 @@ export const renderAsCellLookupOrLtarValue = [
   UITypes.Lookup,
   UITypes.LinkToAnotherRecord,
   UITypes.Links,
+  UITypes.Formula,
 ]
 
 export const MouseClickType = {


### PR DESCRIPTION
closes: #14450

## Change Summary

When a formula field with URL formatting is pulled into another table via a lookup field, the URL formatting is lost — the value renders as plain text instead of a clickable link.

Root cause: the canvas-based grid renderer (`Lookup.ts`) decides how to render a looked-up value using the `renderAsCellLookupOrLtarValue` allowlist in `cell.ts`. `UITypes.Formula` was missing from this list, so formula-type lookups fell back to `PlainCellRenderer` instead of routing through `FormulaCellRenderer`, which already contains the URL-detection and clickable-link logic. Notably, the DOM-based grid component (`Lookup.vue`) already handles this correctly via its `isFormulaUrlLookup` check — this brings the canvas grid in line with that existing behavior.

Fix: added `UITypes.Formula` to `renderAsCellLookupOrLtarValue`.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Verified via code trace: this routes formula-type lookups through the same `FormulaCellRenderer` path already used and proven for direct formula cells. I hit local Windows dev-environment issues (pnpm/Vite, unrelated to this change) that prevented full local UI verification — happy to iterate based on CI or review feedback.

## Additional information / screenshots (optional)

N/A
