### PR TITLE
fix: support sqlite temporary table aliases

### DIFF
--- a/packages/nocodb/jest.config.js
+++ b/packages/nocodb/jest.config.js
@@ -34,7 +34,7 @@ module.exports = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.json',
+        tsconfig: 'tsconfig.jest.json',
       },
     ],
   },

--- a/packages/nocodb/src/dbQueryClient/sqlite.Source.spec.ts
+++ b/packages/nocodb/src/dbQueryClient/sqlite.Source.spec.ts
@@ -1,0 +1,79 @@
+import knex from 'knex';
+import { SqliteDBQueryClient } from './sqlite';
+
+jest.mock('~/dbQueryClient/cross-db-utils/aggregate', () => ({
+  aggregate: jest.fn(),
+}));
+jest.mock('~/dbQueryClient/cross-db-utils/bulk-aggregate', () => ({
+  bulkAggregate: jest.fn(),
+}));
+jest.mock('~/dbQueryClient/aggregations', () => ({
+  getAggregationHandler: jest.fn(),
+}));
+
+const SQLITE_CLIENT = 'sqlite3';
+const SQLITE_MEMORY_CONNECTION = ':memory:';
+const SQLITE_COMPOUND_SELECT_LIMIT_REGRESSION_ROWS = 600;
+const TEMP_TABLE_ALIAS = '_tbl';
+const TEMP_TABLE_FIELDS = ['_id', '_title'];
+
+describe('SqliteDBQueryClient', () => {
+  it('executes temporary table rows from sqlite', async () => {
+    const db = knex({
+      client: SQLITE_CLIENT,
+      connection: { filename: SQLITE_MEMORY_CONNECTION },
+      useNullAsDefault: true,
+    });
+
+    try {
+      const client = new SqliteDBQueryClient();
+
+      const rows = await db.select('*').from(
+        client.temporaryTableRaw({
+          knex: db as any,
+          data: [{ _id: '26', _title: 'Tag' }],
+          fields: TEMP_TABLE_FIELDS,
+          alias: TEMP_TABLE_ALIAS,
+        }),
+      );
+
+      expect(rows).toEqual([{ _id: '26', _title: 'Tag' }]);
+    } finally {
+      await db.destroy();
+    }
+  });
+
+  it('executes temporary table rows above sqlite compound select limits', async () => {
+    const db = knex({
+      client: SQLITE_CLIENT,
+      connection: { filename: SQLITE_MEMORY_CONNECTION },
+      useNullAsDefault: true,
+    });
+
+    try {
+      const client = new SqliteDBQueryClient();
+      const data = Array.from(
+        { length: SQLITE_COMPOUND_SELECT_LIMIT_REGRESSION_ROWS },
+        (_, index) => ({
+          _id: String(index + 1),
+          _title: `Tag ${index + 1}`,
+        }),
+      );
+
+      const rows = await db.count<{ total: number }[]>({ total: '*' }).from(
+        client.temporaryTableRaw({
+          knex: db as any,
+          data,
+          fields: TEMP_TABLE_FIELDS,
+          alias: TEMP_TABLE_ALIAS,
+        }),
+      );
+
+      expect(Number(rows[0].total)).toBe(
+        SQLITE_COMPOUND_SELECT_LIMIT_REGRESSION_ROWS,
+      );
+    } finally {
+      await db.destroy();
+    }
+  });
+});

--- a/packages/nocodb/src/dbQueryClient/sqlite.ts
+++ b/packages/nocodb/src/dbQueryClient/sqlite.ts
@@ -1,9 +1,11 @@
 import { ClientType } from 'nocodb-sdk';
 import type { DBQueryClient } from '~/dbQueryClient/types';
-import type { Knex } from 'knex';
+import type { Knex, XKnex } from '~/db/CustomKnex';
 import type CustomKnex from '~/db/CustomKnex';
 import type { IBaseModelSqlV2 } from '~/db/IBaseModelSqlV2';
 import { GenericDBQueryClient } from '~/dbQueryClient/generic';
