### PR TITLE
fix: don't error-log SDK validation errors in getDataList

### DIFF
--- a/packages/nocodb/src/services/datas.service.ts
+++ b/packages/nocodb/src/services/datas.service.ts
@@ -1,5 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { isLinksOrLTAR, isLinkV2, NcSDKErrorV2, ViewTypes } from 'nocodb-sdk';
+import {
+  isLinksOrLTAR,
+  isLinkV2,
+  NcSDKError,
+  NcSDKErrorV2,
+  ViewTypes,
+} from 'nocodb-sdk';
 import { NcApiVersion } from 'nocodb-sdk';
 import type { BaseModelSqlv2 } from '~/db/BaseModelSqlv2';
 import type { PathParams } from '~/helpers/dataHelpers';
@@ -323,7 +329,12 @@ export class DatasService {
             listArgs,
           );
         } catch (e) {
-          if (e instanceof NcBaseError || e instanceof NcSDKErrorV2) throw e;
+          if (
+            e instanceof NcBaseError ||
+            e instanceof NcSDKError ||
+            e instanceof NcSDKErrorV2
+          )
+            throw e;
           this.logger.error(`Error fetching data: ${e?.message}`, e?.stack);
           NcError.get(context).internalServerError(
             'Please check server log for more details',


### PR DESCRIPTION
## Change Summary

`DatasService.getDataList` runs `count` + `list` in a `Promise.all`. The list branch re-throws only `NcBaseError` and `NcSDKErrorV2`, but the filter parser in `nocodb-sdk` (`filterHelpers_old.ts`) throws `BadRequest extends NcSDKError` — e.g. for `where=(field,isnull)` (unsupported operator) or an unknown field alias. Those fall through to `this.logger.error('Error fetching data: …', e.stack)` plus `NcError.internalServerError(...)`, while the unguarded `count` call rejects with the same `NcSDKError` first and the `GlobalExceptionFilter` answers **422 without logging** (`NcSDKError` is on its skip list).

Net effect today: every caller typo in `where` produces an ERROR-level stack trace in the server log (noisy on hosted log/error-reporting stacks — Cloud Error Reporting groups each new message as a "new error"), although the API correctly answered 422.

This adds `NcSDKError` to the guard so SDK validation errors are re-thrown like the V2 ones and handled by the `GlobalExceptionFilter`, which already maps them to 422 and skips error logging. No behavior change for API clients.

## Change type

- [ ] feat: (new feature for the user, not a new feature for build script)
- [x] fix: (bug fix for the user, not a fix to a build script)
- [ ] docs: (changes to the documentation)
- [ ] style: (formatting, missing semi colons, etc; no production code change)
- [ ] refactor: (refactoring production code, eg. renaming a variable)
- [ ] test: (adding missing tests, refactoring tests; no production code change)
- [ ] chore: (updating grunt tasks etc; no production code change)

## Test/ Verification

- Before: `GET /api/v2/tables/{tableId}/records?where=(someField,isnull)` → HTTP 422 `isnull is not supported.` **and** a server log entry `Error fetching data: isnull is not supported.` with stack trace (observed on 2026.07.0; the code path is identical on 2026.08.2 and `develop`).
- After: same 422 response, no error-level log entry — the `NcSDKError` reaches the `GlobalExceptionFilter`, which is already the path taken by the `count` rejection.
- `NcSDKError` is exported from the `nocodb-sdk` package root (the `GlobalExceptionFilter` imports it from there). Prettier (`packages/nocodb/.prettierrc`) clean.

## Additional information / screenshots (optional)

No linked issue — the change is a two-line guard fix; happy to open one if you prefer tracking it that way. Real infra errors on this path (connection loss, pool exhaustion) still hit the `logger.error` + `internalServerError` branch as before.
