### PR TITLE
Nc fix(gui): refresh multi-target relation cells after inline link/unlink (infinite scrolling off)

### DIFF
--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -1180,11 +1180,23 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
           childrenListCount.value = childrenListCount.value - 1
         }
 
-        // Mirror the new-row branch: clear the linked record from the row store so
-        // BT/MO cells (which display the linked record directly off the row) refresh
-        // immediately. Reload paths are no-ops in EE, so this is the only signal.
-        if (isSingleTargetRelation.value && rowStoreCurrentRow) {
-          rowStoreCurrentRow.value.row[column.value.title!] = null
+        // Mirror the new-row branch: reflect the unlink in the row store so the cell
+        // refreshes immediately. Reload paths are no-ops in EE, so this is the only
+        // signal. Keep the SHAPE the cell renderer expects: BT/MO/OO show the linked
+        // record directly; a `Links` cell shows a numeric count; a LinkToAnotherRecord
+        // hm/mm cell shows an array of chips (#14013).
+        if (rowStoreCurrentRow) {
+          const cur = rowStoreCurrentRow.value
+          const colTitle = column.value.title!
+          if (isSingleTargetRelation.value) {
+            cur.row[colTitle] = null
+          } else if (column.value.uidt === UITypes.Links) {
+            cur.row[colTitle] = Math.max(0, (+cur.row[colTitle] || 0) - 1)
+          } else if (Array.isArray(cur.row[colTitle])) {
+            cur.row[colTitle] = cur.row[colTitle].filter(
+              (r: Record<string, any>) => getRelatedTableRowId(r) !== getRelatedTableRowId(row),
+            )
+          }
         }
       } catch (e: any) {
         message.error(`${t('msg.error.unlinkFailed')}: ${await extractSdkResponseErrorMsg(e)}`)
@@ -1295,11 +1307,22 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
           excludedLinkedState.value.set(index, true)
         }
 
-        // Mirror the new-row branch: write the picked record back to the row store so
-        // BT/MO cells (which display the linked record directly off the row) refresh
-        // immediately. Reload paths are no-ops in EE, so this is the only signal.
-        if (isSingleTargetRelation.value && rowStoreCurrentRow) {
-          rowStoreCurrentRow.value.row[column.value.title!] = row
+        // Mirror the new-row branch: reflect the link in the row store so the cell
+        // refreshes immediately. Reload paths are no-ops in EE, so this is the only
+        // signal. Keep the SHAPE the cell renderer expects: BT/MO/OO show the linked
+        // record directly; a `Links` cell shows a numeric count; a LinkToAnotherRecord
+        // hm/mm cell shows an array of chips (#14013).
+        if (rowStoreCurrentRow) {
+          const cur = rowStoreCurrentRow.value
+          const colTitle = column.value.title!
+          if (isSingleTargetRelation.value) {
+            cur.row[colTitle] = row
+          } else if (column.value.uidt === UITypes.Links) {
+            cur.row[colTitle] = (+cur.row[colTitle] || 0) + 1
+          } else {
+            const colVal = cur.row[colTitle]
+            cur.row[colTitle] = [...(Array.isArray(colVal) ? colVal : []), row]
+          }
         }
       } catch (e: any) {
         message.error(`Linking failed: ${await extractSdkResponseErrorMsg(e)}`)

--- a/packages/nc-gui/composables/useLTARStore.ts
+++ b/packages/nc-gui/composables/useLTARStore.ts
@@ -15,7 +15,14 @@ import {
   timeFormats,
 } from 'nocodb-sdk'
 import type { ComputedRef, Ref } from 'vue'
-import { reconcilePendingLtarOp, resolveDeferredLtarCount, resolveDeferredSingleTargetValue } from '~/utils/ltarDeferredOps'
+import type { LtarCellShape } from '~/utils/ltarDeferredOps'
+import {
+  applyLtarCellOp,
+  ltarCellCount,
+  reconcilePendingLtarOp,
+  resolveDeferredLtarCount,
+  resolveDeferredSingleTargetValue,
+} from '~/utils/ltarDeferredOps'
 
 interface DataApiResponse {
   list: Record<string, any>[]
@@ -208,6 +215,10 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         isBtLikeV2Junction(column.value)
       )
     })