+
+const SQLITE_TEMP_TABLE_COLUMN_PREFIX = 'column';
 
 export class SqliteDBQueryClient
   extends GenericDBQueryClient
@@ -17,6 +19,37 @@ export class SqliteDBQueryClient
   }
   simpleCast(field: string, asType: string) {
     return `CAST(${field} as ${asType})`;
+  }
+
+  temporaryTableRaw({
+    knex,
+    data,
+    fields,
+    alias,
+  }: {
+    data: Record<string, any>[];
+    fields: string[];
+    alias: string;
+    knex: XKnex;
+  }): Knex.Raw {
+    const selectColumns = fields.map(() => '?? as ??').join(', ');
+    const rowPlaceholder = `(${fields.map(() => '?').join(',')})`;
+    const valuesPlaceholder = data.map(() => rowPlaceholder).join(', ');
+    const columnBindings = fields.reduce<any[]>((acc, field, index) => {
+      acc.push(`${SQLITE_TEMP_TABLE_COLUMN_PREFIX}${index + 1}`, field);
+      return acc;
+    }, []);
+    const rowBindings = data.reduce<any[]>((acc, row) => {
+      for (const field of fields) {
+        acc.push(row[field]);
+      }
+      return acc;
+    }, [] as any[]);
+
+    return knex.raw(
+      `(select ${selectColumns} from (values ${valuesPlaceholder})) as ??`,
+      [...columnBindings, ...rowBindings, alias],
+    );
   }
 
   bulkAggregateRowSelector(

--- a/packages/nocodb/tsconfig.jest.json
+++ b/packages/nocodb/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
## Change Summary

SQLite could not execute temporary table queries generated for bulk record updates because the generic implementation emitted `AS alias (columns)` after a `VALUES` table expression. This caused MCP `updateRecords` requests that write many-to-many LTAR values to fail before links could be created.

This change adds a SQLite-specific `temporaryTableRaw` implementation that wraps `VALUES` with an outer `SELECT` for column aliases. It keeps the same temporary table contract and avoids compound-select row limits for larger payloads.

## Change type

- [x] fix: (bug fix)
- [ ] feat: (new feature for the user, not a new feature for build script)
- [ ] chore: (updates grunt tasks etc; no production code change)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [x] test: (adding missing tests, refactoring tests; no production code change)

## Test/ Verification

- RED: `pnpm --dir packages/nocodb exec jest --no-cache --runInBand --forceExit --runTestsByPath src/dbQueryClient/sqlite.Source.spec.ts`
  - Failed on the previous implementation with `SQLITE_ERROR: near "(": syntax error`.
- GREEN:
  - `pnpm --dir packages/nocodb exec prettier --check jest.config.js tsconfig.jest.json src/dbQueryClient/sqlite.ts src/dbQueryClient/sqlite.Source.spec.ts`
  - `pnpm --dir packages/nocodb exec jest --no-cache --runInBand --forceExit --runTestsByPath src/dbQueryClient/sqlite.Source.spec.ts`
  - `pnpm --dir packages/nocodb run test`
  - `jq empty packages/nocodb/src/schema/swagger.json`
  - `jq empty packages/nocodb/src/schema/swagger-v2.json`
- Revert proof: removing only the SQLite override makes both regression tests fail again with the original SQLite syntax error.
- Review: independent review completed with no blocking findings after a follow-up pass.

## Additional information / screenshots

`pnpm --dir packages/nocodb exec tsc --noEmit --pretty false` currently fails on pre-existing errors in `src/dbQueryClient/cross-db-utils/bulk-aggregate.ts`:

- missing export `NC_DISABLE_BULK_AGG_CONSOLIDATION` from `~/utils/nc-config`
- `Logger` imported as type-only but used as a value

closes: #14417
