### PR TITLE
fix(nc-gui): allow workspace owners and creators to reorder databases

### DIFF
--- a/packages/nc-gui/lib/acl.ts
+++ b/packages/nc-gui/lib/acl.ts
@@ -61,6 +61,7 @@ const rolePermissions = {
       baseMove: true,
       baseDuplicate: true,
       newUser: true,
+      baseReorder: true,
     },
   },
   [WorkspaceUserRoles.EDITOR]: {


### PR DESCRIPTION
## Change Summary

Fixes #13572 - Workspace Creators and Owners could not drag-reorder databases in the sidebar tree view or the Base List modal. Only Super Admins could reorder databases due to a missing `baseReorder` ACL permission.

**Root cause:** PR #10909 removed `baseReorder` from the shared permission table to suppress 403 toast errors for Org Viewers on login (Bug #8194). This inadvertently stripped the permission from all non-Super-Admin roles, because only `OrgUserRoles.SUPER_ADMIN` holds a wildcard (`*`) -- all other roles rely on explicit `include` entries.

**Fix:** Add `baseReorder: true` to `WorkspaceUserRoles.CREATOR` in `packages/nc-gui/lib/acl.ts`. The existing role-scope cascade in `roleScopes.workspace` automatically propagates the permission upward to `WorkspaceUserRoles.OWNER`. Lower roles (EDITOR, COMMENTER, VIEWER, NO_ACCESS) remain blocked.

No changes to `bases.ts` are needed -- the existing early-exit guard `if (!isUIAllowed('baseReorder')) return` in `updateIfBaseOrderIsNullOrDuplicate()` already prevents lower-role users from issuing `api.base.update()` calls, so Bug #8194 cannot regress.

closes: #13572

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Verified `baseReorder` is present in `WorkspaceUserRoles.CREATOR` after the change.
- Verified via static analysis that no duplicate permissions exist in the workspace role scope (the built-in ACL validator would throw at runtime if duplicates existed).
- Traced the role-scope cascade: CREATOR -> OWNER both now have `baseReorder: true`; EDITOR, COMMENTER, VIEWER, NO_ACCESS still evaluate `isUIAllowed('baseReorder')` as `false`.
- Confirmed all three UI gating points unlock with a single ACL fix:
  - `BasesSection.vue` L57: `canReorder` computed
  - `BasesSection.vue` L80: `initSortable()` guard
  - `TreeView/index.vue` L339: `<Draggable :disabled="...">` attribute

## Additional information / screenshots (optional)

**Files changed:** 1 file, 1 line added.

**Permission matrix after fix:**

| Role | baseReorder |
|------|-------------|
| Super Admin | yes (wildcard) |
| Workspace Owner | yes (cascaded from CREATOR) |
| Workspace Creator | yes (this PR) |
| Workspace Editor | no |
| Workspace Commenter | no |
| Workspace Viewer | no |
| No Access | no |