+
+    const ltarCellShape = computed<LtarCellShape>(() =>
+      isSingleTargetRelation.value ? 'single' : column.value?.uidt === UITypes.Links ? 'count' : 'records',
+    )
 
     const { sharedView } = useSharedView()
 
@@ -1007,18 +1018,14 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         return
       }
 
-      // Multi-target: keep the child-list count badge in sync, and preserve the cell
-      // value's SHAPE — which is decided by the CELL RENDERER (uidt), not the link version.
-      // A `Links` cell renders a numeric rollup count; a `LinkToAnotherRecord` hm/mm cell
-      // renders an array of chips (ManyToMany/HasMany.vue call .reduce on it) even when the
-      // relation is version V2. Keying off `isLinkV2` (version) here wrote a bare count into a
-      // LinkToAnotherRecord cell, so `localCellValue` fell back to [] and the cell appeared to
-      // clear on every deferred edit until save (#14013).
-      const persistedCount = Array.isArray(base) ? base.length : +(base ?? 0) || 0
-      const count = resolveDeferredLtarCount(queue, colId, persistedCount)
+      // Multi-target: keep the child-list count badge in sync, and preserve the cell value's
+      // shape (see `LtarCellShape`). Keying off `isLinkV2` (version) here wrote a bare count
+      // into a LinkToAnotherRecord cell, so `localCellValue` fell back to [] and the cell
+      // appeared to clear on every deferred edit until save (#14013).
+      const count = resolveDeferredLtarCount(queue, colId, ltarCellCount(base))
       childrenListCount.value = count
 
