### PR TITLE
fix(mcp): propagate authenticated user to context

### DIFF
--- a/packages/nocodb/src/mcp/mcp.controller.Integration.spec.ts
+++ b/packages/nocodb/src/mcp/mcp.controller.Integration.spec.ts
@@ -1,0 +1,61 @@
+import { MCPToken, User } from '~/models';
+import { McpController } from '~/mcp/mcp.controller';
+import type { NcContext, NcRequest } from 'nocodb-sdk';
+import type { McpService } from '~/mcp/mcp.service';
+
+jest.mock('~/models', () => ({
+  MCPToken: {
+    validateToken: jest.fn(),
+  },
+  User: {
+    getWithRoles: jest.fn(),
+  },
+}));
+
+jest.mock('~/mcp/mcp.service', () => ({
+  McpService: class {},
+}));
+
+describe('McpController', () => {
+  it('adds the authenticated MCP user to the request context', async () => {
+    const mcpService = {
+      handleRequest: jest.fn().mockResolvedValue('handled'),
+    };
+    const controller = new McpController(mcpService as unknown as McpService);
+    const context = {
+      workspace_id: 'workspace-id',
+      base_id: 'base-id',
+    } as NcContext;
+    const req = {
+      headers: { 'xc-mcp-token': 'mcp-token' },
+    } as unknown as NcRequest;
+    const res = {};
+    const user = {
+      id: 'user-id',
+      email: 'mcp-user@example.test',
+      email_verified: true,
+      base_roles: { editor: true },
+    };
+
+    jest.mocked(MCPToken.validateToken).mockResolvedValue({
+      fk_user_id: user.id,
+      base_id: context.base_id,
+      fk_workspace_id: context.workspace_id,
+    } as never);
+    jest.mocked(User.getWithRoles).mockResolvedValue(user as never);
+
+    await controller.handleMcpRequest('token-id', req, res, context);
+
+    expect(context.user).toEqual({
+      id: user.id,
+      email: user.email,
+      email_verified: user.email_verified,
+    });
+    expect(mcpService.handleRequest).toHaveBeenCalledWith(
+      'token-id',
+      context,
+      req,
+      res,
+    );
+  });
+});

--- a/packages/nocodb/src/mcp/mcp.controller.ts
+++ b/packages/nocodb/src/mcp/mcp.controller.ts
@@ -50,6 +50,15 @@ export class McpController {
       NcError.forbidden('User has no access');
     }
 
+    // MCP authentication happens in this controller, after the global guard
+    // has built the request context. Keep both representations in sync so
+    // downstream data operations can attribute changes to the MCP user.
+    context.user = {
+      id: req.user.id,
+      email: req.user.email,
+      email_verified: req.user.email_verified,
+    };
+
     return await this.mcpService.handleRequest(tokenId, context, req, res);
   }
 }


### PR DESCRIPTION
## Change Summary

Propagate the user resolved from an MCP token into `NcContext` before dispatching MCP tools.

MCP authentication currently sets `req.user` inside `McpController`, after the request context has already been constructed. As a result, downstream operations that use `context.user` do not know which user made the change. Updating a LinkToAnotherRecord field through the native `updateRecords` tool then fails while updating the related record's LastModifiedBy field with:

    Cannot read properties of undefined (reading 'id')

The fix mirrors the user projection used by `GlobalGuard` and keeps the request and context representations in sync. No MCP tool schema or API is changed.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Reproduced the failure using the official `nocodb/nocodb:2026.08.2` image with PostgreSQL 17 and the native MCP `updateRecords` tool.
- Verified against that running image with Node Inspector that `req.user` was authenticated while `context.user` was missing at the failure site.
- Injected the same three-field user projection at the controller boundary and repeated the unchanged MCP request; the relation was created successfully and returned by `updateRecords`.
- Added a controller regression test that verifies the authenticated MCP user is present in `NcContext` before tool dispatch.
- `pnpm exec jest --runInBand --forceExit --runTestsByPath src/mcp/mcp.controller.Integration.spec.ts`
- `pnpm exec prettier --check src/mcp/mcp.controller.ts src/mcp/mcp.controller.Integration.spec.ts`

## Additional information / screenshots (optional)

This keeps relation updates on the existing native MCP tool and avoids requiring callers to use a separate v3 API token or an additional MCP server.
