### PR TITLE
fix(nocodb): cache a Button column's parsed_tree as a tree, not JSON …

### DIFF
--- a/packages/nocodb/src/models/ButtonColumn.ts
+++ b/packages/nocodb/src/models/ButtonColumn.ts
@@ -175,10 +175,6 @@ export default class ButtonColumn {
       'label',
     ]);
 
-    if (button.type === ButtonActionsType.Url) {
-      button.parsed_tree = stringifyMetaProp(button, 'parsed_tree', null);
-    }
-
     if ('parsed_tree' in updateObj)
       updateObj.parsed_tree = stringifyMetaProp(updateObj, 'parsed_tree', null);
 
@@ -193,10 +189,24 @@ export default class ButtonColumn {
       },
     );
 
+    // The meta row stores `parsed_tree` as JSON text, but every reader expects
+    // the parsed tree — `read()` parses it on the way out of the DB. Caching the
+    // stringified form hands the next reader a string, the formula build throws
+    // on it, and the Button branch of the query builders drops the column from
+    // the SELECT entirely: a button that renders as nothing, with no stored
+    // error to explain it, until the column is edited.
+    //
+    // Built as a separate object rather than mutating `updateObj` back, which
+    // was already handed to `metaUpdate` above.
     await NocoCache.update(
       context,
       `${CacheScope.COL_BUTTON}:${columnId}`,
-      updateObj,
+      'parsed_tree' in updateObj
+        ? {
+            ...updateObj,
+            parsed_tree: parseMetaProp(updateObj, 'parsed_tree', null),
+          }
+        : updateObj,
     );
   }
 


### PR DESCRIPTION
…text

## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