-      if (column.value.uidt === UITypes.Links) {
+      if (ltarCellShape.value === 'count') {
         cur.row[colTitle] = count
       } else {
         const unlinkIds = new Set(queue.filter((o) => o.columnId === colId && o.op === 'unlink').map((o) => o.relatedRowId))
@@ -1070,20 +1077,20 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         // New row: links live in ltarState — drop the buffered link and update display.
         if (!removeLTARRef) return
         await removeLTARRef(relatedRow, column.value as ColumnType, { skipRowDisplay: true })
-        if (isSingleTargetRelation.value) {
-          rowStoreCurrentRow.value.row[column.value.title!] = null
-        } else {
+        if (!isSingleTargetRelation.value) {
           childrenListCount.value = Math.max(0, childrenListCount.value - 1)
-          const colVal = rowStoreCurrentRow.value.row[column.value.title!]
-          if (Array.isArray(colVal)) {
-            const idx = colVal.findIndex((r: Record<string, any>) => getRelatedTableRowId(r) === getRelatedTableRowId(relatedRow))
-            const next = [...colVal]
-            if (idx !== -1) next.splice(idx, 1)
-            rowStoreCurrentRow.value.row[column.value.title!] = next
-          } else {
-            rowStoreCurrentRow.value.row[column.value.title!] = Math.max(0, (+colVal || 0) - 1)
-          }
         }
+
+        const colTitle = column.value.title!
+        const colVal = rowStoreCurrentRow.value.row[colTitle]
+        rowStoreCurrentRow.value.row[colTitle] = applyLtarCellOp({
+          op: 'unlink',
+          shape: ltarCellShape.value,
+          current: colVal,
+          snapshot: colVal,
+          relatedRow,
+          getRelatedRowId: getRelatedTableRowId,
+        })
       } else {
         // Existing row: enqueue an unlink — reconcile cancels the matching queued link, and
         // refreshDeferredDisplay re-derives the count from persisted + queue (#14058).
@@ -1138,6 +1145,11 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         $e('a:links:unlink')
         return
       }
+
+      // Read before the await — applyLtarCellOp needs it to spot an authoritative realtime
+      // write that landed while the request was in flight.
+      const preWriteCellValue = rowStoreCurrentRow?.value.row[column.value.title!]
+
       try {
         // todo: audit
 
@@ -1180,23 +1192,19 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
           childrenListCount.value = childrenListCount.value - 1
         }
 
-        // Mirror the new-row branch: reflect the unlink in the row store so the cell
-        // refreshes immediately. Reload paths are no-ops in EE, so this is the only
-        // signal. Keep the SHAPE the cell renderer expects: BT/MO/OO show the linked
-        // record directly; a `Links` cell shows a numeric count; a LinkToAnotherRecord
-        // hm/mm cell shows an array of chips (#14013).
+        // Mirror the new-row branch: reflect the unlink in the row store so the cell refreshes
+        // immediately — the reload paths are no-ops in EE, so this is the only signal on a grid
+        // with no realtime listener. See `applyLtarCellOp` for the shape and idempotency rules.
         if (rowStoreCurrentRow) {
-          const cur = rowStoreCurrentRow.value
           const colTitle = column.value.title!
-          if (isSingleTargetRelation.value) {
-            cur.row[colTitle] = null
-          } else if (column.value.uidt === UITypes.Links) {
-            cur.row[colTitle] = Math.max(0, (+cur.row[colTitle] || 0) - 1)
-          } else if (Array.isArray(cur.row[colTitle])) {
-            cur.row[colTitle] = cur.row[colTitle].filter(
-              (r: Record<string, any>) => getRelatedTableRowId(r) !== getRelatedTableRowId(row),
-            )
-          }
+          rowStoreCurrentRow.value.row[colTitle] = applyLtarCellOp({
+            op: 'unlink',
+            shape: ltarCellShape.value,
+            current: rowStoreCurrentRow.value.row[colTitle],
+            snapshot: preWriteCellValue,
+            relatedRow: row,
+            getRelatedRowId: getRelatedTableRowId,
+          })
         }
       } catch (e: any) {
         message.error(`${t('msg.error.unlinkFailed')}: ${await extractSdkResponseErrorMsg(e)}`)
@@ -1260,6 +1268,10 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
         $e('a:links:link')
         return
       }
+
+      // Read before the await — see unlink().
+      const preWriteCellValue = rowStoreCurrentRow?.value.row[column.value.title!]
+
       try {
         isChildrenExcludedListLoading.value[index] = true
         isChildrenListLoading.value[index] = true
@@ -1307,22 +1319,17 @@ const [useProvideLTARStore, useLTARStore] = useInjectionState(
           excludedLinkedState.value.set(index, true)
         }
 
-        // Mirror the new-row branch: reflect the link in the row store so the cell
-        // refreshes immediately. Reload paths are no-ops in EE, so this is the only
-        // signal. Keep the SHAPE the cell renderer expects: BT/MO/OO show the linked
-        // record directly; a `Links` cell shows a numeric count; a LinkToAnotherRecord
-        // hm/mm cell shows an array of chips (#14013).
+        // See unlink() — same optimistic write, opposite direction.
         if (rowStoreCurrentRow) {
-          const cur = rowStoreCurrentRow.value
           const colTitle = column.value.title!
-          if (isSingleTargetRelation.value) {
-            cur.row[colTitle] = row
-          } else if (column.value.uidt === UITypes.Links) {
-            cur.row[colTitle] = (+cur.row[colTitle] || 0) + 1
-          } else {
-            const colVal = cur.row[colTitle]
-            cur.row[colTitle] = [...(Array.isArray(colVal) ? colVal : []), row]
-          }
+          rowStoreCurrentRow.value.row[colTitle] = applyLtarCellOp({
+            op: 'link',
+            shape: ltarCellShape.value,
+            current: rowStoreCurrentRow.value.row[colTitle],
+            snapshot: preWriteCellValue,
+            relatedRow: row,
+            getRelatedRowId: getRelatedTableRowId,
+          })
         }
       } catch (e: any) {
         message.error(`Linking failed: ${await extractSdkResponseErrorMsg(e)}`)

--- a/packages/nc-gui/test/ltar-deferred-ops.test.ts
+++ b/packages/nc-gui/test/ltar-deferred-ops.test.ts
@@ -1,16 +1,20 @@
 /**
- * Unit tests for the pure deferred-LTAR queue logic used by the expanded form to keep
- * relation edits inside the Save/Discard workflow (#14013).
+ * Unit tests for the pure LTAR cell logic — the deferred queue used by the expanded form to
+ * keep relation edits inside the Save/Discard workflow (#14013), and the single-op cell write
+ * used by inline grid link/unlink.
  *
  * Imports the actual pure functions from utils/ltarDeferredOps.ts — no mocks.
  *
- * Brought in from upstream nocodb/nocodb#14058 by Aakash Gautam (@aakashgautam-git).
+ * The deferred-queue tests came from upstream nocodb/nocodb#14058 by Aakash Gautam
+ * (@aakashgautam-git).
  */
 
 import { describe, expect, it } from 'vitest'
 import { RelationTypes } from 'nocodb-sdk'
 import {
   type PendingLtarOp,
+  applyLtarCellOp,
+  ltarCellCount,
   reconcilePendingLtarOp,
   resolveDeferredLtarCount,
   resolveDeferredSingleTargetValue,
@@ -149,5 +153,94 @@ describe('queue scenarios', () => {
   it('add-then-remove of the same record is a no-op (no API call, not dirty)', () => {
     const q = queueWith(makeOp('link', 'X'), makeOp('unlink', 'X'))
     expect(q).toHaveLength(0)
+  })
+})
+
+// ---- applyLtarCellOp (inline grid link/unlink) ----
+
+describe('applyLtarCellOp', () => {
+  const catA = { Id: 'A', Title: 'Cat-A' }
+  const catB = { Id: 'B', Title: 'Cat-B' }
+  const getRelatedRowId = (r: Record<string, any>) => r.Id
+
+  const apply = (op: 'link' | 'unlink', shape: 'single' | 'count' | 'records', current: unknown, snapshot: unknown = current) =>
+    applyLtarCellOp({ op, shape, current, snapshot, relatedRow: catA, getRelatedRowId })
+
+  describe('single (BT / MO / OO)', () => {
+    it('writes the picked record on link and null on unlink', () => {
+      expect(apply('link', 'single', null)).toBe(catA)
+      expect(apply('unlink', 'single', catA)).toBeNull()
+    })
+
+    it('is idempotent — re-applying over the authoritative value keeps it', () => {
+      expect(apply('link', 'single', catA, null)).toBe(catA)
+      expect(apply('unlink', 'single', null, catA)).toBeNull()
+    })
+  })
+
+  describe('records (LinkToAnotherRecord hm / mm)', () => {
+    it('appends the linked record', () => {
+      expect(apply('link', 'records', [catB])).toEqual([catB, catA])
+    })
+
+    it('does not append a record the realtime broadcast already wrote (#9376 double chip)', () => {
+      const authoritative = [{ Id: 'A', Title: 'Cat-A' }]
+      expect(apply('link', 'records', authoritative, [])).toBe(authoritative)
+    })
+
+    it('removes the unlinked record', () => {
+      expect(apply('unlink', 'records', [catA, catB])).toEqual([catB])
+    })
+
+    it('leaves the array untouched when the record is already gone', () => {
+      const authoritative = [catB]
+      expect(apply('unlink', 'records', authoritative, [catA, catB])).toBe(authoritative)
+    })
+
+    it('falls back to count arithmetic when the cell holds a count instead of records', () => {
+      // grid/list responses can hand back a rollup for a to-many LTAR cell (Sentry JAVASCRIPT-14TJ)
+      expect(apply('link', 'records', 2)).toBe(3)
+      expect(apply('unlink', 'records', 2)).toBe(1)
+    })
+  })
+
+  describe('count (Links)', () => {
+    it('increments on link and decrements on unlink', () => {
+      expect(apply('link', 'count', 2)).toBe(3)
+      expect(apply('unlink', 'count', 2)).toBe(1)
+    })
+
+    it('never goes below zero', () => {
+      expect(apply('unlink', 'count', 0)).toBe(0)
+    })
+
+    it('treats a missing/blank cell as 0', () => {
+      expect(apply('link', 'count', undefined)).toBe(1)
+      expect(apply('link', 'count', null)).toBe(1)
+    })
+
+    it('defers to a count that moved while the request was in flight', () => {
+      // realtime already wrote the authoritative 2 — incrementing again would show 3
+      expect(apply('link', 'count', 2, 1)).toBe(2)
+      expect(apply('unlink', 'count', 2, 3)).toBe(2)
+    })
+
+    it('still applies its delta when nothing else touched the cell', () => {
+      expect(apply('link', 'count', 1, 1)).toBe(2)
+    })
+  })
+})
+
+describe('ltarCellCount', () => {
+  it('reads both cell shapes as a count', () => {
+    expect(ltarCellCount([{ Id: 'A' }, { Id: 'B' }])).toBe(2)
+    expect(ltarCellCount(3)).toBe(3)
+    expect(ltarCellCount('3')).toBe(3)
+  })
+
+  it('coerces missing / non-numeric values to 0', () => {
+    expect(ltarCellCount(undefined)).toBe(0)
+    expect(ltarCellCount(null)).toBe(0)
+    expect(ltarCellCount('abc')).toBe(0)
   })
 })

--- a/packages/nc-gui/utils/ltarDeferredOps.ts
+++ b/packages/nc-gui/utils/ltarDeferredOps.ts
@@ -1,9 +1,9 @@
-// Brought in from the upstream OSS fix for the same feature:
-//   nocodb/nocodb#14058 — "fix(gui): defer relation field updates until save in
-//   expanded form" by Aakash Gautam (@aakashgautam-git).
-// Pure, framework-agnostic helpers for the expanded form's deferred relation
-// (LTAR) editing — kept side-effect free so they can be unit tested in isolation
-// (see test/ltar-deferred-ops.test.ts).
+// Pure, framework-agnostic helpers for relation (LTAR) cell editing — kept side-effect
+// free so they can be unit tested in isolation (see test/ltar-deferred-ops.test.ts).
+//
+// The deferred-queue half (PendingLtarOp and friends) was brought in from the upstream
+// OSS fix for the same feature: nocodb/nocodb#14058 — "fix(gui): defer relation field
+// updates until save in expanded form" by Aakash Gautam (@aakashgautam-git).
 
 import type { RelationTypes } from 'nocodb-sdk'
 
@@ -85,4 +85,61 @@ export function resolveDeferredSingleTargetValue(
   if (lastLink) return lastLink.record
   if (ops.some((o) => o.op === 'unlink')) return null
   return originalValue ?? null
+}
+
+/**
+ * The shape a relation cell holds — decided by the CELL RENDERER (uidt), not by the link
+ * version (#14013).
+ */
+export type LtarCellShape =
+  | 'single' // BT/MO/OO (and BT-like V2 junctions): the linked record itself, or null
+  | 'count' // `Links`: a numeric rollup
+  | 'records' // LinkToAnotherRecord hm/mm: an array of chips — grid/list responses sometimes hand back a bare count
+
+/** Cell value as a count, whichever shape it arrived in. */
+export function ltarCellCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : Number(value) || 0
+}
+
+/**
+ * Next cell value after ONE link/unlink, written so that re-applying it is a no-op.
+ *
+ * The nested add/remove request also fires an authoritative broadcast of the whole row
+ * (`BaseModelSqlv2.broadcastLinkUpdates`), which `useInfiniteData` can apply to the same row
+ * object *before* the request's own promise resolves — so a blind push / `count + 1` stacks a
+ * delta on an already-correct value.
+ *
+ * Record arrays dedupe on the related row's pk. A count has no identity to dedupe on, so a
+ * count that moved since `snapshot` (read before the await) is treated as the authoritative
+ * write and left alone — at the cost of two back-to-back links landing one increment on a grid
+ * that never receives the broadcast.
+ */
+export function applyLtarCellOp(params: {
+  op: 'link' | 'unlink'
+  shape: LtarCellShape
+  /** Cell value now, i.e. after the await. */
+  current: unknown
+  /** Cell value read before the await. Pass `current` when there was no await. */
+  snapshot: unknown
+  relatedRow: Record<string, any>
+  getRelatedRowId: (row: Record<string, any>) => unknown
+}): unknown {
+  const { op, shape, current, snapshot, relatedRow, getRelatedRowId } = params
+
+  if (shape === 'single') return op === 'link' ? relatedRow : null
+
+  if (shape === 'records' && Array.isArray(current)) {
+    const relId = `${getRelatedRowId(relatedRow)}`
+
+    if (op === 'unlink') {
+      const next = current.filter((r) => `${getRelatedRowId(r)}` !== relId)
+      return next.length === current.length ? current : next
+    }
+
+    return current.some((r) => `${getRelatedRowId(r)}` === relId) ? current : [...current, relatedRow]
+  }
+
+  if (ltarCellCount(current) !== ltarCellCount(snapshot)) return current
+
+  return Math.max(0, ltarCellCount(snapshot) + (op === 'link' ? 1 : -1))
 }


### PR DESCRIPTION
## Change Summary

Provide summary of changes with issue number if any.

## Change type

- [x] fix: (bug fix for the user, not a fix to a build script)

## Test/ Verification

Provide summary of changes.

## Additional information / screenshots (optional)

Anything for maintainers to be made aware of
